### PR TITLE
docs: Update PROJECT-CONTEXT with correct test count and retrospective PRs

### DIFF
--- a/.hestai/context/PROJECT-CONTEXT.oct.md
+++ b/.hestai/context/PROJECT-CONTEXT.oct.md
@@ -27,9 +27,9 @@ ALL_PHASES_COMPLETE::[
 §3::QUALITY_METRICS
 
 TESTS::[
-  UNIT::253_tests,
+  UNIT::257_tests,
   E2E::5_tests,
-  TOTAL::258_tests,
+  TOTAL::262_tests,
   STATUS::ALL_PASSING
 ]
 
@@ -199,7 +199,11 @@ CLOSED_PRS::[
   PR_#43::MERGED[Issue_#37_mediated_picks_enforcement],
   PR_#44::MERGED[Issue_#38_synthesis_semantics],
   PR_#45::MERGED[Issue_#39_atomic_persistence],
-  PR_#46::MERGED[Issue_#40_audit_trail_tombstone]
+  PR_#46::MERGED[Issue_#40_audit_trail_tombstone],
+  PR_#47::MERGED[PROJECT_CONTEXT_update],
+  PR_#51::MERGED[cross_platform_os_replace],
+  PR_#52::MERGED[Issues_#48_#49_#50_retrospective_review_fixes],
+  PR_#53::MERGED[Issue_#48_cross_platform_filelock]
 ]
 
 REPO_URL::https://github.com/elevanaltd/debate-hall-mcp


### PR DESCRIPTION
## Summary
- Fix test count: 257 unit + 5 E2E = 262 total (was 253+5=258)
- Add PRs #47, #51, #52, #53 to CLOSED_PRS section
- Reflects all enforcement hardening work including retrospective fixes

## Context
Final cleanup before v0.1.0 release. All enforcement hardening is complete.

## Test plan
- [x] Test count verified via `pytest --collect-only` (262 tests)
- [x] Pre-commit checks pass
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)