### PR TITLE
docs: update stale RACI informed role descriptions

### DIFF
--- a/src/debate_hall_mcp/server.py
+++ b/src/debate_hall_mcp/server.py
@@ -332,7 +332,7 @@ def create_server() -> FastMCP:
                 - responsible: Proposer role name (required)
                 - accountable: Decision maker role name (required)
                 - consulted: List of advisor role names (optional, max 5)
-                - informed: List of notified role names (optional, no turns)
+                - informed: List of observer role names (optional, max 3, post-verdict OBSERVATION turns)
 
         Returns:
             Dictionary with thread_id, topic, status, turn_count, and synthesis

--- a/src/debate_hall_mcp/tools/orchestrate.py
+++ b/src/debate_hall_mcp/tools/orchestrate.py
@@ -308,7 +308,7 @@ async def run_debate(
             - responsible: Role name for Responsible agent (required)
             - accountable: Role name for Accountable agent (required)
             - consulted: List of Consulted role names (optional, max 5)
-            - informed: List of Informed role names (optional, no turns)
+            - informed: List of Informed role names (optional, max 3, post-verdict OBSERVATION turns)
 
     Returns:
         Dictionary with debate result:


### PR DESCRIPTION
## Summary
- Updates `run_debate` tool docstrings in `server.py` and `orchestrate.py` that still said informed agents get "no turns"
- Now correctly reflects: `informed: List of observer/Informed role names (optional, max 3, post-verdict OBSERVATION turns)`

### Files Changed (2 files, 2 lines each)
- `src/debate_hall_mcp/server.py` — MCP tool registration docstring
- `src/debate_hall_mcp/tools/orchestrate.py` — `run_debate_impl` docstring

## Test plan
- [x] All 1239 tests passing (no logic changes, docstring only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)