### PR TITLE
docs: clarify production-readiness and add deployment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![PyPI version](https://badge.fury.io/py/debate-hall-mcp.svg)](https://badge.fury.io/py/debate-hall-mcp)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 
-Production-grade MCP server for Wind/Wall/Door multi-perspective debate orchestration.
+MCP server for Wind/Wall/Door multi-perspective debate orchestration with production-oriented design patterns.
+
+> **Production Status**: This server implements production-minded patterns (validation, bounded operation, atomic persistence) suitable for development and small-scale deployments. For larger production deployments, see [production deployment considerations](#production-deployment-considerations).
 
 ## Table of Contents
 
@@ -197,6 +199,51 @@ Three cognitive voices in tension:
 | I3 | Finite Closure — hard turn/round limits |
 | I4 | Verifiable Ledger — SHA-256 hash chain |
 | I5 | Safety Override — admin kill switch |
+
+## Production Deployment Considerations
+
+While debate-hall-mcp implements production-minded patterns (validation, bounded operation, atomic persistence), there are considerations for larger-scale production deployments:
+
+### Current Strengths
+- ✅ **Deterministic behavior**: Rule-based validation with no LLM dependency
+- ✅ **Resource limits**: Hard turn/round limits prevent runaway sessions
+- ✅ **Atomic persistence**: File writes use atomic replace with fsync
+- ✅ **GitHub integration**: Rate-limit handling and feature toggles
+
+### Known Limitations for Large-Scale Production
+
+| Area | Current Behavior | Recommendation |
+|------|------------------|----------------|
+| **State Storage** | Defaults to file-based (`debates/` directory) | Configure `DEBATE_HALL_STATE_DIR` to dedicated location outside repo. For multi-instance: use shared filesystem or database backend ([#106](https://github.com/elevanaltd/debate-hall-mcp/issues/106)) |
+| **Concurrency** | Exclusive file locks (readers block readers) | Acceptable for single-instance. For multi-worker: see read/write lock enhancement ([#106](https://github.com/elevanaltd/debate-hall-mcp/issues/106)) |
+| **Hash Verification** | Link continuity only (not content re-computation) | Enhancement planned for stronger integrity ([#105](https://github.com/elevanaltd/debate-hall-mcp/issues/105)) |
+| **Secrets Management** | `.env` auto-load (dev-oriented) | Use explicit environment variables or secret management system in production |
+
+### Production Checklist
+
+Before deploying at scale:
+
+- [ ] Configure `DEBATE_HALL_STATE_DIR` to dedicated path outside repository
+- [ ] Set proper file permissions (600 for state files, 700 for directory)
+- [ ] Use explicit secret injection (avoid `.env` in production)
+- [ ] Plan for state backup/retention
+- [ ] Monitor file lock contention if using multiple workers
+- [ ] Consider database backend for >10 concurrent instances
+
+See [Issue #108](https://github.com/elevanaltd/debate-hall-mcp/issues/108) for comprehensive production deployment guide (work in progress).
+
+### Recommended Use Cases
+
+**Well-suited for:**
+- Development and testing workflows
+- Single-instance or low-concurrency deployments
+- Scripted automation with sequential debates
+- Research and experimentation
+
+**Requires additional work for:**
+- High-concurrency multi-instance production environments
+- Strict security compliance requiring full content verification
+- Large-scale orchestration with 10+ concurrent debates
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Updates README to provide realistic expectations about production-readiness based on community feedback, while acknowledging the solid foundation for development and small-scale use.

## Changes

### README Updates

**Softened claim:**
- Before: "Production-grade MCP server..."
- After: "MCP server... with production-oriented design patterns"
- Added prominent notice about production status with link to considerations

**New section:** "Production Deployment Considerations"
- ✅ Current strengths (validation, limits, atomic persistence, GitHub integration)
- ⚠️ Known limitations for large-scale production
- 📋 Production checklist before scaling
- ✓ Recommended vs. requires-work use cases

### Issues Created

Based on feedback, created issues for identified gaps:

- **#105**: Enhance hash-chain verification with content re-computation
- **#106**: Improve concurrency model for multi-instance deployments  
- **#107**: Align SERVER_VERSION with package version
- **#108**: Add comprehensive production deployment guide

## Rationale

The previous "production-grade" claim was too strong given:
- File-based state storage with exclusive locking (concurrency bottleneck)
- Hash verification is link-only (not full content re-computation)
- `.env` auto-load is dev-oriented
- Lacks multi-instance deployment guidance

The **new framing** is more accurate:
- "Production-minded patterns" ✅ (true: validation, limits, atomic writes)
- Suitable for "development and small-scale deployments" ✅
- Transparent about limitations for large-scale use ✅
- Clear path to improvements via linked issues ✅

## Impact

- **Users**: Better expectations and deployment guidance
- **Contributors**: Clear improvement roadmap via issues
- **Reputation**: More honest about capabilities

## Feedback Source

Based on detailed technical review highlighting gaps in:
- Scalable state storage
- Concurrency handling
- Integrity verification
- Production deployment patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)