### PR TITLE
chore(test): add pytest markers configuration for HestAI alignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,11 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "-v --tb=short"
+markers = [
+    "unit: Fast isolated unit tests (no external dependencies)",
+    "e2e: End-to-end system behavior tests",
+    "integration: Tests requiring external services or cross-module interaction",
+]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary
- Add pytest markers (unit, e2e, integration) to `pyproject.toml`
- Aligns with TEST-STRUCTURE-STANDARD.md Standard 7
- Enables selective test runs with `pytest -m unit` for fast CI gates

## Context
Reviewed debate-hall-mcp test infrastructure against HestAI test structure standard. Found the project **already compliant** with 5/6 standards:

| Standard | Status |
|----------|--------|
| No tests/__init__.py | ✅ Already compliant |
| Package Discovery Explicit | ✅ Hatchling config |
| CI Artifact Validation | ✅ Full CI job exists |
| No sys.path Injection | ✅ Clean conftest.py |
| Pre-commit Hook | ✅ Already configured |
| **Pytest Markers** | ⚠️ Gap → **Fixed** |

## Test plan
- [x] `pytest --collect-only` succeeds (516 tests collected)
- [x] `pytest tests/unit/test___init__.py` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)