### PR TITLE
fix: align package and server versions with pyproject.toml (0.1.1)

### DIFF
--- a/src/debate_hall_mcp/__init__.py
+++ b/src/debate_hall_mcp/__init__.py
@@ -5,5 +5,5 @@ A deterministic crucible where subjective cognitive friction is transmuted into
 objective structural truth through finite, governed, and verifiable dialectic.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __author__ = "HestAI"

--- a/src/debate_hall_mcp/server.py
+++ b/src/debate_hall_mcp/server.py
@@ -23,7 +23,7 @@ from debate_hall_mcp.tools.turn import debate_turn
 
 # Server metadata
 SERVER_NAME = "debate-hall-mcp"
-SERVER_VERSION = "0.1.0"
+SERVER_VERSION = "0.1.1"
 
 # Default state directory
 DEFAULT_STATE_DIR = Path("./debates")

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -5,7 +5,7 @@ def test_package_version() -> None:
     """Test that package version is defined."""
     from debate_hall_mcp import __version__
 
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.1.1"
 
 
 def test_package_author() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "debate-hall-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary
- Fixed version drift discovered during v0.2.0 planning debate
- Updated `src/debate_hall_mcp/__init__.py`: 0.1.0 -> 0.1.1
- Updated `src/debate_hall_mcp/server.py`: 0.1.0 -> 0.1.1
- Updated test assertion in `tests/unit/test___init__.py` to match
- Updated `uv.lock` (automatic from dependency resolution)

## Context
Wall (Codex) identified version inconsistency during v0.2.0 planning:
- pyproject.toml: 0.1.1 (correct - was bumped in #56)
- __init__.py and server.py: 0.1.0 (stale)

## Test plan
- [x] All 262 tests pass
- [x] Lint (ruff) passes
- [x] Format (black) passes
- [x] Typecheck (mypy) passes
- [x] Verify all three version sources show 0.1.1

## Verification
```
pyproject.toml:7:version = "0.1.1"
src/debate_hall_mcp/__init__.py:8:__version__ = "0.1.1"
src/debate_hall_mcp/server.py:26:SERVER_VERSION = "0.1.1"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)