### PR TITLE
fix(server): expose RACI mode and export_decision in MCP tools

### DIFF
--- a/src/debate_hall_mcp/events.py
+++ b/src/debate_hall_mcp/events.py
@@ -172,7 +172,7 @@ def _get_event_file_lock(event_file: Path) -> FileLock:
         since both reads and writes need consistency and contention
         is expected to be low.
     """
-    lock_file = event_file.with_suffix(".events.lock")
+    lock_file = event_file.with_suffix(".lock")
     lock_file.parent.mkdir(parents=True, exist_ok=True)
     return FileLock(str(lock_file))
 

--- a/src/debate_hall_mcp/server.py
+++ b/src/debate_hall_mcp/server.py
@@ -157,18 +157,23 @@ def create_server() -> FastMCP:
         synthesis: str,
         output_format: str | None = None,
         seal: bool = False,
+        export_decision: bool = False,
     ) -> dict[str, Any] | str:
         """Finalize debate. synthesis:Door's final resolution->closes room.
 
         Args:
             output_format: 'json' (default), 'octave', or 'both'
             seal: Add cryptographic seal to OCTAVE output for tamper detection (v1.0.0)
+            export_decision: Export DecisionRecord to context directory for
+                search indexing (Issue #138). Creates an OCTAVE file in
+                .hestai/context/decisions/ that search_decisions can find.
         """
         return debate_close(
             thread_id=thread_id,
             synthesis=synthesis,
             output_format=output_format,  # type: ignore[arg-type]
             seal=seal,
+            export_decision=export_decision,
         )
 
     @server.tool()
@@ -302,6 +307,7 @@ def create_server() -> FastMCP:
         compression_tier: Literal["none", "basic", "aggressive", "ultra"] | None = None,
         primer_tier: Literal["none", "literacy", "standard", "advanced"] | None = None,
         context_files: list[str] | None = None,
+        mode: Literal["standard", "raci"] = "standard",
     ) -> dict[str, Any]:
         """Auto-orchestrate a Wind/Wall/Door debate (ADR-0002).
 
@@ -318,6 +324,9 @@ def create_server() -> FastMCP:
             primer_tier: Override primer tier (None = use tier default)
             context_files: Optional list of absolute file paths to inject as
                 codebase context. Agents will see file contents in their prompts.
+            mode: Debate mode - "standard" for full Wind/Wall/Door debate,
+                "raci" for lightweight RACI Dialogue Mode (Issue #139).
+                RACI completes in exactly 3 turns with no consensus loop.
 
         Returns:
             Dictionary with thread_id, topic, status, turn_count, and synthesis
@@ -329,6 +338,7 @@ def create_server() -> FastMCP:
             compression_tier=compression_tier,
             primer_tier=primer_tier,
             context_files=context_files,
+            mode=mode,
         )
 
     @server.tool()


### PR DESCRIPTION
## Summary
- Expose `mode` parameter on `run_debate` MCP tool, enabling RACI Dialogue Mode (Issue #139) which was implemented in the orchestrator but unreachable via MCP
- Expose `export_decision` parameter on `close_debate` MCP tool, enabling the decision export pipeline (Issue #138) that feeds `search_decisions`
- Fix event lock file naming stutter: `.events.events.lock` → `.events.lock`

## Context
Found during comprehensive v0.5.0 feature validation (10-area test plan covering all Sprint 1-5 features). The RACI mode and export_decision implementations were fully functional with passing tests, but the MCP server wrapper functions did not include these parameters in their signatures, making them unreachable by MCP clients.

## Changes
- `server.py`: Add `mode: Literal["standard", "raci"]` to `run_debate` tool wrapper
- `server.py`: Add `export_decision: bool` to `close_debate` tool wrapper  
- `events.py`: Fix `Path.with_suffix(".events.lock")` → `.with_suffix(".lock")` to avoid double `.events` in lock filename

## Test plan
- [x] All 1096 tests pass (no regressions)
- [x] ruff check: all passed
- [x] mypy --strict on changed files: no issues
- [x] 29 RACI-specific tests pass
- [x] 14 hash chain tests pass
- [x] 74 GitHub integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)