### PR TITLE
chore: update octave-mcp to v1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "fasteners>=0.19",  # Read/write file locking for concurrency (Issue #106)
     "httpx>=0.27.0",  # GitHub API client (Issue #15)
     "python-dotenv>=1.0.0",  # Load .env files for configuration
-    "octave-mcp>=1.0.0",  # v1.0.0: document sealing, parse_with_warnings, repair tiers
+    "octave-mcp>=1.2.0",  # v1.2.0: Specification Refinement
     "python-ulid>=3.0.0",  # ULID for event ordering (ADR-0002)
     "PyYAML>=6.0",  # Tier configuration loading (ADR-0002)
 ]


### PR DESCRIPTION
## Summary
- Update octave-mcp dependency from >=1.0.0 to >=1.2.0
- Get latest specification refinements and improvements from the v1.2.0 release

## Test plan
- [x] Unit tests pass successfully
- [x] Package installs correctly with updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)