### PR TITLE
feat: add .worktree-sync.yaml for automatic config syncing

### DIFF
--- a/.worktree-sync.yaml
+++ b/.worktree-sync.yaml
@@ -1,0 +1,14 @@
+# Worktree File Sync Configuration
+# Files listed here will be synced from main repo to worktrees on session start
+#
+# Format:
+#   - path: "relative/path/to/file"
+#     strategy: symlink|copy  # default: symlink
+#
+# Strategy:
+#   symlink - Single source of truth (changes reflect everywhere)
+#   copy    - Isolated divergence (worktree can modify independently)
+
+# Debate tier configuration (API keys/models configured per-user)
+- path: tiers.yaml
+  strategy: symlink


### PR DESCRIPTION
## Summary
- Adds `.worktree-sync.yaml` configuration file for automatic worktree file syncing
- Declares `tiers.yaml` should be symlinked from main repo to worktrees on session start

## Context
When working in git worktrees, project-specific config files like `tiers.yaml` were not available, causing debate orchestration to fail. This was solved through a Wind/Wall/Door debate that determined the best approach.

## Solution
The `.worktree-sync.yaml` file works with the enhanced `setup-dependencies.sh` hook (committed separately to `~/.claude/hooks/`) which:
- Reads the config file using a pure Bash YAML parser (no external dependencies)
- Supports `symlink` (default) or `copy` strategies per file
- Automatically syncs declared files from main repo to worktrees

## Test plan
- [x] Verified symlink creation on session start
- [x] Tested with `tiers.yaml` in worktree context
- [x] Confirmed existing hook behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)