### PR TITLE
fix: Use os.replace for cross-platform atomic writes

### DIFF
--- a/src/debate_hall_mcp/state.py
+++ b/src/debate_hall_mcp/state.py
@@ -245,8 +245,9 @@ def save_debate_state(room: DebateRoom, state_dir: Path) -> None:
             f.flush()
             os.fsync(f.fileno())  # Ensure data is on disk before rename
 
-        # Atomic rename - POSIX guarantees this is atomic on same filesystem
-        os.rename(tmp_path, str(state_file))
+        # Atomic replace - works cross-platform (POSIX and Windows)
+        # os.replace is atomic on same filesystem and overwrites existing file
+        os.replace(tmp_path, str(state_file))
     except Exception:
         # Clean up temp file on any failure - preserve original file
         with contextlib.suppress(OSError):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -397,13 +397,13 @@ class TestAtomicPersistence:
 
         # Track calls to os.rename
         rename_calls: list[tuple[str, str]] = []
-        original_rename = os.rename
+        original_replace = os.replace
 
-        def tracking_rename(src: str, dst: str) -> None:
+        def tracking_replace(src: str, dst: str) -> None:
             rename_calls.append((src, dst))
-            original_rename(src, dst)
+            original_replace(src, dst)
 
-        monkeypatch.setattr("os.rename", tracking_rename)
+        monkeypatch.setattr("os.replace", tracking_replace)
 
         save_debate_state(room, state_dir)
 
@@ -573,13 +573,13 @@ class TestAtomicPersistence:
         save_debate_state(existing_room, state_dir)
         original_content = (state_dir / "partial-001.json").read_text()
 
-        # Make rename fail to simulate crash after write but before commit
-        def failing_rename(src: str, _dst: str) -> None:
+        # Make replace fail to simulate crash after write but before commit
+        def failing_replace(src: str, _dst: str) -> None:
             # Clean up temp file as the real implementation should
             Path(src).unlink(missing_ok=True)
             raise OSError("Simulated crash during rename")
 
-        monkeypatch.setattr("os.rename", failing_rename)
+        monkeypatch.setattr("os.replace", failing_replace)
 
         with pytest.raises(OSError, match="Simulated crash during rename"):
             save_debate_state(room, state_dir)


### PR DESCRIPTION
## Summary

Fixes Windows incompatibility in atomic file writes discovered during retrospective CE (Gemini) review.

## Problem

`os.rename()` fails on Windows if the target file exists, causing `FileExistsError`. This breaks state persistence updates on non-POSIX environments.

## Solution

Changed `os.rename()` to `os.replace()` which:
- Works cross-platform (POSIX and Windows)
- Atomically overwrites existing files
- Available since Python 3.3

## Test Plan

- [x] All 258 tests passing
- [x] Updated test mocks to use `os.replace`
- [x] mypy strict: 0 errors
- [x] ruff + black: clean

## Source

Retrospective CE (Gemini) review of enforcement hardening PRs #42-#46.

## Related Issues

Created from review findings:
- #48: Add concurrency control (race condition) - HIGH severity
- #49: Enforce synthesis requirement in close_debate - MAJOR
- #50: Non-deterministic error message ordering - MINOR

🤖 Generated with [Claude Code](https://claude.com/claude-code)