### PR TITLE
fix: correct repository URLs and update project context

### DIFF
--- a/.hestai/context/PROJECT-CONTEXT.oct.md
+++ b/.hestai/context/PROJECT-CONTEXT.oct.md
@@ -2,9 +2,9 @@
 
 META:
   TYPE::PROJECT_CONTEXT
-  VERSION::"2.0"
-  GENERATED::"2025-12-24"
-  STATUS::BUILD_COMPLETE
+  VERSION::"2.1"
+  GENERATED::"2025-12-31"
+  STATUS::POST_BUILD_MAINTENANCE
 
 §1::IDENTITY
 
@@ -47,7 +47,8 @@ I1::COGNITIVE_STATE_ISOLATION[
 ]
 
 I2::UNIVERSAL_OCTAVE_BINDING[
-  IMPLEMENTATION::OCTAVE_format_throughout,
+  IMPLEMENTATION::PLANNED[Issue_#29_auto_generate_octave_on_close],
+  STATUS::cognition_validation_implemented+octave_export_pending,
   VERIFICATION::north_star_debate_used_octave
 ]
 
@@ -155,5 +156,21 @@ RELEASE_READY::[
   GitHub::release_v0.1.0,
   MCP_Registry::submission_pending
 ]
+
+§9::OPEN_ISSUES
+
+PRIORITY::[
+  Issue_#29::OCTAVE_auto_generate_on_close[implements_I2_fully],
+  Issue_#33::storage_location_documentation[clarify_worktree_relative_behavior],
+  Issue_#26::OCTAVE_format_support[broader_integration_scope]
+]
+
+CLOSED_PRS::[
+  PR_#23::CLOSED[Wind_exploration_no_code],
+  PR_#25::CLOSED[superseded_CLI+wrong_I2_removal+stale_agents],
+  PR_#34::OPEN[quality_report_valid_for_review]
+]
+
+REPO_URL::https://github.com/elevanaltd/debate-hall-mcp
 
 ===END_PROJECT_CONTEXT===

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ debate-hall-mcp is built on five unchangeable principles:
 
 ```bash
 # Clone and install
-git clone https://github.com/hestai/debate-hall-mcp
+git clone https://github.com/elevanaltd/debate-hall-mcp
 cd debate-hall-mcp
 uv venv && source .venv/bin/activate
 uv pip install -e ".[dev]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ dev = [
 debate-hall-mcp = "debate_hall_mcp.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/hestai/debate-hall-mcp"
-Documentation = "https://github.com/hestai/debate-hall-mcp#readme"
-Repository = "https://github.com/hestai/debate-hall-mcp.git"
-Issues = "https://github.com/hestai/debate-hall-mcp/issues"
+Homepage = "https://github.com/elevanaltd/debate-hall-mcp"
+Documentation = "https://github.com/elevanaltd/debate-hall-mcp#readme"
+Repository = "https://github.com/elevanaltd/debate-hall-mcp.git"
+Issues = "https://github.com/elevanaltd/debate-hall-mcp/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/debate_hall_mcp"]


### PR DESCRIPTION
## Summary
- Fix repository URLs from `hestai/debate-hall-mcp` to `elevanaltd/debate-hall-mcp`
- Update PROJECT-CONTEXT with current issue/PR status
- Close stale PRs #23 and #25

## Changes

### URL Corrections
- `README.md`: Fixed clone URL
- `pyproject.toml`: Fixed Homepage, Documentation, Repository, Issues URLs

### Context Updates
- Bumped PROJECT-CONTEXT to v2.1
- Clarified I2 implementation status (cognition validation done, OCTAVE export pending via Issue #29)
- Added §9 documenting priority issues and closed PRs

## PR Cleanup Performed
| PR | Action | Reason |
|----|--------|--------|
| #23 | Closed | Wind exploration only, 0 file changes |
| #25 | Closed | CLI superseded, I2 removal incorrect, stale agent content |
| #34 | Remains open | Valid quality report for review |

## Related Issues
- Issue #29: OCTAVE auto-generate on close (implements I2 fully)
- Issue #33: Storage location documentation
- Issue #26: OCTAVE format support

## Test plan
- [x] URLs verified against actual repository
- [x] Pre-commit checks passed
- [x] Pre-push quality gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)