### PR TITLE
fix(config): add package-root to tiers.yaml search paths

### DIFF
--- a/src/debate_hall_mcp/config.py
+++ b/src/debate_hall_mcp/config.py
@@ -9,7 +9,8 @@ This module implements:
 Resolution order for tier configuration:
 1. DEBATE_HALL_TIERS_FILE environment variable
 2. ./tiers.yaml (project-local, for team/repo configs)
-3. ~/.debate-hall/tiers.yaml (user-global)
+3. Package-root tiers.yaml (co-located with the debate-hall-mcp installation)
+4. ~/.debate-hall/tiers.yaml (user-global)
 
 No hardcoded defaults - configuration must exist in a tiers.yaml file.
 """
@@ -157,6 +158,10 @@ class TierConfig(BaseModel):
 # Environment variable for tier configuration file
 TIERS_FILE_ENV_VAR = "DEBATE_HALL_TIERS_FILE"
 
+# Package root directory (where debate-hall-mcp is installed from)
+# Navigate from src/debate_hall_mcp/config.py -> project root
+_PACKAGE_ROOT = Path(__file__).resolve().parent.parent.parent
+
 
 class TierConfigNotFoundError(Exception):
     """Raised when no tier configuration file is found."""
@@ -209,7 +214,8 @@ def _get_tiers_file_path() -> Path | None:
     Resolution order:
     1. DEBATE_HALL_TIERS_FILE environment variable
     2. ./tiers.yaml (project-local)
-    3. ~/.debate-hall/tiers.yaml (user-global)
+    3. Package-root tiers.yaml (co-located with installed debate-hall-mcp)
+    4. ~/.debate-hall/tiers.yaml (user-global)
 
     Returns:
         Path to config file, or None if no file exists
@@ -226,7 +232,12 @@ def _get_tiers_file_path() -> Path | None:
     if project_config.exists():
         return project_config.resolve()
 
-    # Priority 3: User-global config
+    # Priority 3: Package-root config (where debate-hall-mcp is installed from)
+    package_config = _PACKAGE_ROOT / "tiers.yaml"
+    if package_config.exists():
+        return package_config
+
+    # Priority 4: User-global config
     home = Path(os.environ.get("HOME", "~")).expanduser()
     home_config = home / ".debate-hall" / "tiers.yaml"
     if home_config.exists():
@@ -241,7 +252,8 @@ def load_tier_config(tier_name: str) -> TierConfig:
     Resolution order:
     1. DEBATE_HALL_TIERS_FILE environment variable
     2. ./tiers.yaml (project-local)
-    3. ~/.debate-hall/tiers.yaml (user-global)
+    3. Package-root tiers.yaml (co-located with debate-hall-mcp)
+    4. ~/.debate-hall/tiers.yaml (user-global)
 
     Args:
         tier_name: Name of the tier to load (e.g., "standard", "premium")
@@ -259,6 +271,7 @@ def load_tier_config(tier_name: str) -> TierConfig:
         raise TierConfigNotFoundError(
             "No tier configuration found. Create tiers.yaml in:\n"
             "  - ./tiers.yaml (project-local)\n"
+            f"  - {_PACKAGE_ROOT}/tiers.yaml (package-root)\n"
             "  - ~/.debate-hall/tiers.yaml (user-global)\n"
             "  - Or set DEBATE_HALL_TIERS_FILE environment variable\n\n"
             "See https://github.com/elevanaltd/debate-hall-mcp#configuration for examples."

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -275,6 +275,7 @@ class TestTierConfigLoader:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """load_tier_config reads from ~/.debate-hall/tiers.yaml if no env var."""
+        import debate_hall_mcp.config as config_module
         from debate_hall_mcp.config import load_tier_config
 
         # Create mock home directory with config
@@ -305,6 +306,8 @@ class TestTierConfigLoader:
         monkeypatch.setenv("HOME", str(mock_home))
         # Change to temp dir so ./tiers.yaml isn't found
         monkeypatch.chdir(tmp_path)
+        # Mock package root to a directory without tiers.yaml
+        monkeypatch.setattr(config_module, "_PACKAGE_ROOT", tmp_path / "no_package")
 
         config = load_tier_config("premium")
         assert config.wall.provider == "openrouter"
@@ -314,12 +317,15 @@ class TestTierConfigLoader:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """load_tier_config raises TierConfigNotFoundError if no config files exist."""
+        import debate_hall_mcp.config as config_module
         from debate_hall_mcp.config import TierConfigNotFoundError, load_tier_config
 
         # Point to non-existent locations
         monkeypatch.delenv("DEBATE_HALL_TIERS_FILE", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
         monkeypatch.chdir(tmp_path / "also_nonexistent" if False else tmp_path)
+        # Mock package root to a directory without tiers.yaml
+        monkeypatch.setattr(config_module, "_PACKAGE_ROOT", tmp_path / "no_package")
 
         # Create empty tmp_path with no tiers.yaml
         with pytest.raises(TierConfigNotFoundError, match="No tier configuration found"):
@@ -468,6 +474,151 @@ class TestTierConfigLoader:
         config = load_tier_config("standard")
         assert config.wind.provider == "openrouter"
         assert config.wind.model == "anthropic/claude-sonnet-4"
+
+    def test_load_tier_config_from_package_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """load_tier_config reads from package-root tiers.yaml when cwd has none."""
+        import debate_hall_mcp.config as config_module
+        from debate_hall_mcp.config import load_tier_config
+
+        # Create a mock package root with tiers.yaml
+        mock_package_root = tmp_path / "package_root"
+        mock_package_root.mkdir()
+        config_file = mock_package_root / "tiers.yaml"
+        config_file.write_text(dedent("""
+            standard:
+              wind:
+                provider: openrouter
+                model: package-root-model
+              wall:
+                provider: openrouter
+                model: package-root-model
+              door:
+                provider: openrouter
+                model: package-root-model
+              settings:
+                max_turns: 42
+        """))
+
+        # No env var, no project-local, no home config
+        monkeypatch.delenv("DEBATE_HALL_TIERS_FILE", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
+        monkeypatch.chdir(tmp_path)  # cwd has no tiers.yaml
+        monkeypatch.setattr(config_module, "_PACKAGE_ROOT", mock_package_root)
+
+        config = load_tier_config("standard")
+        assert config.wind.model == "package-root-model"
+        assert config.settings.max_turns == 42
+
+    def test_load_tier_config_project_local_priority_over_package_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Project-local ./tiers.yaml takes priority over package-root tiers.yaml."""
+        import debate_hall_mcp.config as config_module
+        from debate_hall_mcp.config import load_tier_config
+
+        # Create project-local config
+        project_config = tmp_path / "tiers.yaml"
+        project_config.write_text(dedent("""
+            standard:
+              wind:
+                provider: openrouter
+                model: project-model
+              wall:
+                provider: openrouter
+                model: project-model
+              door:
+                provider: openrouter
+                model: project-model
+              settings:
+                max_turns: 100
+        """))
+
+        # Create package-root config with different values
+        mock_package_root = tmp_path / "package_root"
+        mock_package_root.mkdir()
+        package_config = mock_package_root / "tiers.yaml"
+        package_config.write_text(dedent("""
+            standard:
+              wind:
+                provider: openrouter
+                model: package-model
+              wall:
+                provider: openrouter
+                model: package-model
+              door:
+                provider: openrouter
+                model: package-model
+              settings:
+                max_turns: 1
+        """))
+
+        monkeypatch.delenv("DEBATE_HALL_TIERS_FILE", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(config_module, "_PACKAGE_ROOT", mock_package_root)
+
+        config = load_tier_config("standard")
+        # Should use project-local (max_turns=100), not package-root (max_turns=1)
+        assert config.settings.max_turns == 100
+        assert config.wind.model == "project-model"
+
+    def test_load_tier_config_package_root_priority_over_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Package-root tiers.yaml takes priority over ~/.debate-hall/tiers.yaml."""
+        import debate_hall_mcp.config as config_module
+        from debate_hall_mcp.config import load_tier_config
+
+        # Create package-root config
+        mock_package_root = tmp_path / "package_root"
+        mock_package_root.mkdir()
+        package_config = mock_package_root / "tiers.yaml"
+        package_config.write_text(dedent("""
+            standard:
+              wind:
+                provider: openrouter
+                model: package-model
+              wall:
+                provider: openrouter
+                model: package-model
+              door:
+                provider: openrouter
+                model: package-model
+              settings:
+                max_turns: 77
+        """))
+
+        # Create home dir config
+        mock_home = tmp_path / "home"
+        mock_debate_hall = mock_home / ".debate-hall"
+        mock_debate_hall.mkdir(parents=True)
+        home_config = mock_debate_hall / "tiers.yaml"
+        home_config.write_text(dedent("""
+            standard:
+              wind:
+                provider: cli
+                cli: claude
+              wall:
+                provider: cli
+                cli: codex
+              door:
+                provider: cli
+                cli: gemini
+              settings:
+                max_turns: 5
+        """))
+
+        monkeypatch.delenv("DEBATE_HALL_TIERS_FILE", raising=False)
+        monkeypatch.setenv("HOME", str(mock_home))
+        monkeypatch.chdir(tmp_path)  # no project-local tiers.yaml
+        monkeypatch.setattr(config_module, "_PACKAGE_ROOT", mock_package_root)
+
+        config = load_tier_config("standard")
+        # Should use package-root (max_turns=77), not home (max_turns=5)
+        assert config.settings.max_turns == 77
+        assert config.wind.model == "package-model"
 
     def test_load_tier_config_project_local_priority_over_home(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- Fixes `No tier configuration found` error when debate-hall-mcp is used as an MCP server from a different project's working directory
- Adds the package's own installation directory as a search path for `tiers.yaml`, so the repo-bundled config is always discoverable regardless of the MCP client's cwd
- Updates resolution order: env var → project-local → **package-root (new)** → user-global

## Root Cause
`_get_tiers_file_path()` searched `./tiers.yaml` (relative to cwd) and `~/.debate-hall/tiers.yaml`. When the MCP server process runs from another project's directory, `./tiers.yaml` resolves to that project — not the debate-hall-mcp repo where `tiers.yaml` actually lives.

## Changes
- `src/debate_hall_mcp/config.py`: Added `_PACKAGE_ROOT` constant and package-root search path (Priority 3)
- `tests/unit/test_config.py`: 3 new tests (package-root discovery, project-local priority over package-root, package-root priority over user-global) + fixed 2 existing tests to mock `_PACKAGE_ROOT`

## Test plan
- [x] All 1016 tests pass
- [x] mypy strict passes
- [x] ruff + black clean
- [x] 3 new tests cover: package-root resolution, priority over home, subordination to project-local
- [ ] Manual verification: use debate-hall MCP from a different repo and confirm `run_debate` finds tiers.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)