### PR TITLE
feat: add RACI disjointness validation and graceful I-turn failure degradation

### DIFF
--- a/src/debate_hall_mcp/orchestrator.py
+++ b/src/debate_hall_mcp/orchestrator.py
@@ -28,6 +28,7 @@ Phase 4: Consensus Loop
 
 import asyncio
 import contextlib
+import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -75,6 +76,8 @@ from debate_hall_mcp.tools.get import debate_get
 from debate_hall_mcp.tools.init import debate_init
 from debate_hall_mcp.tools.turn import debate_turn
 from debate_hall_mcp.utils.primers import load_primer
+
+logger = logging.getLogger(__name__)
 
 # Default provider timeout in seconds (M1: CE Review)
 # Increased from 120 to 300 to accommodate slower CLI providers
@@ -1540,6 +1543,7 @@ Respond with your refined synthesis using the OCTAVE response format."""
             # 3. Execute each turn in manifest sequence
             last_response: ProviderResponse | None = None
             verdict_content: str = ""
+            i_failures: list[str] = []
             for spec in manifest.specs:
                 # Get the appropriate user prompt based on turn type
                 if spec.turn_type == TurnType.PROPOSAL:
@@ -1558,18 +1562,70 @@ Respond with your refined synthesis using the OCTAVE response format."""
                 # Get the appropriate system prompt (with agent file resolution)
                 system_prompt = self._get_raci_prompt(spec.turn_type.value, spec.role)
 
-                last_response = await self._execute_raci_role_turn(
-                    role=spec.role,
-                    provider=provider,
-                    thread_id=thread_id,
-                    user_prompt=user_prompt,
-                    system_prompt=system_prompt,
-                    timeout=timeout,
-                )
+                # W2: Graceful I-turn failure degradation — only OBSERVATION turns
+                # get try/except; R/C/A turns still fail-fast (current behavior).
+                if spec.raci_designation == "I":
+                    try:
+                        last_response = await self._execute_raci_role_turn(
+                            role=spec.role,
+                            provider=provider,
+                            thread_id=thread_id,
+                            user_prompt=user_prompt,
+                            system_prompt=system_prompt,
+                            timeout=timeout,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "RACI I-turn failed for role '%s' in thread '%s': %s",
+                            spec.role,
+                            thread_id,
+                            str(e),
+                        )
+                        # Record sentinel turn so the hash chain remains gapless (I4)
+                        sentinel_content = (
+                            f"[OBSERVATION FAILED] Role '{spec.role}' was unable to "
+                            f"provide impact analysis: {type(e).__name__}"
+                        )
+                        debate_turn(
+                            thread_id=thread_id,
+                            role=spec.role,
+                            content=sentinel_content,
+                            model="system",
+                            state_dir=self.state_dir,
+                        )
+                        i_failures.append(spec.role)
+                        continue
+                else:
+                    last_response = await self._execute_raci_role_turn(
+                        role=spec.role,
+                        provider=provider,
+                        thread_id=thread_id,
+                        user_prompt=user_prompt,
+                        system_prompt=system_prompt,
+                        timeout=timeout,
+                    )
 
                 # Capture verdict content (the A-verdict IS the decision)
                 if spec.turn_type == TurnType.VERDICT:
                     verdict_content = last_response.content
+
+            # Log if ALL I-agents failed
+            informed_count = len([s for s in manifest.specs if s.raci_designation == "I"])
+            if i_failures and len(i_failures) == informed_count:
+                logger.error(
+                    "All %d RACI I-turn(s) failed in thread '%s': %s",
+                    informed_count,
+                    thread_id,
+                    i_failures,
+                )
+            elif i_failures:
+                logger.warning(
+                    "%d of %d RACI I-turn(s) failed in thread '%s': %s",
+                    len(i_failures),
+                    informed_count,
+                    thread_id,
+                    i_failures,
+                )
 
             # 4. Close debate with A's verdict as synthesis
             # The verdict is the decision; I-turns are supplementary observations
@@ -1583,14 +1639,17 @@ Respond with your refined synthesis using the OCTAVE response format."""
             )
 
             # Emit debate_closed event
+            closed_payload: dict[str, Any] = {
+                "status": "synthesis",
+                "synthesis_preview": verdict_content[:100],
+                "mode": "raci",
+            }
+            if i_failures:
+                closed_payload["i_turn_failures"] = i_failures
             append_event(
                 thread_id=thread_id,
                 event_type=EventType.DEBATE_CLOSED,
-                payload={
-                    "status": "synthesis",
-                    "synthesis_preview": verdict_content[:100],
-                    "mode": "raci",
-                },
+                payload=closed_payload,
                 state_dir=self.state_dir,
             )
 
@@ -1658,6 +1717,7 @@ Respond with your refined synthesis using the OCTAVE response format."""
             # Execute remaining turns from manifest
             last_response: ProviderResponse | None = None
             verdict_content: str = ""
+            i_failures: list[str] = []
 
             # Check if verdict was already recorded in prior turns
             for prior_i in range(turn_count):
@@ -1685,19 +1745,71 @@ Respond with your refined synthesis using the OCTAVE response format."""
 
                 system_prompt = self._get_raci_prompt(spec.turn_type.value, spec.role)
 
-                last_response = await self._execute_raci_role_turn(
-                    role=spec.role,
-                    provider=provider,
-                    thread_id=thread_id,
-                    user_prompt=user_prompt,
-                    system_prompt=system_prompt,
-                    timeout=timeout,
-                )
-                turn_count += 1
+                # W2: Graceful I-turn failure degradation (same as run_raci)
+                if spec.raci_designation == "I":
+                    try:
+                        last_response = await self._execute_raci_role_turn(
+                            role=spec.role,
+                            provider=provider,
+                            thread_id=thread_id,
+                            user_prompt=user_prompt,
+                            system_prompt=system_prompt,
+                            timeout=timeout,
+                        )
+                        turn_count += 1
+                    except Exception as e:
+                        logger.warning(
+                            "RACI I-turn failed for role '%s' in thread '%s': %s",
+                            spec.role,
+                            thread_id,
+                            str(e),
+                        )
+                        sentinel_content = (
+                            f"[OBSERVATION FAILED] Role '{spec.role}' was unable to "
+                            f"provide impact analysis: {type(e).__name__}"
+                        )
+                        debate_turn(
+                            thread_id=thread_id,
+                            role=spec.role,
+                            content=sentinel_content,
+                            model="system",
+                            state_dir=self.state_dir,
+                        )
+                        turn_count += 1
+                        i_failures.append(spec.role)
+                        continue
+                else:
+                    last_response = await self._execute_raci_role_turn(
+                        role=spec.role,
+                        provider=provider,
+                        thread_id=thread_id,
+                        user_prompt=user_prompt,
+                        system_prompt=system_prompt,
+                        timeout=timeout,
+                    )
+                    turn_count += 1
 
                 # Capture verdict content
                 if spec.turn_type == TurnType.VERDICT:
                     verdict_content = last_response.content
+
+            # Log if ALL I-agents failed
+            informed_count = len([s for s in manifest.specs if s.raci_designation == "I"])
+            if i_failures and len(i_failures) == informed_count:
+                logger.error(
+                    "All %d RACI I-turn(s) failed in thread '%s': %s",
+                    informed_count,
+                    thread_id,
+                    i_failures,
+                )
+            elif i_failures:
+                logger.warning(
+                    "%d of %d RACI I-turn(s) failed in thread '%s': %s",
+                    len(i_failures),
+                    informed_count,
+                    thread_id,
+                    i_failures,
+                )
 
             # Close with verdict (not last I-turn)
             if not verdict_content:
@@ -1710,14 +1822,17 @@ Respond with your refined synthesis using the OCTAVE response format."""
             )
 
             # Emit debate_closed event
+            closed_payload: dict[str, Any] = {
+                "status": "synthesis",
+                "synthesis_preview": verdict_content[:100],
+                "mode": "raci",
+            }
+            if i_failures:
+                closed_payload["i_turn_failures"] = i_failures
             append_event(
                 thread_id=thread_id,
                 event_type=EventType.DEBATE_CLOSED,
-                payload={
-                    "status": "synthesis",
-                    "synthesis_preview": verdict_content[:100],
-                    "mode": "raci",
-                },
+                payload=closed_payload,
                 state_dir=self.state_dir,
             )
 

--- a/src/debate_hall_mcp/raci.py
+++ b/src/debate_hall_mcp/raci.py
@@ -39,8 +39,18 @@ class RACIConfig(BaseModel):
     Validation rules:
     - responsible and accountable must not be empty strings
     - consulted list max 5 entries (bounded governance)
-    - responsible != accountable (separation of concerns)
+    - informed list max 3 entries (prevents cost explosions)
+    - responsible != accountable (separation of concerns, case-insensitive)
     - All role names must be non-empty strings
+
+    Disjointness rules (all comparisons are case-insensitive):
+    - No duplicate entries within informed list (V1)
+    - No duplicate entries within consulted list (V2)
+    - Informed must be disjoint from Responsible (V3)
+    - Informed must be disjoint from Accountable (V4)
+    - Informed must be disjoint from Consulted (V5)
+
+    Each role must have exactly one RACI designation.
     """
 
     responsible: str = Field(..., description="Role name for Responsible agent")
@@ -61,8 +71,8 @@ class RACIConfig(BaseModel):
         if not self.accountable or not self.accountable.strip():
             raise ValueError("accountable must be a non-empty string")
 
-        # Separation of concerns: R != A
-        if self.responsible == self.accountable:
+        # Separation of concerns: R != A (case-insensitive)
+        if self.responsible.lower().strip() == self.accountable.lower().strip():
             raise ValueError(
                 f"responsible and accountable must differ (separation of concerns): "
                 f"both are '{self.responsible}'"
@@ -94,6 +104,58 @@ class RACIConfig(BaseModel):
             if not inf or not inf.strip():
                 raise ValueError(
                     f"informed entry at index {i} is empty: all role names must be non-empty"
+                )
+
+        # --- Disjointness validation (V1-V5) ---
+        # Normalize role names for comparison (lowercase + strip)
+        norm_r = self.responsible.lower().strip()
+        norm_a = self.accountable.lower().strip()
+        norm_consulted = [c.lower().strip() for c in self.consulted]
+        norm_informed = [inf.lower().strip() for inf in self.informed]
+
+        # V1: No duplicate informed entries
+        seen_informed: set[str] = set()
+        for idx, norm_inf in enumerate(norm_informed):
+            if norm_inf in seen_informed:
+                raise ValueError(
+                    f"duplicate in informed list: role '{self.informed[idx]}' appears "
+                    f"more than once — each role must have exactly one RACI designation"
+                )
+            seen_informed.add(norm_inf)
+
+        # V2: No duplicate consulted entries
+        seen_consulted: set[str] = set()
+        for idx, norm_c in enumerate(norm_consulted):
+            if norm_c in seen_consulted:
+                raise ValueError(
+                    f"duplicate in consulted list: role '{self.consulted[idx]}' appears "
+                    f"more than once — each role must have exactly one RACI designation"
+                )
+            seen_consulted.add(norm_c)
+
+        # V3: Informed must be disjoint from Responsible
+        for idx, norm_inf in enumerate(norm_informed):
+            if norm_inf == norm_r:
+                raise ValueError(
+                    f"role '{self.informed[idx]}' appears in both responsible and "
+                    f"informed — each role must have exactly one RACI designation"
+                )
+
+        # V4: Informed must be disjoint from Accountable
+        for idx, norm_inf in enumerate(norm_informed):
+            if norm_inf == norm_a:
+                raise ValueError(
+                    f"role '{self.informed[idx]}' appears in both accountable and "
+                    f"informed — each role must have exactly one RACI designation"
+                )
+
+        # V5: Informed must be disjoint from Consulted
+        consulted_set = set(norm_consulted)
+        for idx, norm_inf in enumerate(norm_informed):
+            if norm_inf in consulted_set:
+                raise ValueError(
+                    f"role '{self.informed[idx]}' appears in both consulted and "
+                    f"informed — each role must have exactly one RACI designation"
                 )
 
         return self

--- a/tests/unit/test_raci.py
+++ b/tests/unit/test_raci.py
@@ -317,6 +317,141 @@ class TestMaxInformedValidation:
         assert config.informed == []
 
 
+class TestRACIDisjointnessValidation:
+    """Tests for RACI role disjointness validation (V1-V5).
+
+    Each role must have exactly one RACI designation.
+    All comparisons are case-insensitive.
+    """
+
+    def test_v1_duplicate_informed_rejected(self) -> None:
+        """V1: Duplicate entries in informed list should be rejected."""
+        with pytest.raises(ValueError, match="duplicate in informed.*appears more than once"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                informed=["ops", "ops"],
+            )
+
+    def test_v2_duplicate_consulted_rejected(self) -> None:
+        """V2: Duplicate entries in consulted list should be rejected."""
+        with pytest.raises(ValueError, match="duplicate in consulted.*appears more than once"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                consulted=["arch", "arch"],
+            )
+
+    def test_v3_informed_overlaps_responsible_rejected(self) -> None:
+        """V3: Informed agent that is also Responsible should be rejected."""
+        with pytest.raises(ValueError, match="role 'dev'.*responsible.*informed"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                informed=["dev"],
+            )
+
+    def test_v4_informed_overlaps_accountable_rejected(self) -> None:
+        """V4: Informed agent that is also Accountable should be rejected."""
+        with pytest.raises(ValueError, match="role 'lead'.*accountable.*informed"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                informed=["lead"],
+            )
+
+    def test_v5_informed_overlaps_consulted_rejected(self) -> None:
+        """V5: Informed agent that is also Consulted should be rejected."""
+        with pytest.raises(ValueError, match="role 'arch'.*consulted.*informed"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                consulted=["arch"],
+                informed=["arch"],
+            )
+
+    def test_case_insensitive_disjointness(self) -> None:
+        """Case differences should be treated as same role (e.g., 'Dev' and 'dev')."""
+        # V3: case-insensitive R vs I
+        with pytest.raises(ValueError, match="role 'Dev'.*responsible.*informed"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                informed=["Dev"],
+            )
+
+    def test_case_insensitive_r_equals_a(self) -> None:
+        """R==A check should also be case-insensitive."""
+        with pytest.raises(ValueError, match="responsible.*accountable|separation"):
+            RACIConfig(
+                responsible="Dev",
+                accountable="dev",
+            )
+
+    def test_valid_config_all_unique_roles(self) -> None:
+        """Config with all unique roles across R/A/C/I should pass validation."""
+        config = RACIConfig(
+            responsible="dev",
+            accountable="lead",
+            consulted=["arch", "security"],
+            informed=["pm", "ops"],
+        )
+        assert config.responsible == "dev"
+        assert config.accountable == "lead"
+        assert config.consulted == ["arch", "security"]
+        assert config.informed == ["pm", "ops"]
+
+    def test_consulted_same_as_responsible_allowed(self) -> None:
+        """Consulted == Responsible is a valid pattern (R appears in proposal + rebuttal).
+
+        This is by design: consulted agents advise, then R synthesizes feedback.
+        Do NOT block this pattern.
+        """
+        config = RACIConfig(
+            responsible="dev",
+            accountable="lead",
+            consulted=["dev"],
+        )
+        assert config.consulted == ["dev"]
+
+    def test_v1_duplicate_informed_case_insensitive(self) -> None:
+        """V1: Duplicate detection in informed should be case-insensitive."""
+        with pytest.raises(ValueError, match="duplicate in informed"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                informed=["Ops", "ops"],
+            )
+
+    def test_v2_duplicate_consulted_case_insensitive(self) -> None:
+        """V2: Duplicate detection in consulted should be case-insensitive."""
+        with pytest.raises(ValueError, match="duplicate in consulted"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                consulted=["Arch", "arch"],
+            )
+
+    def test_v4_case_insensitive_accountable_informed(self) -> None:
+        """V4: Case-insensitive check for accountable vs informed."""
+        with pytest.raises(ValueError, match="role 'LEAD'.*accountable.*informed"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                informed=["LEAD"],
+            )
+
+    def test_v5_case_insensitive_consulted_informed(self) -> None:
+        """V5: Case-insensitive check for consulted vs informed overlap."""
+        with pytest.raises(ValueError, match="role 'ARCH'.*consulted.*informed"):
+            RACIConfig(
+                responsible="dev",
+                accountable="lead",
+                consulted=["arch"],
+                informed=["ARCH"],
+            )
+
+
 class TestObservationTurnOrdering:
     """Tests for OBSERVATION turn ordering in compiled manifests."""
 

--- a/tests/unit/test_raci_orchestrator.py
+++ b/tests/unit/test_raci_orchestrator.py
@@ -725,3 +725,345 @@ class TestRACIObservationTurns:
         assert mock_provider.complete.call_count == 1
         # Synthesis should be the verdict, not the observation
         assert "VERDICT" in result.synthesis or "GO" in result.synthesis
+
+
+class TestITurnFailureDegradation:
+    """Tests for W2: Graceful I-turn failure degradation.
+
+    When an Informed agent's OBSERVATION turn fails, the debate should:
+    1. Record a sentinel turn in the transcript (gapless hash chain - I4)
+    2. Log the failure
+    3. Continue executing other I-turns
+    4. Close the debate normally with the verdict as synthesis
+    """
+
+    @pytest.mark.anyio
+    async def test_i_turn_failure_records_sentinel_content(
+        self,
+        raci_tier_config: TierConfig,
+        temp_state_dir: Path,
+    ) -> None:
+        """Failed I-turn should record sentinel content in transcript."""
+        call_count = 0
+
+        def mock_complete(
+            system_prompt: str,  # noqa: ARG001
+            user_prompt: str,  # noqa: ARG001
+            **kwargs: Any,  # noqa: ARG001
+        ) -> ProviderResponse:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return create_mock_provider_response("PROPOSAL: Deploy API")
+            elif call_count == 2:
+                return create_mock_provider_response("VERDICT: GO")
+            else:
+                # I-turn fails
+                raise RuntimeError("Provider timeout")
+
+        mock_provider = AsyncMock()
+        mock_provider.complete.side_effect = mock_complete
+
+        config = RACIConfig(
+            responsible="dev",
+            accountable="lead",
+            informed=["ops"],
+        )
+
+        orchestrator = DebateOrchestrator(
+            raci_tier_config,
+            temp_state_dir,
+            provider_factory=create_mock_provider_factory(mock_provider),
+        )
+
+        result = await orchestrator.run_raci(topic="Sentinel test", raci_config=config)
+
+        # Debate should still close successfully
+        assert result.status == "synthesis"
+
+        # Verify sentinel turn was recorded
+        room = load_debate_state(result.thread_id, temp_state_dir)
+        sentinel_turns = [t for t in room.turns if "[OBSERVATION FAILED]" in t.content]
+        assert len(sentinel_turns) == 1
+        assert "ops" in sentinel_turns[0].content
+        assert "RuntimeError" in sentinel_turns[0].content
+
+    @pytest.mark.anyio
+    async def test_i_turn_failure_does_not_prevent_debate_closure(
+        self,
+        raci_tier_config: TierConfig,
+        temp_state_dir: Path,
+    ) -> None:
+        """Failed I-turn should not prevent debate from closing with verdict."""
+        call_count = 0
+
+        def mock_complete(
+            system_prompt: str,  # noqa: ARG001
+            user_prompt: str,  # noqa: ARG001
+            **kwargs: Any,  # noqa: ARG001
+        ) -> ProviderResponse:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return create_mock_provider_response("PROPOSAL: Deploy API")
+            elif call_count == 2:
+                return create_mock_provider_response("VERDICT: GO. Approved.")
+            else:
+                raise RuntimeError("I-turn failure")
+
+        mock_provider = AsyncMock()
+        mock_provider.complete.side_effect = mock_complete
+
+        config = RACIConfig(
+            responsible="dev",
+            accountable="lead",
+            informed=["pm"],
+        )
+
+        orchestrator = DebateOrchestrator(
+            raci_tier_config,
+            temp_state_dir,
+            provider_factory=create_mock_provider_factory(mock_provider),
+        )
+
+        result = await orchestrator.run_raci(topic="Closure test", raci_config=config)
+
+        assert result.status == "synthesis"
+        assert "VERDICT" in result.synthesis
+        assert "GO" in result.synthesis
+
+    @pytest.mark.anyio
+    async def test_multiple_i_turns_partial_failure(
+        self,
+        raci_tier_config: TierConfig,
+        temp_state_dir: Path,
+    ) -> None:
+        """Multiple I-turns where one fails but others succeed."""
+        call_count = 0
+
+        def mock_complete(
+            system_prompt: str,  # noqa: ARG001
+            user_prompt: str,  # noqa: ARG001
+            **kwargs: Any,  # noqa: ARG001
+        ) -> ProviderResponse:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return create_mock_provider_response("PROPOSAL: Deploy")
+            elif call_count == 2:
+                return create_mock_provider_response("VERDICT: GO")
+            elif call_count == 3:
+                # First I-turn (ops) succeeds
+                return create_mock_provider_response("OBSERVATION: Ops impact noted.")
+            elif call_count == 4:
+                # Second I-turn (security) fails
+                raise RuntimeError("Security provider down")
+            else:
+                return create_mock_provider_response("OBSERVATION: PM impact noted.")
+
+        mock_provider = AsyncMock()
+        mock_provider.complete.side_effect = mock_complete
+
+        config = RACIConfig(
+            responsible="dev",
+            accountable="lead",
+            informed=["ops", "security", "pm"],
+        )
+
+        orchestrator = DebateOrchestrator(
+            raci_tier_config,
+            temp_state_dir,
+            provider_factory=create_mock_provider_factory(mock_provider),
+        )
+
+        result = await orchestrator.run_raci(topic="Partial failure test", raci_config=config)
+
+        assert result.status == "synthesis"
+
+        # Load transcript
+        room = load_debate_state(result.thread_id, temp_state_dir)
+        # Should have 5 turns: R + A + I(ok) + I(sentinel) + I(ok)
+        assert len(room.turns) == 5
+
+        # One sentinel turn
+        sentinel_turns = [t for t in room.turns if "[OBSERVATION FAILED]" in t.content]
+        assert len(sentinel_turns) == 1
+        assert "security" in sentinel_turns[0].content
+
+        # Two successful observation turns
+        obs_turns = [
+            t
+            for t in room.turns
+            if "OBSERVATION:" in t.content and "[OBSERVATION FAILED]" not in t.content
+        ]
+        assert len(obs_turns) == 2
+
+    @pytest.mark.anyio
+    async def test_all_i_turns_fail_debate_still_closes(
+        self,
+        raci_tier_config: TierConfig,
+        temp_state_dir: Path,
+    ) -> None:
+        """All I-turns fail -- debate still closes with verdict as synthesis."""
+        call_count = 0
+
+        def mock_complete(
+            system_prompt: str,  # noqa: ARG001
+            user_prompt: str,  # noqa: ARG001
+            **kwargs: Any,  # noqa: ARG001
+        ) -> ProviderResponse:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return create_mock_provider_response("PROPOSAL: Deploy")
+            elif call_count == 2:
+                return create_mock_provider_response("VERDICT: GO. Approved.")
+            else:
+                # All I-turns fail
+                raise RuntimeError("All providers down")
+
+        mock_provider = AsyncMock()
+        mock_provider.complete.side_effect = mock_complete
+
+        config = RACIConfig(
+            responsible="dev",
+            accountable="lead",
+            informed=["ops", "pm"],
+        )
+
+        orchestrator = DebateOrchestrator(
+            raci_tier_config,
+            temp_state_dir,
+            provider_factory=create_mock_provider_factory(mock_provider),
+        )
+
+        result = await orchestrator.run_raci(topic="All fail test", raci_config=config)
+
+        # Debate still closes successfully
+        assert result.status == "synthesis"
+        assert "VERDICT" in result.synthesis
+        assert "GO" in result.synthesis
+
+        # Both I-turns should have sentinel content
+        room = load_debate_state(result.thread_id, temp_state_dir)
+        sentinel_turns = [t for t in room.turns if "[OBSERVATION FAILED]" in t.content]
+        assert len(sentinel_turns) == 2
+
+    @pytest.mark.anyio
+    async def test_r_a_turn_failure_still_pauses(
+        self,
+        raci_tier_config: TierConfig,
+        temp_state_dir: Path,
+    ) -> None:
+        """R/C/A turn failure should still cause PAUSED state (unchanged behavior)."""
+        import os
+
+        call_count = 0
+
+        def mock_complete(
+            system_prompt: str,  # noqa: ARG001
+            user_prompt: str,  # noqa: ARG001
+            **kwargs: Any,  # noqa: ARG001
+        ) -> ProviderResponse:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return create_mock_provider_response("PROPOSAL: Deploy")
+            else:
+                # A-turn (verdict) fails -- this should NOT be gracefully degraded
+                raise RuntimeError("Accountable provider failed")
+
+        mock_provider = AsyncMock()
+        mock_provider.complete.side_effect = mock_complete
+
+        config = RACIConfig(
+            responsible="dev",
+            accountable="lead",
+            informed=["pm"],
+        )
+
+        orchestrator = DebateOrchestrator(
+            raci_tier_config,
+            temp_state_dir,
+            provider_factory=create_mock_provider_factory(mock_provider),
+        )
+
+        with pytest.raises(RuntimeError, match="Accountable provider failed"):
+            await orchestrator.run_raci(topic="A-fail test", raci_config=config)
+
+        # Debate should be PAUSED (not closed)
+        state_files = [f for f in os.listdir(temp_state_dir) if f.endswith(".json")]
+        assert len(state_files) == 1
+        thread_id = state_files[0].replace(".json", "")
+        room = load_debate_state(thread_id, temp_state_dir)
+        assert room.status == DebateStatus.PAUSED
+
+    @pytest.mark.anyio
+    async def test_resume_raci_i_turn_failure_degradation(
+        self,
+        raci_tier_config: TierConfig,
+        temp_state_dir: Path,
+    ) -> None:
+        """Resumed RACI debate should also gracefully degrade I-turn failures."""
+        from debate_hall_mcp.raci import compile_raci_manifest
+        from debate_hall_mcp.tools.init import debate_init
+
+        raci_config = RACIConfig(
+            responsible="dev",
+            accountable="lead",
+            informed=["ops"],
+        )
+        manifest = compile_raci_manifest(raci_config)
+
+        # Set up paused debate with R + A turns already done
+        thread_id = "2026-02-14-resume-i-fail-test"
+        debate_init(
+            thread_id=thread_id,
+            topic="Resume I-fail test",
+            mode="raci",
+            state_dir=temp_state_dir,
+        )
+
+        room = load_debate_state(thread_id, temp_state_dir)
+        room.turn_manifest = manifest
+        room.max_turns = len(manifest.specs)
+
+        # Add R and A turns
+        r_turn = Turn(
+            role="dev",
+            content="PROPOSAL: Deploy now.",
+            timestamp=datetime.now(UTC),
+            previous_hash=None,
+        )
+        room.turns.append(r_turn)
+        a_turn = Turn(
+            role="lead",
+            content="VERDICT: GO.",
+            timestamp=datetime.now(UTC),
+            previous_hash=r_turn.hash,
+        )
+        room.turns.append(a_turn)
+        room.status = DebateStatus.PAUSED
+        save_debate_state(room, temp_state_dir)
+
+        # Mock provider that fails for I-turn
+        mock_provider = AsyncMock()
+        mock_provider.complete.side_effect = RuntimeError("Provider down")
+
+        orchestrator = DebateOrchestrator(
+            raci_tier_config,
+            temp_state_dir,
+            provider_factory=create_mock_provider_factory(mock_provider),
+        )
+
+        result = await orchestrator.resume(thread_id)
+
+        # Debate should still close successfully
+        assert result.status == "synthesis"
+        assert "VERDICT" in result.synthesis or "GO" in result.synthesis
+
+        # Sentinel turn should be recorded
+        room = load_debate_state(thread_id, temp_state_dir)
+        sentinel_turns = [t for t in room.turns if "[OBSERVATION FAILED]" in t.content]
+        assert len(sentinel_turns) == 1
+        assert "ops" in sentinel_turns[0].content


### PR DESCRIPTION
## Summary
- **W1: Disjointness validation** — Adds five validation rules (V1-V5) to `RACIConfig` ensuring all RACI role names are unique across designations. Case-insensitive comparison prevents bypass via `"Dev"` vs `"dev"`. Existing R!=A check also made case-insensitive.
- **W2: Graceful I-turn failure** — Wraps Informed agent OBSERVATION turns in try/except so a failed I-agent records a sentinel entry (`[OBSERVATION FAILED]...`) and the debate closes normally with the verdict. R/C/A turns still fail-fast. Hash chain remains gapless via sentinel recording.

Both items were identified during CRS review of PR #162 and designed via RACI debates with GO verdicts from critical-engineer.

### W1 Validation Rules (all ERROR severity)
| Rule | Description |
|------|-------------|
| V1 | No duplicate informed entries |
| V2 | No duplicate consulted entries |
| V3 | Informed disjoint from Responsible |
| V4 | Informed disjoint from Accountable |
| V5 | Informed disjoint from Consulted |

### W2 Failure Behavior
- Individual I-turn failure → `logger.warning` + sentinel in transcript
- All I-turns fail → `logger.error` + debate still closes with verdict
- R/C/A failure → unchanged (PAUSED state, fail-fast)

### Files Changed (4 files, +684/-30)
- `raci.py` — Disjointness validation V1-V5, case-insensitive R!=A
- `orchestrator.py` — try/except for I-turns in `run_raci()` and `_resume_raci()`
- `test_raci.py` — 13 new disjointness tests
- `test_raci_orchestrator.py` — 6 new I-turn failure degradation tests

## Test plan
- [x] All 1239 tests passing (19 new: 13 W1 + 6 W2)
- [x] mypy --strict clean
- [x] ruff + black clean
- [x] W1: `RACIConfig(responsible="dev", accountable="lead", informed=["dev"])` raises ValueError
- [x] W1: `RACIConfig(responsible="Dev", accountable="dev")` raises ValueError (case-insensitive)
- [x] W2: Failed I-turn records sentinel, debate closes with verdict as synthesis
- [x] W2: R/C/A turn failure still causes PAUSED state (unchanged)
- [x] Live tested both scenarios via RACI debates with Informed agent OBSERVATION turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)