### PR TITLE
docs: update .env.example to reflect project-relative detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,18 +37,19 @@
 
 # Debate Storage Location (Issue #33)
 # Directory where debate state files (.json) are saved
-# Default: ./debates (relative to MCP server's working directory)
 #
-# IMPORTANT: MCP clients may start the server with different working directories:
-# - Claude Desktop: typically user's home directory (~)
-# - Claude Code CLI: typically the project directory
-# - Warp terminal: typically the current shell directory
+# Resolution priority:
+# 1. DEBATE_HALL_STATE_DIR env var (if set) - explicit override
+# 2. Project root / "debates" (auto-detected via .git or pyproject.toml)
+# 3. ./debates (fallback if no project markers found)
 #
-# For consistent behavior across all MCP clients, use an absolute path:
+# The default behavior (priority 2) finds your project root and stores
+# debates there, ensuring they live with the code they relate to.
+#
+# For global debate storage (e.g., cross-project debates), set explicitly:
 # DEBATE_HALL_STATE_DIR=/Users/yourusername/debates
 #
-# Or use an environment variable expansion (if supported by your shell):
+# Or use environment variable expansion (if supported):
 # DEBATE_HALL_STATE_DIR=$HOME/debates
 #
-# If unset, debates will be saved to ./debates relative to wherever
-# the MCP server process starts, which may be inconsistent.
+# Leave unset to use automatic project-relative detection (recommended).


### PR DESCRIPTION
## Summary

Fixes outdated documentation in `.env.example` that remained after PR #96 merge.

## Problem

After PR #96 was merged, the `.env.example` file still contained the OLD documentation from commit b10ab70 that described the pre-implementation behavior:
- Mentioned that debates go to `./debates` relative to server CWD
- Listed MCP client differences (Claude Desktop vs CLI vs Warp)
- Did not describe the project-relative detection feature

## Solution

Updated `.env.example` to accurately reflect the implemented 3-tier resolution:
1. `DEBATE_HALL_STATE_DIR` env var (explicit override)
2. Project root / "debates" (auto-detected via `.git` or `pyproject.toml`) 
3. `./debates` (fallback)

## Changes

- Removed outdated "IMPORTANT" section about MCP client working directory differences
- Added clear explanation of 3-tier resolution priority
- Clarified that project-relative detection is the default behavior
- Simplified language and made recommendation clearer
- Brought docs in sync with actual implementation (commits db0e6a0 and 7030cc4)

## Impact

- Users now get accurate documentation about how debate storage works
- Confusion about inconsistent locations is reduced
- Documentation matches the actual code behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)