### PR TITLE
feat(consensus): implement Phase 4 Wind/Wall approval mechanism

### DIFF
--- a/src/debate_hall_mcp/consensus.py
+++ b/src/debate_hall_mcp/consensus.py
@@ -1,0 +1,91 @@
+"""Consensus response parsing for debate-hall-mcp auto-orchestration (Phase 4).
+
+This module implements:
+- ConsensusResult: Model for parsed consensus vote
+- parse_consensus_response: Parser for APPROVE/REJECT responses
+
+The consensus mechanism enables Wind and Wall to review Door's synthesis
+and vote on whether it adequately represents their perspectives.
+
+Parsing Strategy:
+- Fuzzy matching for APPROVE/APPROVED/APPROVAL and REJECT/REJECTED/REJECTION
+- Case-insensitive matching
+- First match wins when both appear
+- Feedback extraction from remaining content
+- Defaults to REJECT if no clear decision found (fail-safe)
+"""
+
+import re
+
+from pydantic import BaseModel, Field
+
+
+class ConsensusResult(BaseModel):
+    """Result of parsing a consensus vote response.
+
+    Fields:
+    - approved: Whether the agent voted to approve the synthesis
+    - feedback: Optional feedback text (especially useful for rejections)
+    """
+
+    approved: bool = Field(..., description="Whether the vote is APPROVE (True) or REJECT (False)")
+    feedback: str | None = Field(default=None, description="Optional feedback from the reviewer")
+
+
+# Patterns for matching approval/rejection keywords
+# Using word boundaries to avoid false matches in prose
+APPROVE_PATTERN = re.compile(r"\b(APPROVE|APPROVED|APPROVAL)\b", re.IGNORECASE)
+REJECT_PATTERN = re.compile(r"\b(REJECT|REJECTED|REJECTION)\b", re.IGNORECASE)
+
+
+def parse_consensus_response(content: str) -> ConsensusResult:
+    """Parse a consensus vote response to extract APPROVE/REJECT decision.
+
+    Parsing rules:
+    1. Search for APPROVE/APPROVED/APPROVAL or REJECT/REJECTED/REJECTION
+    2. Case-insensitive matching
+    3. First keyword found determines the vote (position-based priority)
+    4. Extract remaining content as feedback
+    5. If no clear keyword found, default to REJECT (fail-safe)
+
+    Args:
+        content: The full response content from Wind or Wall
+
+    Returns:
+        ConsensusResult with approved status and optional feedback
+    """
+    if not content or not content.strip():
+        return ConsensusResult(approved=False, feedback=None)
+
+    # Find positions of first APPROVE and REJECT keywords
+    approve_match = APPROVE_PATTERN.search(content)
+    reject_match = REJECT_PATTERN.search(content)
+
+    # Determine which keyword appears first (if any)
+    approve_pos = approve_match.start() if approve_match else float("inf")
+    reject_pos = reject_match.start() if reject_match else float("inf")
+
+    if approve_pos == float("inf") and reject_pos == float("inf"):
+        # No clear keyword found - default to reject with content as feedback
+        return ConsensusResult(approved=False, feedback=content.strip())
+
+    # First keyword wins
+    approved = approve_pos < reject_pos
+
+    # Extract feedback: everything after the keyword match
+    if approved and approve_match:
+        keyword_end = approve_match.end()
+    elif not approved and reject_match:
+        keyword_end = reject_match.end()
+    else:
+        keyword_end = 0
+
+    # Get content after keyword, cleaning up formatting
+    remaining = content[keyword_end:].strip()
+
+    # Remove leading colon, dash, or newlines
+    remaining = re.sub(r"^[\s:.\-\n]+", "", remaining).strip()
+
+    feedback = remaining if remaining else None
+
+    return ConsensusResult(approved=approved, feedback=feedback)

--- a/src/debate_hall_mcp/orchestrator.py
+++ b/src/debate_hall_mcp/orchestrator.py
@@ -1,4 +1,4 @@
-"""Debate Orchestrator for auto-orchestration (Phase 3, ADR-0002).
+"""Debate Orchestrator for auto-orchestration (Phase 3 & 4, ADR-0002).
 
 This module implements:
 - DebateOrchestrator: Core orchestration loop for automated debates
@@ -16,6 +16,13 @@ CE Review Mitigations (Phase 3):
 - M1: Provider timeout handling with asyncio.wait_for()
 - M2: Debate marked PAUSED on failure for recovery
 - M3: Event payload redaction (no content_preview, sanitized errors)
+
+Phase 4: Consensus Loop
+- Wind/Wall approval mechanism for Door's synthesis
+- Refinement loop with feedback on rejection
+- max_refinement_loops from TierSettings (default 3)
+- Stalemate status if max loops exceeded
+- CONSENSUS_VOTE events emitted
 """
 
 import asyncio
@@ -27,13 +34,16 @@ from pydantic import BaseModel, Field
 from ulid import ULID
 
 from debate_hall_mcp.config import TierConfig
+from debate_hall_mcp.consensus import parse_consensus_response
 from debate_hall_mcp.events import EventType, append_event
 from debate_hall_mcp.prompts import (
     DOOR_PROMPT,
     WALL_PROMPT,
     WIND_PROMPT,
     format_door_user_prompt,
+    format_wall_approval_prompt,
     format_wall_user_prompt,
+    format_wind_approval_prompt,
     format_wind_user_prompt,
 )
 from debate_hall_mcp.providers import ProviderResponse, create_provider
@@ -120,6 +130,42 @@ class DebateOrchestrator:
         ulid_suffix = str(ULID())[:8].lower()
         return f"{today}-{safe_subject}-{ulid_suffix}"
 
+    def _create_refinement_prompt(
+        self, topic: str, thread_id: str, rejector: str, feedback: str | None
+    ) -> str:
+        """Create a prompt for Door to refine synthesis based on feedback.
+
+        Args:
+            topic: The debate topic
+            thread_id: Thread ID for state access
+            rejector: The role that rejected (Wind or Wall)
+            feedback: Feedback from the rejector (may be None)
+
+        Returns:
+            Formatted prompt for Door to refine synthesis
+        """
+        feedback_text = feedback if feedback else "No specific feedback provided."
+        return f"""You are participating in a Wind/Wall/Door debate REFINEMENT PHASE.
+
+Topic: {topic}
+Thread ID: {thread_id}
+Your Role: Door (LOGOS) - Synthesis Refiner
+
+To see prior turns and your previous synthesis, call: get_debate("{thread_id}", include_transcript=true)
+
+{rejector} has REJECTED your synthesis with the following feedback:
+{feedback_text}
+
+Your task: Refine your synthesis to address {rejector}'s concerns.
+
+As Door (LOGOS), create a refined synthesis that:
+- Addresses the specific feedback from {rejector}
+- Maintains integration of Wind's possibilities and Wall's constraints
+- Demonstrates how this refinement improves the emergent solution
+- Preserves concrete, actionable implementation steps
+
+Respond with your refined synthesis using the OCTAVE response format."""
+
     async def run(self, topic: str, thread_id: str | None = None) -> DebateResult:
         """Run a complete debate orchestration.
 
@@ -158,11 +204,12 @@ class DebateOrchestrator:
         timeout = self._get_provider_timeout()
 
         try:
-            # 1. Initialize debate
+            # 1. Initialize debate (use mediated mode for orchestrator control of turn sequence)
+            # Mediated mode allows Door to add refinement turns out of normal sequence
             debate_init(
                 thread_id=thread_id,
                 topic=topic,
-                mode="fixed",
+                mode="mediated",
                 state_dir=self.state_dir,
             )
             debate_initialized = True
@@ -270,10 +317,176 @@ class DebateOrchestrator:
                 state_dir=self.state_dir,
             )
 
-            # 6. Close debate with Door's synthesis
+            # Track turn count (3 initial turns: Wind, Wall, Door)
+            turn_count = 3
+            current_synthesis = door_response.content
+
+            # 6. Consensus loop (Phase 4) - if consensus_required
+            if self.tier_config.settings.consensus_required:
+                max_refinement_loops = self.tier_config.settings.max_refinement_loops
+                refinement_count = 0
+
+                while refinement_count <= max_refinement_loops:
+                    # 6a. Wind approval
+                    wind_approval_prompt = format_wind_approval_prompt(topic, thread_id)
+                    wind_approval_response: ProviderResponse = await asyncio.wait_for(
+                        wind_provider.complete(
+                            system_prompt=WIND_PROMPT,
+                            user_prompt=wind_approval_prompt,
+                        ),
+                        timeout=timeout,
+                    )
+                    wind_vote = parse_consensus_response(wind_approval_response.content)
+
+                    # Emit CONSENSUS_VOTE event for Wind
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.CONSENSUS_VOTE,
+                        payload={
+                            "role": "Wind",
+                            "approved": wind_vote.approved,
+                        },
+                        state_dir=self.state_dir,
+                    )
+
+                    # If Wind rejects, refine immediately
+                    if not wind_vote.approved:
+                        refinement_count += 1
+                        if refinement_count > max_refinement_loops:
+                            # Max loops exceeded - stalemate
+                            break
+
+                        # Door refines based on Wind's feedback
+                        refinement_prompt = self._create_refinement_prompt(
+                            topic, thread_id, "Wind", wind_vote.feedback
+                        )
+                        door_response = await asyncio.wait_for(
+                            door_provider.complete(
+                                system_prompt=DOOR_PROMPT,
+                                user_prompt=refinement_prompt,
+                            ),
+                            timeout=timeout,
+                        )
+                        debate_turn(
+                            thread_id=thread_id,
+                            role="Door",
+                            content=door_response.content,
+                            cognition="LOGOS",
+                            model=door_response.model,
+                            token_input=door_response.token_input,
+                            token_output=door_response.token_output,
+                            state_dir=self.state_dir,
+                        )
+                        append_event(
+                            thread_id=thread_id,
+                            event_type=EventType.TURN_ADDED,
+                            payload={
+                                "role": "Door",
+                                "model": door_response.model,
+                            },
+                            state_dir=self.state_dir,
+                        )
+                        turn_count += 1
+                        current_synthesis = door_response.content
+                        continue  # Start consensus loop again
+
+                    # 6b. Wall approval (only if Wind approved)
+                    wall_approval_prompt = format_wall_approval_prompt(topic, thread_id)
+                    wall_approval_response: ProviderResponse = await asyncio.wait_for(
+                        wall_provider.complete(
+                            system_prompt=WALL_PROMPT,
+                            user_prompt=wall_approval_prompt,
+                        ),
+                        timeout=timeout,
+                    )
+                    wall_vote = parse_consensus_response(wall_approval_response.content)
+
+                    # Emit CONSENSUS_VOTE event for Wall
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.CONSENSUS_VOTE,
+                        payload={
+                            "role": "Wall",
+                            "approved": wall_vote.approved,
+                        },
+                        state_dir=self.state_dir,
+                    )
+
+                    # If Wall rejects, refine
+                    if not wall_vote.approved:
+                        refinement_count += 1
+                        if refinement_count > max_refinement_loops:
+                            # Max loops exceeded - stalemate
+                            break
+
+                        # Door refines based on Wall's feedback
+                        refinement_prompt = self._create_refinement_prompt(
+                            topic, thread_id, "Wall", wall_vote.feedback
+                        )
+                        door_response = await asyncio.wait_for(
+                            door_provider.complete(
+                                system_prompt=DOOR_PROMPT,
+                                user_prompt=refinement_prompt,
+                            ),
+                            timeout=timeout,
+                        )
+                        debate_turn(
+                            thread_id=thread_id,
+                            role="Door",
+                            content=door_response.content,
+                            cognition="LOGOS",
+                            model=door_response.model,
+                            token_input=door_response.token_input,
+                            token_output=door_response.token_output,
+                            state_dir=self.state_dir,
+                        )
+                        append_event(
+                            thread_id=thread_id,
+                            event_type=EventType.TURN_ADDED,
+                            payload={
+                                "role": "Door",
+                                "model": door_response.model,
+                            },
+                            state_dir=self.state_dir,
+                        )
+                        turn_count += 1
+                        current_synthesis = door_response.content
+                        continue  # Start consensus loop again
+
+                    # Both approved - exit consensus loop
+                    break
+
+                # Check if we exceeded max loops (stalemate)
+                if refinement_count > max_refinement_loops:
+                    # Close with stalemate status
+                    debate_close(
+                        thread_id=thread_id,
+                        synthesis=current_synthesis,
+                        status="stalemate",
+                        state_dir=self.state_dir,
+                        output_format="json",
+                    )
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.DEBATE_CLOSED,
+                        payload={
+                            "status": "stalemate",
+                            "synthesis_preview": current_synthesis[:100],
+                        },
+                        state_dir=self.state_dir,
+                    )
+                    return DebateResult(
+                        thread_id=thread_id,
+                        topic=topic,
+                        status="stalemate",
+                        turn_count=turn_count,
+                        synthesis=current_synthesis,
+                    )
+
+            # 7. Close debate with Door's synthesis (consensus achieved or not required)
             debate_close(
                 thread_id=thread_id,
-                synthesis=door_response.content,
+                synthesis=current_synthesis,
                 state_dir=self.state_dir,
                 output_format="json",
             )
@@ -284,18 +497,18 @@ class DebateOrchestrator:
                 event_type=EventType.DEBATE_CLOSED,
                 payload={
                     "status": "synthesis",
-                    "synthesis_preview": door_response.content[:100],
+                    "synthesis_preview": current_synthesis[:100],
                 },
                 state_dir=self.state_dir,
             )
 
-            # 7. Return result
+            # 8. Return result
             return DebateResult(
                 thread_id=thread_id,
                 topic=topic,
                 status="synthesis",
-                turn_count=3,
-                synthesis=door_response.content,
+                turn_count=turn_count,
+                synthesis=current_synthesis,
             )
 
         except Exception as e:
@@ -317,4 +530,317 @@ class DebateOrchestrator:
                     room.status = DebateStatus.PAUSED
                     save_debate_state(room, self.state_dir)
 
+            raise
+
+    async def resume(self, thread_id: str) -> DebateResult:
+        """Resume a PAUSED debate from where it left off.
+
+        This method loads the debate state, validates it's PAUSED, and continues
+        the orchestration from the appropriate point based on the turn count.
+
+        Args:
+            thread_id: The thread ID of the paused debate
+
+        Returns:
+            DebateResult with debate outcome
+
+        Raises:
+            FileNotFoundError: If debate doesn't exist
+            ValueError: If debate is not in PAUSED status
+        """
+        # Load debate state
+        room = load_debate_state(thread_id, self.state_dir)
+
+        # Validate status is PAUSED
+        if room.status != DebateStatus.PAUSED:
+            raise ValueError(
+                f"Cannot resume debate with status '{room.status.value}': "
+                f"only PAUSED debates can be resumed"
+            )
+
+        topic = room.topic
+        turn_count = len(room.turns)
+        timeout = self._get_provider_timeout()
+
+        # Mark as active for resumption
+        room.status = DebateStatus.ACTIVE
+        save_debate_state(room, self.state_dir)
+
+        try:
+            # Create providers
+            wind_provider = create_provider(self.tier_config.wind)
+            wall_provider = create_provider(self.tier_config.wall)
+            door_provider = create_provider(self.tier_config.door)
+
+            # Determine existing turns by role
+            existing_roles = {t.role for t in room.turns}
+            door_turns = [t for t in room.turns if t.role == "Door"]
+            current_synthesis = door_turns[-1].content if door_turns else ""
+
+            # CE Blocking Fix #1 & #2: Complete missing Wind/Wall/Door turns before close
+            # If turn_count < 3, we need to complete the missing turns first
+            # Fix #2: Handle turn_count=0 case where Wind failed immediately after init
+            if turn_count < 3:
+                # Complete missing Wind turn if needed (CE Fix #2)
+                if "Wind" not in existing_roles:
+                    wind_user_prompt = format_wind_user_prompt(topic, thread_id)
+                    wind_response: ProviderResponse = await asyncio.wait_for(
+                        wind_provider.complete(
+                            system_prompt=WIND_PROMPT,
+                            user_prompt=wind_user_prompt,
+                        ),
+                        timeout=timeout,
+                    )
+                    debate_turn(
+                        thread_id=thread_id,
+                        role="Wind",
+                        content=wind_response.content,
+                        cognition="PATHOS",
+                        model=wind_response.model,
+                        token_input=wind_response.token_input,
+                        token_output=wind_response.token_output,
+                        state_dir=self.state_dir,
+                    )
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.TURN_ADDED,
+                        payload={"role": "Wind", "model": wind_response.model},
+                        state_dir=self.state_dir,
+                    )
+                    turn_count += 1
+
+                # Complete missing Wall turn if needed
+                if "Wall" not in existing_roles:
+                    wall_user_prompt = format_wall_user_prompt(topic, thread_id)
+                    wall_response: ProviderResponse = await asyncio.wait_for(
+                        wall_provider.complete(
+                            system_prompt=WALL_PROMPT,
+                            user_prompt=wall_user_prompt,
+                        ),
+                        timeout=timeout,
+                    )
+                    debate_turn(
+                        thread_id=thread_id,
+                        role="Wall",
+                        content=wall_response.content,
+                        cognition="ETHOS",
+                        model=wall_response.model,
+                        token_input=wall_response.token_input,
+                        token_output=wall_response.token_output,
+                        state_dir=self.state_dir,
+                    )
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.TURN_ADDED,
+                        payload={"role": "Wall", "model": wall_response.model},
+                        state_dir=self.state_dir,
+                    )
+                    turn_count += 1
+
+                # Complete missing Door turn if needed (always needed if we're here)
+                if "Door" not in existing_roles:
+                    door_user_prompt = format_door_user_prompt(topic, thread_id)
+                    door_response: ProviderResponse = await asyncio.wait_for(
+                        door_provider.complete(
+                            system_prompt=DOOR_PROMPT,
+                            user_prompt=door_user_prompt,
+                        ),
+                        timeout=timeout,
+                    )
+                    debate_turn(
+                        thread_id=thread_id,
+                        role="Door",
+                        content=door_response.content,
+                        cognition="LOGOS",
+                        model=door_response.model,
+                        token_input=door_response.token_input,
+                        token_output=door_response.token_output,
+                        state_dir=self.state_dir,
+                    )
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.TURN_ADDED,
+                        payload={"role": "Door", "model": door_response.model},
+                        state_dir=self.state_dir,
+                    )
+                    turn_count += 1
+                    current_synthesis = door_response.content
+
+            # If we have Wind, Wall, Door turns (>=3), resume from consensus
+            if turn_count >= 3 and self.tier_config.settings.consensus_required:
+                max_refinement_loops = self.tier_config.settings.max_refinement_loops
+                refinement_count = max(0, turn_count - 3)  # Estimate refinements done
+
+                while refinement_count <= max_refinement_loops:
+                    # Wind approval
+                    wind_approval_prompt = format_wind_approval_prompt(topic, thread_id)
+                    wind_approval_response: ProviderResponse = await asyncio.wait_for(
+                        wind_provider.complete(
+                            system_prompt=WIND_PROMPT,
+                            user_prompt=wind_approval_prompt,
+                        ),
+                        timeout=timeout,
+                    )
+                    wind_vote = parse_consensus_response(wind_approval_response.content)
+
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.CONSENSUS_VOTE,
+                        payload={"role": "Wind", "approved": wind_vote.approved},
+                        state_dir=self.state_dir,
+                    )
+
+                    if not wind_vote.approved:
+                        refinement_count += 1
+                        if refinement_count > max_refinement_loops:
+                            break
+
+                        refinement_prompt = self._create_refinement_prompt(
+                            topic, thread_id, "Wind", wind_vote.feedback
+                        )
+                        door_response = await asyncio.wait_for(
+                            door_provider.complete(
+                                system_prompt=DOOR_PROMPT,
+                                user_prompt=refinement_prompt,
+                            ),
+                            timeout=timeout,
+                        )
+                        debate_turn(
+                            thread_id=thread_id,
+                            role="Door",
+                            content=door_response.content,
+                            cognition="LOGOS",
+                            model=door_response.model,
+                            token_input=door_response.token_input,
+                            token_output=door_response.token_output,
+                            state_dir=self.state_dir,
+                        )
+                        append_event(
+                            thread_id=thread_id,
+                            event_type=EventType.TURN_ADDED,
+                            payload={"role": "Door", "model": door_response.model},
+                            state_dir=self.state_dir,
+                        )
+                        turn_count += 1
+                        current_synthesis = door_response.content
+                        continue
+
+                    # Wall approval
+                    wall_approval_prompt = format_wall_approval_prompt(topic, thread_id)
+                    wall_approval_response: ProviderResponse = await asyncio.wait_for(
+                        wall_provider.complete(
+                            system_prompt=WALL_PROMPT,
+                            user_prompt=wall_approval_prompt,
+                        ),
+                        timeout=timeout,
+                    )
+                    wall_vote = parse_consensus_response(wall_approval_response.content)
+
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.CONSENSUS_VOTE,
+                        payload={"role": "Wall", "approved": wall_vote.approved},
+                        state_dir=self.state_dir,
+                    )
+
+                    if not wall_vote.approved:
+                        refinement_count += 1
+                        if refinement_count > max_refinement_loops:
+                            break
+
+                        refinement_prompt = self._create_refinement_prompt(
+                            topic, thread_id, "Wall", wall_vote.feedback
+                        )
+                        door_response = await asyncio.wait_for(
+                            door_provider.complete(
+                                system_prompt=DOOR_PROMPT,
+                                user_prompt=refinement_prompt,
+                            ),
+                            timeout=timeout,
+                        )
+                        debate_turn(
+                            thread_id=thread_id,
+                            role="Door",
+                            content=door_response.content,
+                            cognition="LOGOS",
+                            model=door_response.model,
+                            token_input=door_response.token_input,
+                            token_output=door_response.token_output,
+                            state_dir=self.state_dir,
+                        )
+                        append_event(
+                            thread_id=thread_id,
+                            event_type=EventType.TURN_ADDED,
+                            payload={"role": "Door", "model": door_response.model},
+                            state_dir=self.state_dir,
+                        )
+                        turn_count += 1
+                        current_synthesis = door_response.content
+                        continue
+
+                    # Both approved
+                    break
+
+                # Check for stalemate
+                if refinement_count > max_refinement_loops:
+                    debate_close(
+                        thread_id=thread_id,
+                        synthesis=current_synthesis,
+                        status="stalemate",
+                        state_dir=self.state_dir,
+                        output_format="json",
+                    )
+                    append_event(
+                        thread_id=thread_id,
+                        event_type=EventType.DEBATE_CLOSED,
+                        payload={
+                            "status": "stalemate",
+                            "synthesis_preview": current_synthesis[:100],
+                        },
+                        state_dir=self.state_dir,
+                    )
+                    return DebateResult(
+                        thread_id=thread_id,
+                        topic=topic,
+                        status="stalemate",
+                        turn_count=turn_count,
+                        synthesis=current_synthesis,
+                    )
+
+            # Close with synthesis
+            debate_close(
+                thread_id=thread_id,
+                synthesis=current_synthesis,
+                state_dir=self.state_dir,
+                output_format="json",
+            )
+            append_event(
+                thread_id=thread_id,
+                event_type=EventType.DEBATE_CLOSED,
+                payload={
+                    "status": "synthesis",
+                    "synthesis_preview": current_synthesis[:100],
+                },
+                state_dir=self.state_dir,
+            )
+            return DebateResult(
+                thread_id=thread_id,
+                topic=topic,
+                status="synthesis",
+                turn_count=turn_count,
+                synthesis=current_synthesis,
+            )
+
+        except Exception as e:
+            with contextlib.suppress(Exception):
+                append_event(
+                    thread_id=thread_id,
+                    event_type=EventType.ERROR,
+                    payload={"error_type": type(e).__name__},
+                    state_dir=self.state_dir,
+                )
+            with contextlib.suppress(Exception):
+                room = load_debate_state(thread_id, self.state_dir)
+                room.status = DebateStatus.PAUSED
+                save_debate_state(room, self.state_dir)
             raise

--- a/src/debate_hall_mcp/prompts/__init__.py
+++ b/src/debate_hall_mcp/prompts/__init__.py
@@ -531,3 +531,97 @@ Do NOT simply average or compromise between positions.
 Your role is to INTEGRATE and create something that honors both while transcending the apparent conflict.
 
 Respond using the OCTAVE response format defined in your system prompt."""
+
+
+def format_wind_approval_prompt(topic: str, thread_id: str) -> str:
+    """Format user prompt for Wind (PATHOS) consensus approval review.
+
+    Per ADR-0002, agents call get_debate() to access prior turns rather than
+    having context injected. This maintains I1 (Cognitive State Isolation).
+
+    Args:
+        topic: The debate topic
+        thread_id: Thread ID for state access via get_debate()
+
+    Returns:
+        Formatted user prompt for consensus review
+    """
+    return f"""You are participating in a Wind/Wall/Door debate CONSENSUS PHASE.
+
+Topic: {topic}
+Thread ID: {thread_id}
+Your Role: Wind (PATHOS) - Consensus Reviewer
+
+To review Door's synthesis and prior turns, call: get_debate("{thread_id}", include_transcript=true)
+
+Your task: Review Door's synthesis and vote APPROVE or REJECT.
+
+As Wind (PATHOS), evaluate whether the synthesis:
+- Preserves the creative possibilities you expanded
+- Honors the spirit of innovation and exploration
+- Maintains the vision while addressing constraints
+- Enables emergent capabilities beyond either/or
+
+RESPONSE FORMAT:
+Start your response with exactly one of:
+- APPROVE - if the synthesis honors Wind's expansion
+- REJECT - if the synthesis fails to capture creative potential
+
+If you REJECT, provide specific feedback on what is missing or needs refinement.
+Door will use your feedback to create a refined synthesis.
+
+Do NOT provide new possibilities or expand the discussion.
+Your role now is to VALIDATE the synthesis from Wind's perspective.
+
+Example:
+APPROVE
+
+The synthesis successfully integrates Wind's heretical path while respecting constraints.
+The emergent capabilities enable the innovation we sought."""
+
+
+def format_wall_approval_prompt(topic: str, thread_id: str) -> str:
+    """Format user prompt for Wall (ETHOS) consensus approval review.
+
+    Per ADR-0002, agents call get_debate() to access prior turns rather than
+    having context injected. This maintains I1 (Cognitive State Isolation).
+
+    Args:
+        topic: The debate topic
+        thread_id: Thread ID for state access via get_debate()
+
+    Returns:
+        Formatted user prompt for consensus review
+    """
+    return f"""You are participating in a Wind/Wall/Door debate CONSENSUS PHASE.
+
+Topic: {topic}
+Thread ID: {thread_id}
+Your Role: Wall (ETHOS) - Consensus Reviewer
+
+To review Door's synthesis and prior turns, call: get_debate("{thread_id}", include_transcript=true)
+
+Your task: Review Door's synthesis and vote APPROVE or REJECT.
+
+As Wall (ETHOS), evaluate whether the synthesis:
+- Respects the constraints you identified
+- Addresses the risks with appropriate mitigations
+- Maintains structural integrity and feasibility
+- Does not violate hard constraints
+
+RESPONSE FORMAT:
+Start your response with exactly one of:
+- APPROVE - if the synthesis properly addresses constraints
+- REJECT - if the synthesis violates constraints or ignores risks
+
+If you REJECT, provide specific feedback on which constraints are violated.
+Door will use your feedback to create a refined synthesis.
+
+Do NOT validate new claims or assess new evidence.
+Your role now is to VALIDATE the synthesis from Wall's perspective.
+
+Example:
+APPROVE
+
+The synthesis addresses the security constraints I raised and includes appropriate
+mitigations for the identified risks. The implementation path is feasible."""

--- a/src/debate_hall_mcp/tools/close.py
+++ b/src/debate_hall_mcp/tools/close.py
@@ -34,6 +34,7 @@ def debate_close(
     synthesis: str,
     state_dir: Path | None = None,
     output_format: OutputFormat | None = None,
+    status: str | None = None,
 ) -> dict[str, Any] | str:
     """Close debate with final synthesis.
 
@@ -48,6 +49,8 @@ def debate_close(
         output_format: Output format - 'json', 'octave', or 'both'.
             If not specified, defaults to 'octave' when octave_mode=True,
             otherwise 'json' (Issue #26)
+        status: Override termination reason - 'synthesis' (default) or 'stalemate'.
+            Used by auto-orchestration for consensus loop failures.
 
     Returns:
         Depends on output_format:
@@ -89,9 +92,14 @@ def debate_close(
     else:
         effective_format = "json"
 
+    # Determine termination reason from status parameter (Phase 4: consensus loop)
+    termination_reason = TerminationReason.SYNTHESIS
+    if status == "stalemate":
+        termination_reason = TerminationReason.STALEMATE
+
     # Close debate via engine (validates active state and synthesis content)
     engine = DebateEngine(room)
-    validation_result = engine.close_debate(TerminationReason.SYNTHESIS, synthesis=synthesis)
+    validation_result = engine.close_debate(termination_reason, synthesis=synthesis)
 
     # Save updated state
     save_debate_state(room, state_dir)

--- a/src/debate_hall_mcp/tools/orchestrate.py
+++ b/src/debate_hall_mcp/tools/orchestrate.py
@@ -1,13 +1,17 @@
-"""run_debate tool - Auto-orchestration entry point (Phase 3, ADR-0002).
+"""run_debate and resume_debate tools - Auto-orchestration (Phase 3 & 4, ADR-0002).
 
 This module implements:
 - run_debate: MCP tool for automated Wind/Wall/Door debates
+- resume_debate: MCP tool for resuming PAUSED debates
 
-The tool wraps DebateOrchestrator, providing tier configuration loading
+The tools wrap DebateOrchestrator, providing tier configuration loading
 and state directory resolution automatically.
 
 CE Review Mitigations (Phase 3):
 - M4: Input validation at tool boundary (topic and thread_id)
+
+Phase 4 Additions:
+- resume_debate: Resumes debates from PAUSED status after failures
 """
 
 from typing import Any
@@ -15,7 +19,12 @@ from typing import Any
 from debate_hall_mcp.config import load_tier_config
 from debate_hall_mcp.orchestrator import DebateOrchestrator
 from debate_hall_mcp.providers import create_provider  # noqa: F401 - used in patch
-from debate_hall_mcp.state import _validate_thread_id_for_filesystem, get_state_dir
+from debate_hall_mcp.state import (
+    DebateStatus,
+    _validate_thread_id_for_filesystem,
+    get_state_dir,
+    load_debate_state,
+)
 
 # M4: Maximum topic length (reasonable limit for debate topics)
 MAX_TOPIC_LENGTH = 1000
@@ -86,6 +95,74 @@ async def run_debate(
     result = await orchestrator.run(topic=topic, thread_id=thread_id)
 
     # Return as dictionary
+    return {
+        "thread_id": result.thread_id,
+        "topic": result.topic,
+        "status": result.status,
+        "turn_count": result.turn_count,
+        "synthesis": result.synthesis,
+    }
+
+
+async def resume_debate(
+    thread_id: str,
+    tier: str = "standard",
+) -> dict[str, Any]:
+    """Resume a PAUSED debate from where it left off.
+
+    This tool allows resuming debates that were paused due to failures
+    (provider timeouts, errors, etc.) during auto-orchestration.
+
+    The resume logic:
+    1. Validates thread_id and loads debate state
+    2. Validates debate is in PAUSED status
+    3. Determines resume point from turn count
+    4. Continues orchestration (consensus loop if enabled)
+    5. Returns the final result
+
+    Args:
+        thread_id: The thread ID of the paused debate
+        tier: Tier configuration name (default: "standard")
+
+    Returns:
+        Dictionary with debate result (same format as run_debate):
+        - thread_id: Unique debate thread identifier
+        - topic: The debate topic
+        - status: Final status (synthesis, stalemate, etc.)
+        - turn_count: Number of turns completed
+        - synthesis: Door's final synthesis (if status=synthesis)
+
+    Raises:
+        ValueError: If thread_id contains unsafe chars (M4)
+        FileNotFoundError: If debate doesn't exist
+        ValueError: If debate is not in PAUSED status
+        KeyError: If tier configuration is not found
+        Exception: If provider fails during resumption
+    """
+    # M4: Validate thread_id at tool boundary
+    _validate_thread_id_for_filesystem(thread_id)
+
+    # Get state directory
+    state_dir = get_state_dir()
+
+    # Validate debate exists and is PAUSED before creating orchestrator
+    room = load_debate_state(thread_id, state_dir)
+    if room.status != DebateStatus.PAUSED:
+        raise ValueError(
+            f"Cannot resume debate with status '{room.status.value}': "
+            f"only PAUSED debates can be resumed"
+        )
+
+    # Load tier configuration
+    tier_config = load_tier_config(tier)
+
+    # Create orchestrator
+    orchestrator = DebateOrchestrator(tier_config, state_dir)
+
+    # Resume debate
+    result = await orchestrator.resume(thread_id=thread_id)
+
+    # Return as dictionary (same format as run_debate)
     return {
         "thread_id": result.thread_id,
         "topic": result.topic,

--- a/tests/unit/test_consensus.py
+++ b/tests/unit/test_consensus.py
@@ -1,0 +1,230 @@
+"""Unit tests for consensus response parser (Phase 4: Consensus Implementation).
+
+Tests the consensus response parsing:
+- ConsensusResult model structure
+- parse_consensus_response function
+- Handling of APPROVE/REJECT variations
+- Feedback extraction
+- Edge cases
+"""
+
+from debate_hall_mcp.consensus import ConsensusResult, parse_consensus_response
+
+
+class TestConsensusResultModel:
+    """Tests for ConsensusResult Pydantic model."""
+
+    def test_consensus_result_approved_with_feedback(self) -> None:
+        """ConsensusResult should accept approved=True with feedback."""
+        result = ConsensusResult(approved=True, feedback="Looks good!")
+        assert result.approved is True
+        assert result.feedback == "Looks good!"
+
+    def test_consensus_result_rejected_with_feedback(self) -> None:
+        """ConsensusResult should accept approved=False with feedback."""
+        result = ConsensusResult(approved=False, feedback="Needs revision")
+        assert result.approved is False
+        assert result.feedback == "Needs revision"
+
+    def test_consensus_result_approved_without_feedback(self) -> None:
+        """ConsensusResult should accept approved=True without feedback."""
+        result = ConsensusResult(approved=True, feedback=None)
+        assert result.approved is True
+        assert result.feedback is None
+
+    def test_consensus_result_rejected_without_feedback(self) -> None:
+        """ConsensusResult should accept approved=False without feedback."""
+        result = ConsensusResult(approved=False, feedback=None)
+        assert result.approved is False
+        assert result.feedback is None
+
+
+class TestParseConsensusResponseApprove:
+    """Tests for parsing APPROVE responses."""
+
+    def test_parse_simple_approve(self) -> None:
+        """Should parse simple APPROVE response."""
+        content = "APPROVE"
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_parse_approved(self) -> None:
+        """Should parse APPROVED response (past tense)."""
+        content = "APPROVED"
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_parse_approval(self) -> None:
+        """Should parse APPROVAL response (noun form)."""
+        content = "APPROVAL"
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_parse_approve_lowercase(self) -> None:
+        """Should parse lowercase approve."""
+        content = "approve"
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_parse_approve_mixed_case(self) -> None:
+        """Should parse mixed case Approve."""
+        content = "Approve"
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_parse_approve_with_feedback(self) -> None:
+        """Should parse APPROVE with feedback text."""
+        content = """APPROVE
+
+The synthesis effectively integrates Wind's expansion with Wall's constraints.
+The implementation path is clear and actionable."""
+        result = parse_consensus_response(content)
+        assert result.approved is True
+        assert result.feedback is not None
+        assert "synthesis" in result.feedback.lower()
+
+    def test_parse_approve_with_colon(self) -> None:
+        """Should parse APPROVE: with colon prefix."""
+        content = "APPROVE: This is well-reasoned synthesis."
+        result = parse_consensus_response(content)
+        assert result.approved is True
+        assert result.feedback is not None
+        assert "well-reasoned" in result.feedback
+
+
+class TestParseConsensusResponseReject:
+    """Tests for parsing REJECT responses."""
+
+    def test_parse_simple_reject(self) -> None:
+        """Should parse simple REJECT response."""
+        content = "REJECT"
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_parse_rejected(self) -> None:
+        """Should parse REJECTED response (past tense)."""
+        content = "REJECTED"
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_parse_rejection(self) -> None:
+        """Should parse REJECTION response (noun form)."""
+        content = "REJECTION"
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_parse_reject_lowercase(self) -> None:
+        """Should parse lowercase reject."""
+        content = "reject"
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_parse_reject_mixed_case(self) -> None:
+        """Should parse mixed case Reject."""
+        content = "Reject"
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_parse_reject_with_feedback(self) -> None:
+        """Should parse REJECT with feedback text."""
+        content = """REJECT
+
+The synthesis fails to address the critical constraint raised by Wall.
+The implementation path needs to account for the security implications."""
+        result = parse_consensus_response(content)
+        assert result.approved is False
+        assert result.feedback is not None
+        assert "security" in result.feedback.lower()
+
+    def test_parse_reject_with_colon(self) -> None:
+        """Should parse REJECT: with colon prefix."""
+        content = "REJECT: Missing consideration of edge cases."
+        result = parse_consensus_response(content)
+        assert result.approved is False
+        assert result.feedback is not None
+        assert "edge cases" in result.feedback
+
+
+class TestParseConsensusResponseEdgeCases:
+    """Tests for edge cases in consensus parsing."""
+
+    def test_parse_approve_with_leading_whitespace(self) -> None:
+        """Should handle leading whitespace."""
+        content = "   APPROVE"
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_parse_reject_with_trailing_whitespace(self) -> None:
+        """Should handle trailing whitespace."""
+        content = "REJECT   "
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_parse_approve_on_second_line(self) -> None:
+        """Should find APPROVE on non-first line."""
+        content = """## WIND (PATHOS) - Consensus Review
+
+APPROVE
+
+The synthesis captures the essential tension."""
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_parse_approve_in_structured_format(self) -> None:
+        """Should parse APPROVE in OCTAVE-style structured response."""
+        content = """## WIND (PATHOS) - Consensus Vote
+
+### VERDICT
+APPROVE
+
+### REASONING
+The synthesis demonstrates emergent integration."""
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_parse_reject_in_structured_format(self) -> None:
+        """Should parse REJECT in OCTAVE-style structured response."""
+        content = """## WALL (ETHOS) - Consensus Vote
+
+### VERDICT
+REJECT
+
+### REASONING
+Insufficient evidence for the proposed implementation."""
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_parse_ambiguous_defaults_to_reject(self) -> None:
+        """Ambiguous response without clear APPROVE/REJECT should default to reject."""
+        content = "I think this needs more work."
+        result = parse_consensus_response(content)
+        assert result.approved is False
+        assert result.feedback is not None
+
+    def test_parse_empty_string_defaults_to_reject(self) -> None:
+        """Empty string should default to reject."""
+        content = ""
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_parse_whitespace_only_defaults_to_reject(self) -> None:
+        """Whitespace-only should default to reject."""
+        content = "   \n\t  "
+        result = parse_consensus_response(content)
+        assert result.approved is False
+
+    def test_approve_takes_precedence_when_both_present(self) -> None:
+        """When both APPROVE and REJECT appear, first one wins."""
+        content = """APPROVE
+
+This is good, though I considered REJECT initially."""
+        result = parse_consensus_response(content)
+        assert result.approved is True
+
+    def test_reject_first_when_before_approve(self) -> None:
+        """When REJECT appears before APPROVE, REJECT wins."""
+        content = """REJECT
+
+The synthesis mentions APPROVE but I disagree."""
+        result = parse_consensus_response(content)
+        assert result.approved is False

--- a/tests/unit/test_orchestrator_consensus.py
+++ b/tests/unit/test_orchestrator_consensus.py
@@ -1,0 +1,403 @@
+"""Unit tests for consensus loop in DebateOrchestrator (Phase 4: Consensus Implementation).
+
+Tests the consensus loop flow:
+- Both approve -> synthesis status
+- Wind rejects -> refinement loop
+- Wall rejects -> refinement loop
+- Max loops exceeded -> stalemate status
+- consensus_required=False skips loop
+- CONSENSUS_VOTE events emitted
+- Turn count reflects all turns including consensus
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from debate_hall_mcp.config import RoleConfig, TierConfig, TierSettings
+from debate_hall_mcp.events import EventType, load_events
+from debate_hall_mcp.orchestrator import DebateOrchestrator
+from debate_hall_mcp.providers import ProviderResponse
+
+
+@pytest.fixture
+def tier_config_consensus() -> TierConfig:
+    """Create a tier configuration with consensus enabled."""
+    return TierConfig(
+        wind=RoleConfig(provider="cli", cli="claude", role="wind-agent"),
+        wall=RoleConfig(provider="cli", cli="codex", role="wall-agent"),
+        door=RoleConfig(provider="cli", cli="gemini", role="door-agent"),
+        settings=TierSettings(
+            consensus_required=True,
+            max_turns=12,
+            max_refinement_loops=3,
+        ),
+    )
+
+
+@pytest.fixture
+def tier_config_no_consensus() -> TierConfig:
+    """Create a tier configuration with consensus disabled."""
+    return TierConfig(
+        wind=RoleConfig(provider="cli", cli="claude", role="wind-agent"),
+        wall=RoleConfig(provider="cli", cli="codex", role="wall-agent"),
+        door=RoleConfig(provider="cli", cli="gemini", role="door-agent"),
+        settings=TierSettings(
+            consensus_required=False,
+            max_turns=12,
+            max_refinement_loops=3,
+        ),
+    )
+
+
+@pytest.fixture
+def temp_state_dir(tmp_path: Path) -> Path:
+    """Create a temporary state directory."""
+    state_dir = tmp_path / "debates"
+    state_dir.mkdir()
+    return state_dir
+
+
+def create_mock_response(content: str, model: str = "test-model") -> ProviderResponse:
+    """Create a mock ProviderResponse."""
+    return ProviderResponse(
+        content=content,
+        model=model,
+        token_input=100,
+        token_output=200,
+    )
+
+
+class TestConsensusLoopBothApprove:
+    """Tests for when both Wind and Wall approve."""
+
+    @pytest.mark.anyio
+    async def test_both_approve_results_in_synthesis_status(
+        self, tier_config_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """When both Wind and Wall approve, debate should close with synthesis status."""
+        orchestrator = DebateOrchestrator(tier_config_consensus, temp_state_dir)
+
+        responses = [
+            # Initial debate round
+            create_mock_response("## WIND - Possibilities\nExpanding..."),
+            create_mock_response("## WALL - Validation\nValidating..."),
+            create_mock_response("## DOOR - Synthesis\nSynthesizing..."),
+            # Consensus round
+            create_mock_response("APPROVE\nThe synthesis is well-integrated."),  # Wind
+            create_mock_response("APPROVE\nConstraints properly addressed."),  # Wall
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Consensus test")
+
+        assert result.status == "synthesis"
+
+    @pytest.mark.anyio
+    async def test_both_approve_includes_synthesis_content(
+        self, tier_config_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """When both approve, synthesis should contain Door's synthesis."""
+        orchestrator = DebateOrchestrator(tier_config_consensus, temp_state_dir)
+        door_synthesis = "## DOOR - Final Synthesis\nThe integrated solution..."
+
+        responses = [
+            create_mock_response("Wind response"),
+            create_mock_response("Wall response"),
+            create_mock_response(door_synthesis),
+            create_mock_response("APPROVE"),  # Wind
+            create_mock_response("APPROVE"),  # Wall
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Synthesis content test")
+
+        assert result.synthesis is not None
+        assert "integrated solution" in result.synthesis.lower()
+
+
+class TestConsensusLoopWindRejects:
+    """Tests for when Wind rejects."""
+
+    @pytest.mark.anyio
+    async def test_wind_rejects_triggers_refinement(
+        self, tier_config_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """When Wind rejects, Door should refine and consensus repeats."""
+        orchestrator = DebateOrchestrator(tier_config_consensus, temp_state_dir)
+
+        responses = [
+            # Initial round
+            create_mock_response("Wind: Initial expansion"),
+            create_mock_response("Wall: Initial validation"),
+            create_mock_response("Door: Initial synthesis"),
+            # First consensus - Wind rejects
+            create_mock_response("REJECT\nMissing creative potential."),
+            # No Wall vote needed - refinement triggered
+            # Refinement
+            create_mock_response("Door: Refined synthesis incorporating feedback"),
+            # Second consensus - both approve
+            create_mock_response("APPROVE\nNow captures possibilities."),
+            create_mock_response("APPROVE\nConstraints still valid."),
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Wind rejection test")
+
+        # Should eventually reach synthesis after refinement
+        assert result.status == "synthesis"
+        # Turn count should include refinement turns
+        assert result.turn_count > 3
+
+
+class TestConsensusLoopWallRejects:
+    """Tests for when Wall rejects."""
+
+    @pytest.mark.anyio
+    async def test_wall_rejects_triggers_refinement(
+        self, tier_config_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """When Wall rejects, Door should refine and consensus repeats."""
+        orchestrator = DebateOrchestrator(tier_config_consensus, temp_state_dir)
+
+        responses = [
+            # Initial round
+            create_mock_response("Wind: Initial expansion"),
+            create_mock_response("Wall: Initial validation"),
+            create_mock_response("Door: Initial synthesis"),
+            # First consensus - Wind approves, Wall rejects
+            create_mock_response("APPROVE\nCaptures possibilities."),
+            create_mock_response("REJECT\nMissing security constraints."),
+            # Refinement
+            create_mock_response("Door: Refined synthesis with security constraints"),
+            # Second consensus - both approve
+            create_mock_response("APPROVE\nStill expansive."),
+            create_mock_response("APPROVE\nSecurity addressed."),
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Wall rejection test")
+
+        assert result.status == "synthesis"
+        assert result.turn_count > 3
+
+
+class TestConsensusLoopMaxIterations:
+    """Tests for max refinement loop behavior."""
+
+    @pytest.mark.anyio
+    async def test_max_loops_exceeded_results_in_stalemate(self, temp_state_dir: Path) -> None:
+        """When max_refinement_loops exceeded, debate should end with stalemate."""
+        # Use config with max_refinement_loops=2 for faster test
+        config = TierConfig(
+            wind=RoleConfig(provider="cli", cli="claude", role="wind-agent"),
+            wall=RoleConfig(provider="cli", cli="codex", role="wall-agent"),
+            door=RoleConfig(provider="cli", cli="gemini", role="door-agent"),
+            settings=TierSettings(
+                consensus_required=True,
+                max_turns=20,
+                max_refinement_loops=2,
+            ),
+        )
+        orchestrator = DebateOrchestrator(config, temp_state_dir)
+
+        responses = [
+            # Initial round
+            create_mock_response("Wind: Initial"),
+            create_mock_response("Wall: Initial"),
+            create_mock_response("Door: Initial"),
+            # Loop 1: reject
+            create_mock_response("REJECT"),
+            create_mock_response("Door: Refinement 1"),
+            # Loop 2: reject
+            create_mock_response("REJECT"),
+            create_mock_response("Door: Refinement 2"),
+            # Loop 3 would exceed max_refinement_loops=2
+            create_mock_response("REJECT"),
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Max loops test")
+
+        assert result.status == "stalemate"
+
+
+class TestConsensusDisabled:
+    """Tests for consensus_required=False."""
+
+    @pytest.mark.anyio
+    async def test_consensus_disabled_skips_consensus_loop(
+        self, tier_config_no_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """When consensus_required=False, should skip consensus loop."""
+        orchestrator = DebateOrchestrator(tier_config_no_consensus, temp_state_dir)
+
+        responses = [
+            create_mock_response("Wind response"),
+            create_mock_response("Wall response"),
+            create_mock_response("Door synthesis"),
+            # No consensus responses should be needed
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="No consensus test")
+
+        # Should close immediately with synthesis
+        assert result.status == "synthesis"
+        # Should only have 3 turns (Wind, Wall, Door)
+        assert result.turn_count == 3
+
+
+class TestConsensusVoteEvents:
+    """Tests for CONSENSUS_VOTE event emission."""
+
+    @pytest.mark.anyio
+    async def test_emits_consensus_vote_event_for_wind(
+        self, tier_config_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """Should emit CONSENSUS_VOTE event when Wind votes."""
+        orchestrator = DebateOrchestrator(tier_config_consensus, temp_state_dir)
+
+        responses = [
+            create_mock_response("Wind"),
+            create_mock_response("Wall"),
+            create_mock_response("Door"),
+            create_mock_response("APPROVE"),  # Wind vote
+            create_mock_response("APPROVE"),  # Wall vote
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Wind vote event test")
+
+        events = load_events(result.thread_id, temp_state_dir)
+        consensus_events = [e for e in events if e.event_type == EventType.CONSENSUS_VOTE]
+
+        # Should have at least one consensus vote event for Wind
+        assert len(consensus_events) >= 1
+        wind_votes = [e for e in consensus_events if e.payload.get("role") == "Wind"]
+        assert len(wind_votes) >= 1
+
+    @pytest.mark.anyio
+    async def test_emits_consensus_vote_event_for_wall(
+        self, tier_config_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """Should emit CONSENSUS_VOTE event when Wall votes."""
+        orchestrator = DebateOrchestrator(tier_config_consensus, temp_state_dir)
+
+        responses = [
+            create_mock_response("Wind"),
+            create_mock_response("Wall"),
+            create_mock_response("Door"),
+            create_mock_response("APPROVE"),  # Wind vote
+            create_mock_response("APPROVE"),  # Wall vote
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Wall vote event test")
+
+        events = load_events(result.thread_id, temp_state_dir)
+        consensus_events = [e for e in events if e.event_type == EventType.CONSENSUS_VOTE]
+
+        # Should have consensus vote event for Wall
+        wall_votes = [e for e in consensus_events if e.payload.get("role") == "Wall"]
+        assert len(wall_votes) >= 1
+
+    @pytest.mark.anyio
+    async def test_consensus_vote_event_includes_approved_status(
+        self, tier_config_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """CONSENSUS_VOTE event should include approved status."""
+        orchestrator = DebateOrchestrator(tier_config_consensus, temp_state_dir)
+
+        responses = [
+            create_mock_response("Wind"),
+            create_mock_response("Wall"),
+            create_mock_response("Door"),
+            create_mock_response("APPROVE"),  # Wind approves
+            create_mock_response("REJECT"),  # Wall rejects
+            create_mock_response("Door: Refinement"),
+            create_mock_response("APPROVE"),  # Wind
+            create_mock_response("APPROVE"),  # Wall
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Vote status event test")
+
+        events = load_events(result.thread_id, temp_state_dir)
+        consensus_events = [e for e in events if e.event_type == EventType.CONSENSUS_VOTE]
+
+        # Each vote event should have an 'approved' field
+        for event in consensus_events:
+            assert "approved" in event.payload
+
+
+class TestTurnCountWithConsensus:
+    """Tests for turn count including consensus turns."""
+
+    @pytest.mark.anyio
+    async def test_turn_count_includes_refinement_turns(
+        self, tier_config_consensus: TierConfig, temp_state_dir: Path
+    ) -> None:
+        """Turn count should include Door's refinement turns."""
+        orchestrator = DebateOrchestrator(tier_config_consensus, temp_state_dir)
+
+        responses = [
+            # Initial round (3 turns)
+            create_mock_response("Wind"),
+            create_mock_response("Wall"),
+            create_mock_response("Door"),
+            # Consensus 1: Wind rejects (vote doesn't count as turn)
+            create_mock_response("REJECT"),
+            # Refinement (1 turn)
+            create_mock_response("Door: Refined"),
+            # Consensus 2: both approve
+            create_mock_response("APPROVE"),
+            create_mock_response("APPROVE"),
+        ]
+
+        with patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider:
+            mock_provider = AsyncMock()
+            mock_provider.complete.side_effect = responses
+            mock_create_provider.return_value = mock_provider
+
+            result = await orchestrator.run(topic="Turn count test")
+
+        # 3 initial turns + 1 refinement = 4 turns minimum
+        assert result.turn_count >= 4

--- a/tests/unit/test_prompts_consensus.py
+++ b/tests/unit/test_prompts_consensus.py
@@ -1,0 +1,113 @@
+"""Unit tests for consensus prompts (Phase 4: Consensus Implementation).
+
+Tests the Wind/Wall approval prompt formatters:
+- format_wind_approval_prompt
+- format_wall_approval_prompt
+- Prompt structure and content
+- Thread ID inclusion for get_debate() calls
+"""
+
+from debate_hall_mcp.prompts import (
+    format_wall_approval_prompt,
+    format_wind_approval_prompt,
+)
+
+
+class TestFormatWindApprovalPrompt:
+    """Tests for format_wind_approval_prompt function."""
+
+    def test_includes_topic(self) -> None:
+        """Wind approval prompt should include the topic."""
+        prompt = format_wind_approval_prompt(topic="AI governance", thread_id="2026-01-30-test")
+        assert "AI governance" in prompt
+
+    def test_includes_thread_id(self) -> None:
+        """Wind approval prompt should include thread_id for get_debate() call."""
+        prompt = format_wind_approval_prompt(topic="Test topic", thread_id="2026-01-30-test-abc")
+        assert "2026-01-30-test-abc" in prompt
+
+    def test_includes_get_debate_instruction(self) -> None:
+        """Wind approval prompt should instruct agent to call get_debate()."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "get_debate" in prompt.lower()
+
+    def test_identifies_role_as_wind(self) -> None:
+        """Wind approval prompt should identify the role as Wind."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "Wind" in prompt
+
+    def test_mentions_approve_reject_decision(self) -> None:
+        """Wind approval prompt should mention APPROVE/REJECT decision."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "APPROVE" in prompt.upper() or "approve" in prompt.lower()
+        assert "REJECT" in prompt.upper() or "reject" in prompt.lower()
+
+    def test_mentions_synthesis_review(self) -> None:
+        """Wind approval prompt should mention reviewing Door's synthesis."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "synthesis" in prompt.lower()
+
+    def test_mentions_consensus(self) -> None:
+        """Wind approval prompt should mention consensus process."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "consensus" in prompt.lower()
+
+
+class TestFormatWallApprovalPrompt:
+    """Tests for format_wall_approval_prompt function."""
+
+    def test_includes_topic(self) -> None:
+        """Wall approval prompt should include the topic."""
+        prompt = format_wall_approval_prompt(topic="Data privacy", thread_id="2026-01-30-test")
+        assert "Data privacy" in prompt
+
+    def test_includes_thread_id(self) -> None:
+        """Wall approval prompt should include thread_id for get_debate() call."""
+        prompt = format_wall_approval_prompt(topic="Test topic", thread_id="2026-01-30-test-xyz")
+        assert "2026-01-30-test-xyz" in prompt
+
+    def test_includes_get_debate_instruction(self) -> None:
+        """Wall approval prompt should instruct agent to call get_debate()."""
+        prompt = format_wall_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "get_debate" in prompt.lower()
+
+    def test_identifies_role_as_wall(self) -> None:
+        """Wall approval prompt should identify the role as Wall."""
+        prompt = format_wall_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "Wall" in prompt
+
+    def test_mentions_approve_reject_decision(self) -> None:
+        """Wall approval prompt should mention APPROVE/REJECT decision."""
+        prompt = format_wall_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "APPROVE" in prompt.upper() or "approve" in prompt.lower()
+        assert "REJECT" in prompt.upper() or "reject" in prompt.lower()
+
+    def test_mentions_synthesis_review(self) -> None:
+        """Wall approval prompt should mention reviewing Door's synthesis."""
+        prompt = format_wall_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "synthesis" in prompt.lower()
+
+    def test_mentions_consensus(self) -> None:
+        """Wall approval prompt should mention consensus process."""
+        prompt = format_wall_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "consensus" in prompt.lower()
+
+
+class TestPromptsDifferentiate:
+    """Tests ensuring Wind and Wall prompts have appropriate differences."""
+
+    def test_wind_prompt_mentions_pathos(self) -> None:
+        """Wind approval prompt should reference PATHOS cognition."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "PATHOS" in prompt or "pathos" in prompt.lower() or "Wind" in prompt
+
+    def test_wall_prompt_mentions_ethos(self) -> None:
+        """Wall approval prompt should reference ETHOS cognition."""
+        prompt = format_wall_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "ETHOS" in prompt or "ethos" in prompt.lower() or "Wall" in prompt
+
+    def test_prompts_are_different(self) -> None:
+        """Wind and Wall approval prompts should be different."""
+        wind_prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        wall_prompt = format_wall_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert wind_prompt != wall_prompt

--- a/tests/unit/tools/test_orchestrate_resume.py
+++ b/tests/unit/tools/test_orchestrate_resume.py
@@ -1,0 +1,769 @@
+"""Unit tests for resume_debate tool (Phase 4: Consensus Implementation).
+
+Tests the resume_debate MCP tool:
+- Resume from PAUSED status
+- Validates status is PAUSED before resuming
+- Determines resume point from state
+- Returns same dict format as run_debate
+
+CE Blocking Issue Fix (Phase 4):
+- Test for resume() with turn_count < 3 (incomplete Wind/Wall/Door sequence)
+- Verifies resume() completes missing turns before consensus/close
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from debate_hall_mcp.config import RoleConfig, TierConfig, TierSettings
+from debate_hall_mcp.orchestrator import DebateResult
+from debate_hall_mcp.state import DebateMode, DebateRoom, DebateStatus, save_debate_state
+from debate_hall_mcp.tools.orchestrate import resume_debate
+
+
+@pytest.fixture
+def temp_state_dir(tmp_path: Path) -> Path:
+    """Create a temporary state directory."""
+    state_dir = tmp_path / "debates"
+    state_dir.mkdir()
+    return state_dir
+
+
+@pytest.fixture
+def mock_tier_config() -> TierConfig:
+    """Create a mock tier config."""
+    return TierConfig(
+        wind=RoleConfig(provider="cli", cli="claude", role="wind-agent"),
+        wall=RoleConfig(provider="cli", cli="codex", role="wall-agent"),
+        door=RoleConfig(provider="cli", cli="gemini", role="door-agent"),
+        settings=TierSettings(
+            consensus_required=True,
+            max_turns=12,
+            max_refinement_loops=3,
+        ),
+    )
+
+
+def create_paused_debate(thread_id: str, state_dir: Path, topic: str = "Test topic") -> DebateRoom:
+    """Create a PAUSED debate room in state directory."""
+    room = DebateRoom(
+        thread_id=thread_id,
+        topic=topic,
+        mode=DebateMode.FIXED,
+        status=DebateStatus.PAUSED,
+        max_turns=12,
+    )
+    save_debate_state(room, state_dir)
+    return room
+
+
+def create_active_debate(thread_id: str, state_dir: Path, topic: str = "Test topic") -> DebateRoom:
+    """Create an ACTIVE debate room in state directory."""
+    room = DebateRoom(
+        thread_id=thread_id,
+        topic=topic,
+        mode=DebateMode.FIXED,
+        status=DebateStatus.ACTIVE,
+        max_turns=12,
+    )
+    save_debate_state(room, state_dir)
+    return room
+
+
+class TestResumeDebateValidation:
+    """Tests for resume_debate input validation."""
+
+    @pytest.mark.anyio
+    async def test_raises_error_for_nonexistent_thread(self, temp_state_dir: Path) -> None:
+        """resume_debate should raise error for non-existent thread_id."""
+        with (patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,):
+            mock_get_state_dir.return_value = temp_state_dir
+
+            with pytest.raises(FileNotFoundError):
+                await resume_debate(thread_id="nonexistent-thread")
+
+    @pytest.mark.anyio
+    async def test_raises_error_for_active_debate(self, temp_state_dir: Path) -> None:
+        """resume_debate should raise error if debate is ACTIVE (not PAUSED)."""
+        thread_id = "2026-01-30-active-debate"
+        create_active_debate(thread_id, temp_state_dir)
+
+        with (patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,):
+            mock_get_state_dir.return_value = temp_state_dir
+
+            with pytest.raises(ValueError, match="PAUSED"):
+                await resume_debate(thread_id=thread_id)
+
+    @pytest.mark.anyio
+    async def test_raises_error_for_synthesis_debate(self, temp_state_dir: Path) -> None:
+        """resume_debate should raise error if debate is already SYNTHESIS."""
+        thread_id = "2026-01-30-synthesis-debate"
+        room = DebateRoom(
+            thread_id=thread_id,
+            topic="Completed topic",
+            mode=DebateMode.FIXED,
+            status=DebateStatus.SYNTHESIS,
+            synthesis="Final synthesis",
+        )
+        save_debate_state(room, temp_state_dir)
+
+        with (patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,):
+            mock_get_state_dir.return_value = temp_state_dir
+
+            with pytest.raises(ValueError, match="PAUSED"):
+                await resume_debate(thread_id=thread_id)
+
+    @pytest.mark.anyio
+    async def test_raises_error_for_path_unsafe_thread_id(self) -> None:
+        """resume_debate should raise error for path-unsafe thread_id."""
+        with pytest.raises(ValueError, match="path-unsafe"):
+            await resume_debate(thread_id="../evil-path")
+
+
+class TestResumeDebateExecution:
+    """Tests for resume_debate execution flow."""
+
+    @pytest.mark.anyio
+    async def test_resumes_paused_debate(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """resume_debate should resume a PAUSED debate."""
+        thread_id = "2026-01-30-paused-debate"
+        create_paused_debate(thread_id, temp_state_dir, topic="Paused topic")
+
+        mock_result = DebateResult(
+            thread_id=thread_id,
+            topic="Paused topic",
+            status="synthesis",
+            turn_count=5,
+            synthesis="Resumed synthesis",
+        )
+
+        with (
+            patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,
+            patch("debate_hall_mcp.tools.orchestrate.load_tier_config") as mock_load_config,
+            patch(
+                "debate_hall_mcp.tools.orchestrate.DebateOrchestrator"
+            ) as mock_orchestrator_class,
+        ):
+            mock_get_state_dir.return_value = temp_state_dir
+            mock_load_config.return_value = mock_tier_config
+
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.resume = AsyncMock(return_value=mock_result)
+            mock_orchestrator_class.return_value = mock_orchestrator
+
+            result = await resume_debate(thread_id=thread_id)
+
+        assert result["thread_id"] == thread_id
+        assert result["status"] == "synthesis"
+
+    @pytest.mark.anyio
+    async def test_returns_dict_format(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """resume_debate should return same dict format as run_debate."""
+        thread_id = "2026-01-30-format-test"
+        create_paused_debate(thread_id, temp_state_dir, topic="Format test topic")
+
+        mock_result = DebateResult(
+            thread_id=thread_id,
+            topic="Format test topic",
+            status="synthesis",
+            turn_count=4,
+            synthesis="Test synthesis",
+        )
+
+        with (
+            patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,
+            patch("debate_hall_mcp.tools.orchestrate.load_tier_config") as mock_load_config,
+            patch(
+                "debate_hall_mcp.tools.orchestrate.DebateOrchestrator"
+            ) as mock_orchestrator_class,
+        ):
+            mock_get_state_dir.return_value = temp_state_dir
+            mock_load_config.return_value = mock_tier_config
+
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.resume = AsyncMock(return_value=mock_result)
+            mock_orchestrator_class.return_value = mock_orchestrator
+
+            result = await resume_debate(thread_id=thread_id)
+
+        # Should have same keys as run_debate
+        assert "thread_id" in result
+        assert "topic" in result
+        assert "status" in result
+        assert "turn_count" in result
+        assert "synthesis" in result
+
+    @pytest.mark.anyio
+    async def test_uses_tier_from_parameter(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """resume_debate should use specified tier."""
+        thread_id = "2026-01-30-tier-test"
+        create_paused_debate(thread_id, temp_state_dir)
+
+        mock_result = DebateResult(
+            thread_id=thread_id,
+            topic="Test topic",
+            status="synthesis",
+            turn_count=3,
+            synthesis="Synthesis",
+        )
+
+        with (
+            patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,
+            patch("debate_hall_mcp.tools.orchestrate.load_tier_config") as mock_load_config,
+            patch(
+                "debate_hall_mcp.tools.orchestrate.DebateOrchestrator"
+            ) as mock_orchestrator_class,
+        ):
+            mock_get_state_dir.return_value = temp_state_dir
+            mock_load_config.return_value = mock_tier_config
+
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.resume = AsyncMock(return_value=mock_result)
+            mock_orchestrator_class.return_value = mock_orchestrator
+
+            await resume_debate(thread_id=thread_id, tier="premium")
+
+        mock_load_config.assert_called_once_with("premium")
+
+    @pytest.mark.anyio
+    async def test_default_tier_is_standard(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """resume_debate should use 'standard' tier by default."""
+        thread_id = "2026-01-30-default-tier"
+        create_paused_debate(thread_id, temp_state_dir)
+
+        mock_result = DebateResult(
+            thread_id=thread_id,
+            topic="Test topic",
+            status="synthesis",
+            turn_count=3,
+            synthesis="Synthesis",
+        )
+
+        with (
+            patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,
+            patch("debate_hall_mcp.tools.orchestrate.load_tier_config") as mock_load_config,
+            patch(
+                "debate_hall_mcp.tools.orchestrate.DebateOrchestrator"
+            ) as mock_orchestrator_class,
+        ):
+            mock_get_state_dir.return_value = temp_state_dir
+            mock_load_config.return_value = mock_tier_config
+
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.resume = AsyncMock(return_value=mock_result)
+            mock_orchestrator_class.return_value = mock_orchestrator
+
+            await resume_debate(thread_id=thread_id)
+
+        mock_load_config.assert_called_once_with("standard")
+
+
+class TestResumeDebateResumePoint:
+    """Tests for determining resume point from state."""
+
+    @pytest.mark.anyio
+    async def test_passes_thread_id_to_orchestrator_resume(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """resume_debate should pass thread_id to orchestrator.resume()."""
+        thread_id = "2026-01-30-resume-point"
+        create_paused_debate(thread_id, temp_state_dir, topic="Resume point topic")
+
+        mock_result = DebateResult(
+            thread_id=thread_id,
+            topic="Resume point topic",
+            status="synthesis",
+            turn_count=5,
+            synthesis="Resumed",
+        )
+
+        with (
+            patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,
+            patch("debate_hall_mcp.tools.orchestrate.load_tier_config") as mock_load_config,
+            patch(
+                "debate_hall_mcp.tools.orchestrate.DebateOrchestrator"
+            ) as mock_orchestrator_class,
+        ):
+            mock_get_state_dir.return_value = temp_state_dir
+            mock_load_config.return_value = mock_tier_config
+
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.resume = AsyncMock(return_value=mock_result)
+            mock_orchestrator_class.return_value = mock_orchestrator
+
+            await resume_debate(thread_id=thread_id)
+
+        # Verify orchestrator.resume was called with thread_id
+        mock_orchestrator.resume.assert_called_once_with(thread_id=thread_id)
+
+
+class TestResumeDebateIncompleteTurns:
+    """Tests for resume() when debate paused before all Wind/Wall/Door turns completed.
+
+    CE blocking issue: If debate pauses at turn_count < 3, resume() would call
+    debate_close() with empty synthesis, causing ValueError.
+
+    Fix requirement: resume() must complete missing turns before consensus/close.
+    """
+
+    @pytest.mark.anyio
+    async def test_resume_completes_missing_turns_when_paused_after_wind(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """resume() should complete Wall and Door turns when paused after Wind only.
+
+        Scenario:
+        - Debate paused after Wind turn (turn_count=1)
+        - Resume should complete Wall turn, then Door turn
+        - Then proceed to consensus/close
+        """
+        from debate_hall_mcp.providers import ProviderResponse
+        from debate_hall_mcp.state import Turn, load_debate_state
+
+        thread_id = "2026-01-30-paused-after-wind"
+
+        # Create a PAUSED debate with only Wind turn
+        room = DebateRoom(
+            thread_id=thread_id,
+            topic="Test incomplete turns",
+            mode=DebateMode.MEDIATED,
+            status=DebateStatus.PAUSED,
+            max_turns=12,
+            turns=[
+                Turn(
+                    role="Wind",
+                    content="Wind's initial exploration",
+                    timestamp=datetime.now(tz=UTC),
+                    cognition="PATHOS",
+                ),
+            ],
+        )
+        save_debate_state(room, temp_state_dir)
+
+        # Verify the debate state has only 1 turn
+        loaded = load_debate_state(thread_id, temp_state_dir)
+        assert len(loaded.turns) == 1
+        assert loaded.turns[0].role == "Wind"
+
+        # Mock providers to return content for Wall and Door turns
+        mock_wall_response = ProviderResponse(
+            content="Wall's validation response",
+            model="test-wall-model",
+            token_input=100,
+            token_output=50,
+        )
+        mock_door_response = ProviderResponse(
+            content="Door's synthesis after completing missing turns",
+            model="test-door-model",
+            token_input=200,
+            token_output=100,
+        )
+        mock_wind_approval = ProviderResponse(
+            content="APPROVED: The synthesis is valid.",
+            model="test-wind-model",
+            token_input=50,
+            token_output=20,
+        )
+        mock_wall_approval = ProviderResponse(
+            content="APPROVED: The synthesis is valid.",
+            model="test-wall-model",
+            token_input=50,
+            token_output=20,
+        )
+
+        # Create mock providers
+        mock_wind_provider = AsyncMock()
+        mock_wall_provider = AsyncMock()
+        mock_door_provider = AsyncMock()
+
+        # Set up the complete() method to return appropriate responses
+        mock_wind_provider.complete = AsyncMock(return_value=mock_wind_approval)
+        mock_wall_provider.complete = AsyncMock(
+            side_effect=[mock_wall_response, mock_wall_approval]
+        )
+        mock_door_provider.complete = AsyncMock(return_value=mock_door_response)
+
+        with (
+            patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider,
+            patch("debate_hall_mcp.orchestrator.append_event"),
+        ):
+            # Mock provider creation to return our test providers
+            def create_provider_side_effect(config: RoleConfig) -> AsyncMock:
+                if "wind" in str(config.role).lower():
+                    return mock_wind_provider
+                elif "wall" in str(config.role).lower():
+                    return mock_wall_provider
+                else:
+                    return mock_door_provider
+
+            mock_create_provider.side_effect = create_provider_side_effect
+
+            from debate_hall_mcp.orchestrator import DebateOrchestrator
+
+            orchestrator = DebateOrchestrator(
+                tier_config=mock_tier_config,
+                state_dir=temp_state_dir,
+            )
+
+            # This should NOT raise ValueError about empty synthesis
+            result = await orchestrator.resume(thread_id)
+
+        # Verify debate completed successfully
+        assert result.status in ("synthesis", "stalemate")
+        assert result.synthesis is not None
+        assert result.synthesis != ""
+
+        # Verify turns were added (should now have Wind + Wall + Door = 3+ turns)
+        final_state = load_debate_state(thread_id, temp_state_dir)
+        assert (
+            len(final_state.turns) >= 3
+        ), f"Expected at least 3 turns after resume, got {len(final_state.turns)}"
+
+        # Check that Wall and Door turns were added
+        roles_after_resume = [t.role for t in final_state.turns]
+        assert "Wall" in roles_after_resume, "Wall turn should have been added"
+        assert "Door" in roles_after_resume, "Door turn should have been added"
+
+    @pytest.mark.anyio
+    async def test_resume_completes_door_turn_when_paused_after_wall(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """resume() should complete Door turn when paused after Wind+Wall only.
+
+        Scenario:
+        - Debate paused after Wall turn (turn_count=2)
+        - Resume should complete Door turn
+        - Then proceed to consensus/close
+        """
+        from debate_hall_mcp.providers import ProviderResponse
+        from debate_hall_mcp.state import Turn, load_debate_state
+
+        thread_id = "2026-01-30-paused-after-wall"
+
+        # Create turns with proper hash chain
+        wind_turn = Turn(
+            role="Wind",
+            content="Wind's exploration",
+            timestamp=datetime.now(tz=UTC),
+            cognition="PATHOS",
+            previous_hash=None,  # First turn has no previous
+        )
+        wall_turn = Turn(
+            role="Wall",
+            content="Wall's validation",
+            timestamp=datetime.now(tz=UTC),
+            cognition="ETHOS",
+            previous_hash=wind_turn.hash,  # Chain to Wind's hash
+        )
+
+        # Create a PAUSED debate with Wind and Wall turns (no Door)
+        room = DebateRoom(
+            thread_id=thread_id,
+            topic="Test incomplete - missing Door",
+            mode=DebateMode.MEDIATED,
+            status=DebateStatus.PAUSED,
+            max_turns=12,
+            turns=[wind_turn, wall_turn],
+        )
+        save_debate_state(room, temp_state_dir)
+
+        # Verify initial state
+        loaded = load_debate_state(thread_id, temp_state_dir)
+        assert len(loaded.turns) == 2
+        assert "Door" not in [t.role for t in loaded.turns]
+
+        # Mock providers
+        mock_door_response = ProviderResponse(
+            content="Door's synthesis completing the debate",
+            model="test-door-model",
+            token_input=200,
+            token_output=100,
+        )
+        mock_wind_approval = ProviderResponse(
+            content="APPROVED: Synthesis is valid.",
+            model="test-wind-model",
+            token_input=50,
+            token_output=20,
+        )
+        mock_wall_approval = ProviderResponse(
+            content="APPROVED: Synthesis is valid.",
+            model="test-wall-model",
+            token_input=50,
+            token_output=20,
+        )
+
+        mock_wind_provider = AsyncMock()
+        mock_wall_provider = AsyncMock()
+        mock_door_provider = AsyncMock()
+
+        mock_wind_provider.complete = AsyncMock(return_value=mock_wind_approval)
+        mock_wall_provider.complete = AsyncMock(return_value=mock_wall_approval)
+        mock_door_provider.complete = AsyncMock(return_value=mock_door_response)
+
+        with (
+            patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider,
+            patch("debate_hall_mcp.orchestrator.append_event"),
+        ):
+
+            def create_provider_side_effect(config: RoleConfig) -> AsyncMock:
+                if "wind" in str(config.role).lower():
+                    return mock_wind_provider
+                elif "wall" in str(config.role).lower():
+                    return mock_wall_provider
+                else:
+                    return mock_door_provider
+
+            mock_create_provider.side_effect = create_provider_side_effect
+
+            from debate_hall_mcp.orchestrator import DebateOrchestrator
+
+            orchestrator = DebateOrchestrator(
+                tier_config=mock_tier_config,
+                state_dir=temp_state_dir,
+            )
+
+            # This should NOT raise ValueError about empty synthesis
+            result = await orchestrator.resume(thread_id)
+
+        # Verify debate completed successfully
+        assert result.status in ("synthesis", "stalemate")
+        assert result.synthesis is not None
+        assert result.synthesis != ""
+
+        # Verify Door turn was added
+        final_state = load_debate_state(thread_id, temp_state_dir)
+        assert len(final_state.turns) >= 3
+        roles_after_resume = [t.role for t in final_state.turns]
+        assert "Door" in roles_after_resume, "Door turn should have been added"
+
+    @pytest.mark.anyio
+    async def test_resume_no_longer_raises_valueerror_after_fix(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """Verify the CE-identified bug is fixed: resume() no longer raises ValueError.
+
+        This test verifies the fix for the CE-identified bug:
+        - Debate paused after Wind turn only (turn_count=1)
+        - resume() now completes missing Wall and Door turns
+        - No ValueError is raised
+        """
+        from debate_hall_mcp.providers import ProviderResponse
+        from debate_hall_mcp.state import Turn, load_debate_state
+
+        thread_id = "2026-01-30-bug-fix-verification"
+
+        # Create a PAUSED debate with only Wind turn (no Door)
+        room = DebateRoom(
+            thread_id=thread_id,
+            topic="Bug fix verification - should not raise ValueError",
+            mode=DebateMode.MEDIATED,
+            status=DebateStatus.PAUSED,
+            max_turns=12,
+            turns=[
+                Turn(
+                    role="Wind",
+                    content="Wind's initial content",
+                    timestamp=datetime.now(tz=UTC),
+                    cognition="PATHOS",
+                ),
+            ],
+        )
+        save_debate_state(room, temp_state_dir)
+
+        # Disable consensus to go straight to close (simpler test)
+        mock_tier_config_no_consensus = TierConfig(
+            wind=mock_tier_config.wind,
+            wall=mock_tier_config.wall,
+            door=mock_tier_config.door,
+            settings=TierSettings(
+                consensus_required=False,  # Skip consensus, go straight to close
+                max_turns=12,
+                max_refinement_loops=3,
+            ),
+        )
+
+        # Mock providers to return valid content
+        mock_wall_response = ProviderResponse(
+            content="Wall's validation response",
+            model="test-wall-model",
+            token_input=100,
+            token_output=50,
+        )
+        mock_door_response = ProviderResponse(
+            content="Door's synthesis after completing missing turns",
+            model="test-door-model",
+            token_input=200,
+            token_output=100,
+        )
+
+        mock_wind_provider = AsyncMock()
+        mock_wall_provider = AsyncMock()
+        mock_door_provider = AsyncMock()
+
+        mock_wind_provider.complete = AsyncMock()
+        mock_wall_provider.complete = AsyncMock(return_value=mock_wall_response)
+        mock_door_provider.complete = AsyncMock(return_value=mock_door_response)
+
+        with (
+            patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider,
+            patch("debate_hall_mcp.orchestrator.append_event"),
+        ):
+
+            def create_provider_side_effect(config: RoleConfig) -> AsyncMock:
+                if "wind" in str(config.role).lower():
+                    return mock_wind_provider
+                elif "wall" in str(config.role).lower():
+                    return mock_wall_provider
+                else:
+                    return mock_door_provider
+
+            mock_create_provider.side_effect = create_provider_side_effect
+
+            from debate_hall_mcp.orchestrator import DebateOrchestrator
+
+            orchestrator = DebateOrchestrator(
+                tier_config=mock_tier_config_no_consensus,
+                state_dir=temp_state_dir,
+            )
+
+            # After fix, this should NOT raise ValueError
+            result = await orchestrator.resume(thread_id)
+
+        # Verify debate completed successfully
+        assert result.status == "synthesis"
+        assert result.synthesis is not None
+        assert result.synthesis != ""
+
+        # Verify all turns were added
+        final_state = load_debate_state(thread_id, temp_state_dir)
+        assert len(final_state.turns) == 3  # Wind + Wall + Door
+        roles = [t.role for t in final_state.turns]
+        assert "Wind" in roles
+        assert "Wall" in roles
+        assert "Door" in roles
+
+    @pytest.mark.anyio
+    async def test_resume_completes_wind_turn_when_paused_at_zero_turns(
+        self, temp_state_dir: Path, mock_tier_config: TierConfig
+    ) -> None:
+        """resume() should complete Wind, Wall, Door turns when paused with zero turns.
+
+        CE Blocking Issue #2:
+        - A debate can be PAUSED with turn_count=0 if Wind fails immediately after init
+        - The current resume() fix handles missing Wall/Door but NOT missing Wind
+        - This test verifies resume() handles turn_count=0 by completing Wind first
+
+        Scenario:
+        - Debate initialized but Wind provider failed before returning
+        - Debate is PAUSED with 0 turns
+        - Resume should complete Wind turn FIRST, then Wall, then Door
+        - Then proceed to consensus/close
+        """
+        from debate_hall_mcp.providers import ProviderResponse
+        from debate_hall_mcp.state import load_debate_state
+
+        thread_id = "2026-01-30-paused-at-zero-turns"
+
+        # Create a PAUSED debate with ZERO turns (Wind failed immediately after init)
+        room = DebateRoom(
+            thread_id=thread_id,
+            topic="Test zero turns - Wind failed at init",
+            mode=DebateMode.MEDIATED,
+            status=DebateStatus.PAUSED,
+            max_turns=12,
+            turns=[],  # No turns - Wind failed before completing
+        )
+        save_debate_state(room, temp_state_dir)
+
+        # Verify the debate state has 0 turns
+        loaded = load_debate_state(thread_id, temp_state_dir)
+        assert len(loaded.turns) == 0, "Test precondition: debate should have 0 turns"
+
+        # Disable consensus to go straight to close (simpler test path)
+        mock_tier_config_no_consensus = TierConfig(
+            wind=mock_tier_config.wind,
+            wall=mock_tier_config.wall,
+            door=mock_tier_config.door,
+            settings=TierSettings(
+                consensus_required=False,  # Skip consensus, go straight to close
+                max_turns=12,
+                max_refinement_loops=3,
+            ),
+        )
+
+        # Mock providers to return valid content for all three turns
+        mock_wind_response = ProviderResponse(
+            content="Wind's initial exploration of possibilities",
+            model="test-wind-model",
+            token_input=100,
+            token_output=50,
+        )
+        mock_wall_response = ProviderResponse(
+            content="Wall's validation of constraints",
+            model="test-wall-model",
+            token_input=100,
+            token_output=50,
+        )
+        mock_door_response = ProviderResponse(
+            content="Door's synthesis integrating Wind and Wall",
+            model="test-door-model",
+            token_input=200,
+            token_output=100,
+        )
+
+        mock_wind_provider = AsyncMock()
+        mock_wall_provider = AsyncMock()
+        mock_door_provider = AsyncMock()
+
+        mock_wind_provider.complete = AsyncMock(return_value=mock_wind_response)
+        mock_wall_provider.complete = AsyncMock(return_value=mock_wall_response)
+        mock_door_provider.complete = AsyncMock(return_value=mock_door_response)
+
+        with (
+            patch("debate_hall_mcp.orchestrator.create_provider") as mock_create_provider,
+            patch("debate_hall_mcp.orchestrator.append_event"),
+        ):
+
+            def create_provider_side_effect(config: RoleConfig) -> AsyncMock:
+                if "wind" in str(config.role).lower():
+                    return mock_wind_provider
+                elif "wall" in str(config.role).lower():
+                    return mock_wall_provider
+                else:
+                    return mock_door_provider
+
+            mock_create_provider.side_effect = create_provider_side_effect
+
+            from debate_hall_mcp.orchestrator import DebateOrchestrator
+
+            orchestrator = DebateOrchestrator(
+                tier_config=mock_tier_config_no_consensus,
+                state_dir=temp_state_dir,
+            )
+
+            # This should complete all three turns: Wind, Wall, Door
+            result = await orchestrator.resume(thread_id)
+
+        # Verify debate completed successfully
+        assert result.status == "synthesis"
+        assert result.synthesis is not None
+        assert result.synthesis != ""
+
+        # Verify Wind was called (the key assertion for this bug fix)
+        mock_wind_provider.complete.assert_called_once()
+
+        # Verify all three turns were added in correct order
+        final_state = load_debate_state(thread_id, temp_state_dir)
+        assert len(final_state.turns) == 3, f"Expected 3 turns, got {len(final_state.turns)}"
+        roles = [t.role for t in final_state.turns]
+        assert roles == ["Wind", "Wall", "Door"], f"Expected ['Wind', 'Wall', 'Door'], got {roles}"


### PR DESCRIPTION
## Summary

- Implements Issue #111 Phase 4: Consensus mechanism with Wind/Wall approval and refinement loops
- Adds `resume_debate` tool for recovering from PAUSED debates after failures
- New `ConsensusResult` model with fuzzy parsing for APPROVE/REJECT responses
- Consensus loop in orchestrator: Wind→Wall review, Door refines on reject, STALEMATE on max loops exceeded

## Test plan

- [x] Parser tests: 28 tests in `test_consensus.py`
- [x] Prompt tests: 17 tests in `test_prompts_consensus.py`
- [x] Consensus loop tests: 10 tests in `test_orchestrator_consensus.py`
- [x] Resume tests: 13 tests in `test_orchestrate_resume.py`
- [x] Full suite: 734 tests pass
- [x] Quality gates: ruff/mypy/black clean

## Review Status

- CRS (Gemini): APPROVED - 98% reliability score
- CE (Codex): APPROVED - after 2 fix iterations for resume path edge cases
  - Fix 1: Handle turn_count<3 (missing Door turn on resume)
  - Fix 2: Handle turn_count=0 (Wind failure after init on resume)

## Files Changed

**New Files:**
- `src/debate_hall_mcp/consensus.py` - ConsensusResult model + parser
- `tests/unit/test_consensus.py` - Parser tests
- `tests/unit/test_prompts_consensus.py` - Prompt tests
- `tests/unit/test_orchestrator_consensus.py` - Consensus loop tests
- `tests/unit/tools/test_orchestrate_resume.py` - Resume tests

**Modified Files:**
- `src/debate_hall_mcp/prompts/__init__.py` - Added approval prompts
- `src/debate_hall_mcp/orchestrator.py` - Consensus loop + resume()
- `src/debate_hall_mcp/tools/orchestrate.py` - resume_debate tool
- `src/debate_hall_mcp/tools/close.py` - Added status parameter

Closes #111 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)