### PR TITLE
docs: align model assignments with M019 study evidence

### DIFF
--- a/docs/examples/multi-model-debate-patterns.md
+++ b/docs/examples/multi-model-debate-patterns.md
@@ -8,10 +8,12 @@ Real-world examples of debate-hall-mcp used for architectural decisions.
 
 **Question:** How should debate-hall-mcp integrate OCTAVE skills for token efficiency?
 
-**Participants:**
+**Participants (pre-study assignments):**
 - Wind (Gemini) - Explored possibilities
 - Wall (GPT-5.1-Codex) - Identified failure modes
 - Door (Claude Opus 4.5) - Synthesized solution
+
+> **Note:** This debate used model assignments before the M019 study. For optimal results, see [Model Cognitive Optimization Study](../evidence/model-cognitive-optimization-study.md) which recommends: Claude→Wind, GPT→Wall, Gemini→Door.
 
 **Key Finding:** The synthesis produced "OCTAVE-Aware, Not OCTAVE-Dependent" - a third way that neither Wind nor Wall proposed alone.
 
@@ -54,11 +56,15 @@ DOOR synthesized: View-layer preamble that teaches by example without dependenci
 
 ### 1. Use Different Models for Different Roles
 
+**Evidence-based assignment (M019 study, 29% quality improvement):**
+
 ```
-Wind (exploration) → Use creative models (Gemini, Claude)
-Wall (critique) → Use analytical models (GPT-Codex, o3)
-Door (synthesis) → Use balanced models (Claude Opus, GPT-5)
+Wind (PATHOS) → Claude Opus 4.5  (divergent thinking, metaphorical reasoning)
+Wall (ETHOS)  → GPT-5.2         (analytical rigor, structured evaluation)
+Door (LOGOS)  → Gemini 3 Pro    (pattern synthesis, emergent connections)
 ```
+
+See [Model Cognitive Optimization Study](../evidence/model-cognitive-optimization-study.md) for detailed evidence.
 
 ### 2. Mediated Mode for Controlled Experiments
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -19,7 +19,7 @@ Enables agents to:
 - Use fixed or mediated mode
 - Apply Flash Debate pattern for quick decisions
 - Apply Socratic pattern for premise clarification
-- Integrate with multi-model specialist debates (Gemini Wind, Codex Wall, Claude Door)
+- Integrate with multi-model specialist debates (Claude Wind, GPT Wall, Gemini Door per M019)
 - Know when to escalate to debate-hall from orchestration workflows
 
 **Triggers**: `debate`, `wind wall door`, `dialectic`, `multi-perspective`, `structured decision`, `architecture decision`

--- a/skills/debate-hall/SKILL.md
+++ b/skills/debate-hall/SKILL.md
@@ -111,9 +111,10 @@ META:
     ENFORCEMENT::"Convention, not server-enforced"
   ]
   MULTI_MODEL::[
-    WIND::clink(gemini,ideator)→PATHOS_exploration,
-    WALL::clink(codex,validator)→ETHOS_validation,
-    DOOR::Claude_synthesis→LOGOS_integration,
+    // Evidence: M019 Model Cognitive Optimization Study (29% quality improvement)
+    WIND::clink(claude,ideator)→PATHOS_exploration,    // Claude: divergent thinking, metaphor
+    WALL::clink(codex,validator)→ETHOS_validation,     // GPT: analytical rigor, structured eval
+    DOOR::clink(gemini,synthesizer)→LOGOS_integration, // Gemini: pattern synthesis, emergence
     AUDIT::agent_role+model_in_turn_metadata
   ]
 


### PR DESCRIPTION
## Summary

- Updates prescriptive documentation to reflect M019 study findings (29% quality improvement)
- Aligns model-to-role assignments across skill and example documentation

**Evidence-based configuration:**
```
Wind (PATHOS) → Claude Opus 4.5  (divergent thinking, metaphorical reasoning)
Wall (ETHOS)  → GPT-5.2         (analytical rigor, structured evaluation)
Door (LOGOS)  → Gemini 3 Pro    (pattern synthesis, emergent connections)
```

## Changes

| File | Change |
|------|--------|
| `skills/debate-hall/SKILL.md` | Updated MULTI_MODEL section with evidence citation |
| `skills/README.md` | Corrected model assignment order |
| `docs/examples/multi-model-debate-patterns.md` | Added M019 evidence-based guidance, noted pre-study examples |

## Test plan

- [x] Verify no conflicts with consolidated usage-patterns.md structure
- [x] Cross-reference with docs/evidence/recommendations.md (already aligned)
- [x] Preserve historical debate transcripts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)