### PR TITLE
docs: update test count and coverage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ cd debate-hall-mcp
 uv venv && source .venv/bin/activate
 uv pip install -e ".[dev]"
 
-# Run tests (500+ tests, 90%+ coverage)
+# Run tests (496 tests, 92%+ coverage)
 pytest
 
 # Quality checks


### PR DESCRIPTION
Update README metrics to reflect actual test suite:
- 496 tests (was 500+)
- 92%+ coverage (was 90%+, actual 92.47%)

Trivial documentation update for v0.4.0 release.