### PR TITLE
fix(cli): correct entry point from cli to server module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
 ]
 
 [project.scripts]
-debate-hall-mcp = "debate_hall_mcp.cli:main"
+debate-hall-mcp = "debate_hall_mcp.server:main"
 
 [project.urls]
 Homepage = "https://github.com/elevanaltd/debate-hall-mcp"


### PR DESCRIPTION
## Summary
- Fixed MCP server startup failure by correcting the pyproject.toml entry point
- Changed `debate_hall_mcp.cli:main` to `debate_hall_mcp.server:main`
- The `cli.py` module referenced in the entry point never existed; `main()` is in `server.py`

## Root Cause
The pyproject.toml defined the CLI entry point as `debate_hall_mcp.cli:main` but no `cli.py` module exists. The `main()` function that runs the MCP server is in `server.py`.

## Test plan
- [x] Server imports successfully
- [x] All 516 tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] MCP tools verified working in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)