### PR TITLE
fix: Use cross-platform filelock instead of fcntl (Issue #48)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "mcp>=1.0.0",
     "pydantic>=2.0.0",
+    "filelock>=3.0.0",  # Cross-platform file locking (Issue #48)
 ]
 
 [project.optional-dependencies]

--- a/src/debate_hall_mcp/state.py
+++ b/src/debate_hall_mcp/state.py
@@ -12,17 +12,16 @@ Immutables Compliance:
 """
 
 import contextlib
-import fcntl
 import hashlib
 import json
 import os
 import tempfile
-from collections.abc import Generator
 from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from filelock import FileLock
 from pydantic import BaseModel, Field, field_validator
 
 # Security: Patterns that indicate path traversal or directory injection
@@ -211,39 +210,24 @@ def _validate_thread_id_for_filesystem(thread_id: str) -> None:
             raise ValueError(f"Invalid thread_id '{thread_id}': contains path-unsafe characters")
 
 
-@contextlib.contextmanager
-def _file_lock(lock_file: Path, exclusive: bool = True) -> Generator[None, None, None]:
-    """Context manager for file-based locking (Issue #48 - Concurrency Control).
+def _get_file_lock(lock_file: Path) -> FileLock:
+    """Get a cross-platform file lock (Issue #48 - Concurrency Control).
 
-    Uses fcntl for POSIX advisory locking. Prevents race conditions when
-    multiple processes access the same debate state simultaneously.
+    Uses filelock library for cross-platform file locking.
+    Works on POSIX (Linux, macOS) and Windows.
 
     Args:
         lock_file: Path to the lock file (typically {thread_id}.lock)
-        exclusive: If True, acquire exclusive (write) lock. If False, shared (read) lock.
 
-    Yields:
-        None - lock is held for the duration of the context
+    Returns:
+        FileLock instance that can be used as context manager
 
     Note:
-        Advisory locks only work if all processes use the same locking mechanism.
-        This is appropriate for debate-hall-mcp where all access goes through this module.
+        filelock uses exclusive locks only. For our use case this is fine
+        since reads are fast and contention is expected to be low.
     """
     lock_file.parent.mkdir(parents=True, exist_ok=True)
-
-    # Create lock file if it doesn't exist
-    fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT)
-    try:
-        # Acquire lock (blocks until available)
-        lock_type = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
-        fcntl.flock(fd, lock_type)
-        try:
-            yield
-        finally:
-            # Release lock
-            fcntl.flock(fd, fcntl.LOCK_UN)
-    finally:
-        os.close(fd)
+    return FileLock(str(lock_file))
 
 
 def save_debate_state(room: DebateRoom, state_dir: Path) -> None:
@@ -278,8 +262,8 @@ def save_debate_state(room: DebateRoom, state_dir: Path) -> None:
     state_file = state_dir / f"{room.thread_id}.json"
     lock_file = state_dir / f"{room.thread_id}.lock"
 
-    # Acquire exclusive lock for write operation
-    with _file_lock(lock_file, exclusive=True):
+    # Acquire exclusive lock for write operation (cross-platform via filelock)
+    with _get_file_lock(lock_file):
         # Create temp file in same directory (required for atomic rename on same filesystem)
         fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
         try:
@@ -320,8 +304,9 @@ def load_debate_state(thread_id: str, state_dir: Path) -> DebateRoom:
     if not state_file.exists():
         raise FileNotFoundError(f"No state file found for thread {thread_id}")
 
-    # Acquire shared lock for read operation (allows concurrent reads, blocks writes)
-    with _file_lock(lock_file, exclusive=False), open(state_file) as f:
+    # Acquire lock for read operation (cross-platform via filelock)
+    # Note: filelock only supports exclusive locks, but reads are fast so this is acceptable
+    with _get_file_lock(lock_file), open(state_file) as f:
         data = json.load(f)
 
     return DebateRoom.model_validate(data)

--- a/uv.lock
+++ b/uv.lock
@@ -338,6 +338,7 @@ name = "debate-hall-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "filelock" },
     { name = "mcp" },
     { name = "pydantic" },
 ]
@@ -356,6 +357,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
+    { name = "filelock", specifier = ">=3.0.0" },
     { name = "inline-snapshot", marker = "extra == 'dev'", specifier = ">=0.15.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
@@ -374,6 +376,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.20.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/23/ce7a1126827cedeb958fc043d61745754464eb56c5937c35bbf2b8e26f34/filelock-3.20.1.tar.gz", hash = "sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c", size = 19476, upload-time = "2025-12-15T23:54:28.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/7f/a1a97644e39e7316d850784c642093c99df1290a460df4ede27659056834/filelock-3.20.1-py3-none-any.whl", hash = "sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a", size = 16666, upload-time = "2025-12-15T23:54:26.874Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes cross-platform compatibility issue identified during CE (Gemini) signoff review.

## Problem

The `fcntl` module used for file locking is POSIX-only. On Windows, importing the module causes `ImportError`, making the application completely unusable.

## Solution

- Replaced `fcntl` with `filelock` library (cross-platform)
- Added `filelock>=3.0.0` to dependencies
- Works on POSIX (Linux, macOS) and Windows

## Signoff Status

| Reviewer | Verdict | Notes |
|----------|---------|-------|
| CRS (Codex) | APPROVED_WITH_NOTES | All concerns addressed |
| CE (Gemini) | **GO** (100%) | Cross-platform issue resolved |

## Test Plan

- [x] All 262 tests passing
- [x] mypy strict: 0 errors
- [x] ruff + black: clean

## Files Changed

- `pyproject.toml` - Added filelock dependency
- `src/debate_hall_mcp/state.py` - Replaced fcntl with filelock
- `uv.lock` - Updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)