### PR TITLE
fix(ci): strip 'v' prefix from version for PyPI verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,12 +122,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Extract version (strip v prefix)
+        id: version
+        run: |
+          VERSION="${{ github.ref_name }}"
+          echo "VERSION=${VERSION#v}" >> $GITHUB_OUTPUT
+
       - name: Wait for package to be available
         run: |
           # Wait up to 5 minutes for package to propagate
           for i in {1..30}; do
-            if pip index versions debate-hall-mcp | grep -q "${{ github.ref_name }}"; then
-              echo "Package version ${{ github.ref_name }} is available on PyPI"
+            if pip index versions debate-hall-mcp | grep -q "${{ steps.version.outputs.VERSION }}"; then
+              echo "Package version ${{ steps.version.outputs.VERSION }} is available on PyPI"
               exit 0
             fi
             echo "Waiting for package to be available (attempt $i/30)..."
@@ -138,7 +144,7 @@ jobs:
 
       - name: Install from PyPI
         run: |
-          pip install debate-hall-mcp==${{ github.ref_name }}
+          pip install debate-hall-mcp==${{ steps.version.outputs.VERSION }}
 
       - name: Verify installation
         run: |
@@ -157,6 +163,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Extract version (strip v prefix)
+        id: version
+        run: |
+          VERSION="${{ github.ref_name }}"
+          echo "VERSION=${VERSION#v}" >> $GITHUB_OUTPUT
+
       - name: Update release notes
         uses: softprops/action-gh-release@v2
         with:
@@ -166,7 +178,7 @@ jobs:
 
             Install from PyPI:
             ```bash
-            pip install debate-hall-mcp==${{ github.ref_name }}
+            pip install debate-hall-mcp==${{ steps.version.outputs.VERSION }}
             ```
 
             ## Documentation
@@ -176,4 +188,4 @@ jobs:
 
             ## PyPI
 
-            View on PyPI: https://pypi.org/project/debate-hall-mcp/${{ github.ref_name }}/
+            View on PyPI: https://pypi.org/project/debate-hall-mcp/${{ steps.version.outputs.VERSION }}/


### PR DESCRIPTION
## Summary

Fix the publish workflow verification step that will fail because `github.ref_name` returns `v0.1.1` but PyPI versions are `0.1.1` (without the `v` prefix).

## Changes

- Add version extraction step to strip `v` prefix using bash parameter expansion
- Update `verify-publication` job to use stripped version for:
  - `pip index versions` check
  - `pip install` command
  - Version assertion echo
- Update `create-github-release-notes` job to use stripped version in:
  - Installation instructions
  - PyPI URL

## Context

Same fix as octave-mcp PR #80. Required before creating v0.1.1 release.

## Test plan

- [x] YAML syntax validated
- [x] Pre-commit hooks pass
- [ ] Will be verified on v0.1.1 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)