### PR TITLE
RFC-0001: Add path_contract schema and constraint-as-catalyst prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 debates/*.json
 debates/*.jsonl
 debates/*.lock
+debates/**/*.json
+debates/**/*.jsonl
+debates/**/*.lock
+debates/**/*.events.jsonl
 *.jsonl
 
 # Python

--- a/debates/2026-02-22-mythology-in-octave-assessment.oct.md
+++ b/debates/2026-02-22-mythology-in-octave-assessment.oct.md
@@ -1,0 +1,24 @@
+===COMPILED_DECISION===
+META:
+  TYPE::COMPILED_DECISION
+  VERSION::"1.0"
+  THREAD_ID::"2026-02-22-mythology-in-octave-assessment"
+  TOPIC::"How should OCTAVE lean into mythological vocabulary? Permission vs formalization — the Mythological Compression Principle"
+  DECIDED_AT::"2026-02-22T16:27:32.637092+00:00"
+OUTCOME:
+  SYNTHESIS::"1. Wind proposed mythology as a native compression layer with a 10-tradition guide and examples per tradition. 2. Wall constrained this: the spec defines grammar not vocabulary; a formal guide is a pattern library in disguise; the paradox itself proves teaching is redundant. 3. Door synthesized: the Mythological Compression Principle — mythology is OCTAVE's native compression dialect, not its grammar. Permission, not formalization. 4. Deliverable: one documentation section naming 10 traditions as a spectrum with 3-5 total examples. No spec changes, no pattern library, no formal mappings. 5. Issue #110 closed with this decision: mythological pattern library rejected as formal construct; Mythological Compression Principle adopted as documentation philosophy."
+  DECISION_HASH::"08dd6841727ebcf7366a80b5e358715c265b22292bbf69a996c4e95a87999c91"
+  STATUS::synthesis
+RATIONALE:
+  WIND_PERSPECTIVES::["MYTHOLOGY_AS_NATIVE_COMPRESSION_LAYER — LLMs ALREADY speak mythology fluently. The paradigm blindness paradox means we don't need to TEACH, we need to PERMIT. Proposed 10-tradition guide with examples: Greek (highest saturation), Norse (RAGNAROK::SYSTEM_COLLAPSE), Hindu (KARMA::FEEDBACK_LOOP), Egyptian (ANUBIS::JUDGEMENT_GATE), Japanese (KINTSUGI::BEAUTIFUL_REPAIR). Zero implementation cost, infinite compression surface, self-documenting, cross-model portable."]
+  WALL_CONSTRAINTS::["VERDICT: Mythology belongs in spirit, not specification. Wind's 10-tradition guide is a pattern library in disguise. EVIDENCE: (E1) Spec defines grammar not vocabulary. (E2) Single developer — more surface = more debt. (E3) If LLMs already understand zero-shot, formal guide is redundant. (E4) Mythology-heavy guide signals niche tool. (E5) Cultural sensitivity concern with reductive mappings. CONSTRAINT: At most ONE paragraph of encouragement, not a catalogue."]
+  DOOR_REFINEMENTS::["The Mythological Compression Principle — Neither Library Nor Silence. The resolution: if paradigm blindness is real (JOURNEY::ODYSSEAN works zero-shot), then teaching is redundant and permission is sufficient. Deliverable: one section naming 10 traditions as SPECTRUM (not dictionary), 3-5 total examples, ending with 'Use mythology freely. Models already understand.' Wind gets mythology elevated; Wall gets no spec changes. The deeper insight: mythology works because the semantic payload is already pre-loaded in every LLM's weights."]
+VALIDATION:
+  CONSENSUS_REACHED::false
+  VOTES::[wind::null,wall::null]
+  REFINEMENT_COUNT::0
+  TURN_COUNT::3
+PROVENANCE:
+  EXTRACTED_AT::"2026-02-23T04:26:23.734155+00:00"
+  SOURCE_HASH::"0b2f440418b499c2e16ffc975730d7ddd66b357d0c6b20d8e8ff7b6331656b7b"
+===END===

--- a/debates/2026-04-28-decision-governance-synthesis.oct.md
+++ b/debates/2026-04-28-decision-governance-synthesis.oct.md
@@ -177,7 +177,7 @@ META:
   ]
   SCHEMA_NOTE::ratified_per_HO_DECISION_GOVERNANCE_GRAVITY_TIERED_20260428_extends_HestAI_MCP_ADR_0060
 §9::REFERENCES
-  ADR_0060::"/Volumes/HestAI-MCP/docs/adr/adr-0060-rfc-adr-alignment.md"
+  ADR_0060::"HestAI-MCP/docs/adr/adr-0060-rfc-adr-alignment.md"
   VISIBILITY_RULES_V2_3::".hestai-sys/standards/rules/visibility-rules.oct.md"
   DEBATE_THREAD::"2026-04-28-decision-record-governance-for-01kqa2vb"
   ISSUE::"https://github.com/elevanaltd/elevana-studio/issues/633"

--- a/debates/2026-04-28-decision-governance-synthesis.oct.md
+++ b/debates/2026-04-28-decision-governance-synthesis.oct.md
@@ -1,0 +1,186 @@
+===DECISION_GOVERNANCE_GRAVITY_TIERED_SYNTHESIS===
+META:
+  TYPE::DEBATE_SYNTHESIS
+  VERSION::"1.0"
+  STATUS::ADOPTED
+  CANONICAL::"debates/2026-04-28-decision-governance-synthesis.oct.md"
+  SOURCE::"debate-hall thread 2026-04-28-decision-record-governance-for-01kqa2vb (synthesised by HO)"
+  DATE::"2026-04-28"
+  AUDIENCE::cognitive_evidence
+  COMPRESSION_TIER::CONSERVATIVE
+  LOSS_PROFILE::[
+    preserve::causal_chains⊕heuristic_steps⊕test_cases⊕migration_phases,
+    drop::verbose_phrasing⊕conversational_framing
+  ]
+  PROVENANCE::[
+    "debate-hall thread 2026-04-28-decision-record-governance-for-01kqa2vb",
+    "Issue #633",
+    "HO synthesis 2026-04-28"
+  ]
+§1::QUESTION_DEBATED
+  PROMPT::"Should every ratified decision in elevana-studio originate from a GitHub Issue per HestAI-MCP ADR-0060 (ADR↔Issue alignment, every ADR must have a linked Issue, numbers match), or do we need a tiered model that distinguishes heavyweight architectural decisions from lightweight documented choices?"
+  STANDARD_REFERENCED::HestAI_MCP_ADR_0060_RFC_ADR_alignment
+§2::SYNTHESIZED_MODEL
+  NAME::GRAVITY_TIERED_OCTAVE_MONOLITH
+  KEY_INSIGHT::"Decouple Governance Principle (deliberation via Issue) from Storage Medium (Markdown files). ADR-0060 mandates Issue+ADR linkage for architectural decisions. It does NOT mandate Markdown-file-per-decision storage."
+  IMPLICATION::"Strict ADR-0060 compliance can be satisfied while keeping the OCTAVE monolith — an ADR becomes a TIER::ARCHITECTURAL node with ISSUE_REF::#NNN inside DECISIONS.oct.md, same provenance, different storage."
+  §2a::THREE_TIERS
+    TIER_ARCHITECTURAL:
+      TRIGGER::crosses_boundaries∨irreversible∨security_invariant
+      TREATMENT::Issue_plus_OCTAVE_node_with_ISSUE_REF_field
+      ADR_0060::strict_compliance
+    TIER_CONVENTION:
+      TRIGGER::documented_choice_no_boundary_crossing
+      TREATMENT::inline_OCTAVE_node_no_Issue
+      ADR_0060::exempt
+    TIER_MICRO:
+      TRIGGER::mechanizable_via_linter∨CI∨DB_schema
+      TREATMENT::encode_in_tooling_delete_doc_entirely
+      ADR_0060::not_applicable
+  §2b::CLASSIFICATION_HEURISTIC
+    BUDGET::under_30_seconds
+    STEP_1_MECHANIZATION_TEST:
+      QUESTION::"Can CI / linter / DB schema enforce this?"
+      YES_PATH::TIER_MICRO_encode_delete_doc
+      NO_PATH::continue_to_gravity_test
+    STEP_2_GRAVITY_TEST:
+      SCORING::one_point_each
+      DIMENSIONS::[
+        irreversible_in_under_one_day_of_solo_work,
+        crosses_module_or_app_or_vendor_boundaries,
+        security_invariant_or_data_ownership_boundary
+      ]
+      SCORE_1_TO_3::TIER_ARCHITECTURAL_Issue_plus_linked_ADR_node
+      SCORE_0::TIER_CONVENTION_inline_node_no_Issue
+  §2c::TEST_CASES_VERIFIED
+    CASE_1:
+      NAME::cron_alter_job_not_UPDATE
+      PATH::[Mechanization_no→Gravity_0]
+      RESULT::TIER_CONVENTION_inline
+    CASE_2:
+      NAME::reconciler_orphan_policy
+      PATH::[Mechanization_no→Gravity_2_boundary_plus_security]
+      RESULT::TIER_ARCHITECTURAL_with_AMENDS_parent
+    CASE_3:
+      NAME::client_canonical_model
+      PATH::[Mechanization_no→Gravity_2_boundary_plus_irreversible]
+      RESULT::TIER_ARCHITECTURAL_full_Issue_plus_ADR
+    CASE_4:
+      NAME::kebab_case_file_names
+      PATH::Mechanization_yes_ESLint_or_repo_config
+      RESULT::TIER_MICRO_encode_delete_doc
+    CASE_5:
+      NAME::no_admin_tools_in_portal
+      PATH::[Mechanization_no→Gravity_2_boundary_plus_security]
+      RESULT::TIER_ARCHITECTURAL_Issue
+  §2d::ADR_0060_STANCE
+    VERDICT::JUSTIFIED_EXTENSION_VIA_FORMAT_DECOUPLING
+    MANDATE_HONORED::"every architectural decision links to an Issue with matching number"
+    IMPLEMENTATION_EXTENDED::"the ADR is an OCTAVE node, not a Markdown file"
+    OUT_OF_SCOPE::Conventions_and_Micros_do_not_meet_the_architectural_bar_that_triggers_the_standard
+  §2e::TOKEN_EFFICIENCY_EVIDENCE
+    MONOLITH_FOOTPRINT::"100 OCTAVE nodes ≈ 3500 tokens"
+    DETACHED_FOOTPRINT::"100 detached Markdown files ≈ 80000 tokens of file-traversal overhead"
+    RATIO::twenty_x_efficiency_for_agent_wholesale_load
+    JUSTIFIES::format_decoupling_claim
+§3::MIGRATION_PATH
+  PRINCIPLE::four_phases_zero_filesystem_churn
+  PHASE_1_METADATA_SWEEP:
+    ACTION::agent_parses_existing_DECISIONS_oct_md
+    STEP::applies_classification_heuristic
+    OUTPUT::injects_TIER_field_on_every_entry
+  PHASE_2_ISSUE_BACKFILL:
+    SCOPE::ONLY_for_TIER_ARCHITECTURAL_items_estimate_13
+    ACTION::generate_retroactive_GitHub_Issues_tagged_legacy_migration
+    INJECTION::ISSUE_REF_field_added_to_each_node
+    EXCLUSION::no_Issues_for_estimate_5_conventions_or_estimate_12_retired_entries
+  PHASE_3_FRACTAL_COLLAPSE:
+    ACTION::fold_estimate_15_sub_decisions_into_parent_nodes
+    FORM::nested_arrays_under_parent_token
+  PHASE_4_ARCHIVE_VERIFY:
+    ACTION::confirm_retired_items_in_DECISIONS_ARCHIVE_oct_md
+    TARGET::final_monolith_size_under_3500_tokens
+§4::PRACTICAL_CAVEAT
+  RISK::"TIER::MICRO requires real tooling discipline. If the linter rule is not actually written, the choice becomes undocumented + undetected drift."
+  MITIGATION::TIER_MICRO_requires_commit_reference_to_enforcement_code_linter_rule_or_schema_constraint_or_CI_check_BEFORE_doc_is_deleted
+§5::VISIBILITY_RULES_PLACEMENT
+  STANDARD_REF::".hestai-sys/standards/rules/visibility-rules.oct.md"
+  STANDARD_VERSION::v2.3
+  P30_DEBATE_SYNTHESIS::[
+    location::debates_slash,
+    format::oct_md,
+    lifecycle::COMMITTED,
+    audience::cognitive_evidence
+  ]
+  P31_DEBATE_TRANSCRIPT::[
+    location::debates_slash,
+    format::json,
+    lifecycle::GITIGNORED,
+    layer::working_state
+  ]
+  T6_DEBATES_TIER::[
+    location::debates_slash,
+    lifecycle::oct_md_committed⊕json_gitignored
+  ]
+  CANONICAL_HOME::"debates/2026-04-28-decision-governance-synthesis.oct.md"
+  PRIOR_LOCATION::Tier_3_session_notes_for_immediate_availability_at_hestai_state_sessions
+§6::SELF_APPLICATION
+  CLAIM::"The adoption of this model is itself an architectural decision per its own gravity test."
+  GOVERNANCE_PATTERN_REALIGNMENT:
+    TOKEN::HO-DECISION-GOVERNANCE-GRAVITY-TIERED-20260428
+    TIER::ARCHITECTURAL
+    ISSUE_REF::"#633"
+    STATUS::PROPOSED
+    DECISION::adopt_gravity_tiered_octave_monolith_from_debate_thread_2026_04_28_decision_record_governance_for_01kqa2vb
+    BECAUSE::[
+      twenty_x_token_efficiency_for_agent_load,
+      ADR_0060_compliance_via_ISSUE_REF_in_octave_nodes,
+      eliminates_issue_noise_for_conventions,
+      mechanization_tier_eliminates_documentation_for_enforceable_rules
+    ]
+    EXTENDS::HestAI_MCP_ADR_0060_RFC_ADR_alignment
+    ROUTING::implement_via_document_cleanup_workstream_class_B_phase_1_through_4
+    EVIDENCE::[debate_thread_2026-04-28-decision-record-governance-for-01kqa2vb,"debates/2026-04-28-decision-governance-synthesis.oct.md"]
+§7::HANDOFF_TO_DOCUMENT_CLEANUP_WORKSTREAM
+  COMPANION_TOKEN::HO_HESTAI_CLEANUP_20260428
+  CLEANUP_CLASS_B_TASKS::[
+    R1::author_debates_2026_04_28_decision_governance_synthesis_oct_md_as_proper_OCTAVE,
+    R2::author_HO_DECISION_GOVERNANCE_GRAVITY_TIERED_20260428_token_in_DECISIONS_oct_md_after_ISSUE_REF_populated,
+    R3::update_DECISIONS_oct_md_META_block_to_add_SCHEMA_convention_per_section_8,
+    R4::execute_four_phase_migration_on_existing_estimate_50_entries
+  ]
+§8::SCHEMA_HEADER_CONVENTION
+  TARGET::DECISIONS_oct_md_META_block
+  SCHEMA_REQUIRED::[
+    TOKEN,
+    TIER,
+    STATUS,
+    DECISION,
+    BECAUSE
+  ]
+  TIER_DEFINITIONS::[
+    ARCHITECTURAL::issue_required_plus_ISSUE_REF_field,
+    CONVENTION::no_issue_inline_only,
+    MICRO::no_doc_encode_in_tooling_with_ENFORCEMENT_REF_to_linter_or_ci_or_schema
+  ]
+  SCHEMA_REQUIRED_BY_TIER::[
+    ARCHITECTURAL_REQUIRES::[ISSUE_REF,EXTENDS_or_AMENDS_or_SUPERSEDES_when_applicable],
+    CONVENTION_REQUIRES::[],
+    MICRO_REQUIRES::[ENFORCEMENT_REF_pointing_to_commit_or_file_implementing_mechanism]
+  ]
+  SCHEMA_OPTIONAL::[
+    EVIDENCE,
+    IMPLEMENTATION_HANDOFF,
+    CONSTRAINTS,
+    AMENDMENTS,
+    domain_specific
+  ]
+  SCHEMA_NOTE::ratified_per_HO_DECISION_GOVERNANCE_GRAVITY_TIERED_20260428_extends_HestAI_MCP_ADR_0060
+§9::REFERENCES
+  ADR_0060::"/Volumes/HestAI-MCP/docs/adr/adr-0060-rfc-adr-alignment.md"
+  VISIBILITY_RULES_V2_3::".hestai-sys/standards/rules/visibility-rules.oct.md"
+  DEBATE_THREAD::"2026-04-28-decision-record-governance-for-01kqa2vb"
+  ISSUE::"https://github.com/elevanaltd/elevana-studio/issues/633"
+  COMPANION_DECISION_TOKEN::HO-DECISION-GOVERNANCE-GRAVITY-TIERED-20260428
+  COMPANION_VISIBILITY_TOKEN::HO-VISIBILITY-RULES-CANONICAL-SUPERSEDE-ADR0003-20260428
+===END===

--- a/docs/rfc-0001-path-contract-wind-learning-loop.md
+++ b/docs/rfc-0001-path-contract-wind-learning-loop.md
@@ -48,7 +48,7 @@ The user wants the loop to demonstrate **constraint-as-catalyst**: ideas that ar
 
 ## 3. Proposed design (one-line summary)
 
-Add a single typed field, **`path_contract`**, attached to each Wind path. It is **mutated, not replaced** by each role as the path traverses Wind → Wall → (consensus-Wind) → Door. No new turn types, no new orchestrator phases.
+Add a single typed field, **`path_contract`**, attached to each Wind path. It is **append-only** — each role appends to its own field's revision history; no role may overwrite another's prior writes. No new turn types, no new orchestrator phases.
 
 ### 3.1 Schema
 
@@ -65,33 +65,69 @@ class PathFrame(TypedDict):
     assumed_problem: str
     success_criterion: str
     accepted_failure_mode: str
-    hard_invariants_touched: list[HardInvariant]
+    hard_invariants_touched: list[HardInvariant]   # closed enum only — no free-text invariant IDs
 
 class InvariantVerdict(TypedDict):
     status: Literal["HARD_pass", "HARD_fail", "SOFT_disputed"]
     rationale: str
 
 class PathDiff(TypedDict):
-    accepted: list[str]      # invariant keys Wind now accepts
-    disputed: list[str]      # SOFT keys Wind still pushes back on, with rationale
-    reframed: list[str]      # invariant keys whose reframing opens a new possibility
+    accepted: list[InvariantEntry]   # invariant keys Wind accepts (with terminal_rationale if HARD_fail)
+    disputed: list[InvariantEntry]   # SOFT keys Wind still pushes back on, with rationale
+    reframed: list[InvariantEntry]   # invariant keys whose reframing opens a new possibility
+
+class InvariantEntry(TypedDict):
+    invariant: HardInvariant
+    rationale: str
+
+# Append-only revision wrappers — written exactly once each, by the owning role
+class FrameRevision(TypedDict):
+    rev: int                                # 0, 1, 2 …
+    written_at: datetime
+    written_by: Literal["Wind"]             # only Wind may append
+    value: PathFrame
+
+class VerdictRevision(TypedDict):
+    rev: int
+    written_at: datetime
+    written_by: Literal["Wall"]             # only Wall may append
+    value: dict[HardInvariant, InvariantVerdict]
+
+class DiffRevision(TypedDict):
+    rev: int
+    written_at: datetime
+    written_by: Literal["Wind"]             # consensus-phase Wind
+    value: PathDiff
 
 class PathContract(TypedDict):
     path_id: str
-    frame: PathFrame                          # written by Wind (turn 1)
-    verdict: dict[str, InvariantVerdict]      # written by Wall (turn 2), keyed by invariant
-    diff: PathDiff | None                     # written by Wind in consensus phase
+    frame_history: list[FrameRevision]      # rev 0 written turn 1; further revs only on Wind reframe
+    verdict_history: list[VerdictRevision]  # one rev per Wall turn (initial + each consensus reject)
+    diff_history: list[DiffRevision]        # one rev per Wind consensus turn
 ```
+
+**Storage model**: append-only, immutable per revision. Provenance is reconstructible by reading `_history` lists in order.
+
+**Prompt-context view**: each role sees the *latest* revision per field plus the revision count (so an agent knows "this is Wall's 2nd verdict, after Wind's reframe"). Revision history details are stored but not blasted into every prompt — keeps tokens bounded.
+
+**Ownership rule** (validator-enforced):
+- Only Wind may append to `frame_history` or `diff_history`.
+- Only Wall may append to `verdict_history`.
+- Door reads only — never writes contract fields.
+- A write from a non-owning role is recorded as a validator-failure event and rejected.
 
 ### 3.2 Lifecycle
 
 | Stage | Role | Field written | Notes |
 |---|---|---|---|
-| 1 | Wind | `frame` per path | Includes `hard_invariants_touched` from a closed enum (safer; see §8 Q1) |
-| 2 | Wall | `verdict[invariant]` | Per path, every invariant Wind flagged is scored HARD_pass / HARD_fail / SOFT_disputed |
-| 3 | Door | (reads only) | Initial synthesis; can be skipped for A/B variant where Wind always re-engages |
-| 4+ | Wind (consensus) | `diff` | Must reference Wall's verdict entries by invariant key. **Empty `diff` is invalid** when any HARD_fail exists. |
-| 4+ | Door (refinement) | (reads full contract history) | Synthesis must cite ≥1 `accepted`, ≥1 `disputed`, ≥1 `reframed` entry across paths |
+| 1 | Wind | `frame_history.append(rev=0, …)` per path | Includes `hard_invariants_touched` from a closed enum |
+| 2 | Wall | `verdict_history.append(rev=0, …)` | Every invariant Wind flagged is scored HARD_pass / HARD_fail / SOFT_disputed |
+| 3 | Door | (reads only) | Initial synthesis |
+| 4+ | Wind (consensus) | `diff_history.append(rev=N, …)` | Must reference Wall's verdict entries by invariant key. **Required content rule** below. |
+| 4+ | Wall (re-approval after Door refines) | `verdict_history.append(rev=N+1, …)` | Wall re-validates against the refined synthesis; previous verdict revisions remain visible for provenance |
+| 4+ | Door (refinement) | (reads full contract history) | Synthesis citation rule per §5.4 |
+
+**Required content rule for `diff` revisions**: for every entry in the latest `verdict` revision with `status == HARD_fail`, the corresponding invariant must appear in `diff.accepted` (with a `terminal_rationale` explaining why no creative reframe is possible) **or** in `diff.reframed` (with the new possibility it opens). Silent omission is invalid.
 
 The state machine arc is unchanged; only the payload schema thickens.
 
@@ -151,16 +187,19 @@ With:
 
 Add:
 
-> Your synthesis must cite **at least one** `accepted` entry, **at least one** `disputed` entry, and **at least one** `reframed` entry across the paths' contracts. This forces genuine integration — averaging or compromise will fail validation.
+> Your synthesis must cite **every non-empty category** (`accepted` / `disputed` / `reframed`) across the paths' contracts. If a category is empty for all paths, do not invent entries — instead, briefly note its absence (e.g. "no constraints disputed; Wind accepted Wall's verdict in full").
+>
+> Additional rule: when any path has a `HARD_fail` verdict in Wall's output, your synthesis must cite, for that path, **either** a `reframed` entry that addresses the failure **or** an `accepted` entry whose `terminal_rationale` explains why the failure is unreframeable. Silent omission is invalid — this is the constraint-as-catalyst proof.
 
 ---
 
 ## 6. Orchestrator changes
 
-Minimal. Only two:
+Three:
 
-1. **`PathContract` is part of the debate state**, persisted alongside transcripts. The `<DEBATE_STATE>` block in prompts includes a `<PATH_CONTRACTS>` sub-block with the contracts to date.
-2. **Validation guard** in `_execute_consensus_loop` (`orchestrator.py:482-560`): when Wind votes (line 485), assert that for every path with `verdict` entries containing `HARD_fail`, the corresponding `diff` is non-empty. If empty → reject the Wind output and retry once before treating it as a malformed turn (existing error path).
+1. **`PathContract` is part of the debate state**, persisted alongside transcripts. The `<DEBATE_STATE>` block in prompts includes a `<PATH_CONTRACTS>` sub-block with the **latest revision** per field plus revision counts (full history available in storage but not pushed into prompts on every turn).
+2. **Validation guard** in `_execute_consensus_loop` (`orchestrator.py:482-560`): when Wind votes (line 485), enforce the **required content rule** from §3.2 — every `HARD_fail` invariant must appear in either `diff.accepted` (with `terminal_rationale`) or `diff.reframed`. Violations → reject and retry once, then existing error path. Symmetrically, when Door's synthesis is produced, validate that every cited entry exists in the contract (no fabricated citations).
+3. **Validator failures recorded as events** via the existing `events.py` system. Failure types: empty/insufficient `diff` when HARD_fail exists, write from non-owning role (ownership rule §3.1), Door citation of non-existent contract entry, schema-shape violations. This makes the A/B "invalid contract rate" metric directly measurable.
 
 The consensus loop itself, `max_refinement_loops`, and the Wall re-approval invariant at line 507 are unchanged.
 
@@ -188,15 +227,31 @@ Quantitative:
 - **Stalemate rate** over the corpus.
 - **Token cost** per debate (treatment will be higher; we want to know by how much).
 - **Wall reject rate** in consensus phase (treatment should fall — better-grounded ideas pass faster).
+- **Invalid contract rate** — % of treatment debates that fire any validator-failure event (empty diff under HARD_fail, ownership violation, citation of non-existent entry). High rate → prompt design is failing; build is regressed.
+- **Door citation accuracy** — % of Door-cited contract entries that actually exist. Treatment must be ≥99%; lower implies Door is hallucinating provenance.
 
 Qualitative (blind review by the user, ideally double-blind):
 - **Synthesis novelty** — does Door's output contain ideas not present verbatim in Wind's initial paths? (Treatment should win.)
 - **Constraint-as-catalyst evidence** — count of Door synthesis claims that cite a `reframed` path_contract entry.
 - **Provenance auditability** — can a reader trace each Door claim to a role contribution?
+- **Bogus reframing rate** — blind reviewer flags `reframed` entries that are not substantively novel vs. their corresponding `accepted` entries. Watches for Wind producing fake structure to satisfy the prompt.
+- **Wind originality preservation** — fraction of Wind's turn-1 *Heretical* path elements that survive into Door's final synthesis, control vs treatment. If treatment shows *lower* preservation, Wind is conforming to Wall's pressure rather than pushing further — exactly the failure mode Free-MAD warns about. This is the regression check.
 
 ### 7.4 Decision rule
 
-Ship treatment if: (a) qualitative novelty wins ≥60% of blind comparisons, (b) stalemate rate doesn't increase, (c) token cost increase <40%. Otherwise iterate or revert.
+**Hard gates** (must all pass before A/B is considered valid):
+- **Flag-off byte-identical**: with `path_contract_enabled = False`, treatment build produces byte-identical transcripts to control on the same seed/topic. Failure → block A/B and fix the off-mode regression.
+- **Door citation accuracy ≥99%** on treatment. Failure → reject; prompt or validator is broken.
+- **Invalid contract rate <5%** on treatment. Failure → reject; prompt design needs iteration before re-running A/B.
+
+**Ship rule** (after gates pass):
+- Qualitative novelty wins ≥60% of blind comparisons, AND
+- Stalemate rate does not increase, AND
+- Wind originality preservation does not decrease (no conformity regression), AND
+- Bogus reframing rate ≤10% per blind review, AND
+- Token cost increase <40%.
+
+Otherwise iterate prompts or revert.
 
 ---
 
@@ -240,23 +295,37 @@ References:
 
 ## 11. Implementation plan (if accepted)
 
+### 11.1 Pre-build gate (must pass before any code)
+
 | # | Task | Issue |
 |---|---|---|
-| 1 | Schema + types (`PathContract`, `PathFrame`, `InvariantVerdict`, `PathDiff`, `HardInvariant`) — default-empty so existing flows degrade gracefully | [#196](https://github.com/elevanaltd/debate-hall-mcp/issues/196) |
-| 2 | State serialization — extend `state.py` to persist contracts alongside transcripts | [#197](https://github.com/elevanaltd/debate-hall-mcp/issues/197) |
-| 3 | Prompt updates — four templates in `prompts/__init__.py` (Wind initial, Wall, Wind consensus, Door) | [#198](https://github.com/elevanaltd/debate-hall-mcp/issues/198) |
-| 4 | Context compiler — inject `<PATH_CONTRACTS>` sub-block into `<DEBATE_STATE>` | [#199](https://github.com/elevanaltd/debate-hall-mcp/issues/199) |
-| 5 | Orchestrator guard — validation in `_execute_consensus_loop` for non-empty `diff` when HARD_fail exists | [#200](https://github.com/elevanaltd/debate-hall-mcp/issues/200) |
-| 6 | Feature flag `tier_config.settings.path_contract_enabled` (default off; A/B treatment sets on) | [#201](https://github.com/elevanaltd/debate-hall-mcp/issues/201) |
-| 7 | Tests — golden files; flag-off byte-identity; HARD_fail forces non-empty diff; Door cites all three diff categories | [#202](https://github.com/elevanaltd/debate-hall-mcp/issues/202) |
-| 8 | A/B harness — script + operator guide for the two-machine comparison | [#203](https://github.com/elevanaltd/debate-hall-mcp/issues/203) |
+| 0 | **No-code prompt simulation** — pick 5 historical debates from `debates/`. Manually inject the proposed `<PATH_CONTRACTS>` block and the new prompt text (§5) into a fresh debate run, no orchestrator changes. Read whether Wind's `diff` substantively engages Wall's verdict or just restates the originals. **Gate**: if 4/5 produce restatement, the prompt design is wrong — iterate prompts and re-run before opening any other sub-issue. | [#204](https://github.com/elevanaltd/debate-hall-mcp/issues/204) |
+
+### 11.2 Build sub-issues
+
+| # | Task | Issue |
+|---|---|---|
+| 1 | Schema + types — append-only revision history per field; closed enum for invariant IDs; ownership rules (Wind→frame/diff, Wall→verdict, Door read-only) | [#196](https://github.com/elevanaltd/debate-hall-mcp/issues/196) |
+| 2 | State serialization — extend `state.py` to persist `PathContract` history; backward-compatible read of pre-RFC state | [#197](https://github.com/elevanaltd/debate-hall-mcp/issues/197) |
+| 3 | Prompt updates — four templates in `prompts/__init__.py`; Door's citation rule is **conditional** per §5.4 (cite every non-empty category; require reframed-or-terminal-accepted only when HARD_fail exists) | [#198](https://github.com/elevanaltd/debate-hall-mcp/issues/198) |
+| 4 | Context compiler — inject `<PATH_CONTRACTS>` showing latest revision per field plus revision counts | [#199](https://github.com/elevanaltd/debate-hall-mcp/issues/199) |
+| 5 | Orchestrator guards — required-content rule for `diff` (§3.2); Door citation existence check; ownership-violation check; emit validator-failure events | [#200](https://github.com/elevanaltd/debate-hall-mcp/issues/200) |
+| 6 | Feature flag `tier_config.settings.path_contract_enabled` (default OFF; A/B treatment sets ON). **Rollout sequence**: flag-off in main → A/B run → review metrics → decision. No "broad ship" stage exists by design. | [#201](https://github.com/elevanaltd/debate-hall-mcp/issues/201) |
+| 7 | Tests — golden files; **flag-off byte-identical to control** (hard gate); required-content rule enforced; ownership rule enforced; Door citation existence enforced; round-trip serialization | [#202](https://github.com/elevanaltd/debate-hall-mcp/issues/202) |
+| 8 | A/B harness — script + operator guide for two-machine comparison; captures all metrics from §7.3 (incl. invalid contract rate, citation accuracy, originality preservation, bogus reframing) | [#203](https://github.com/elevanaltd/debate-hall-mcp/issues/203) |
 
 Parent tracker: [#195](https://github.com/elevanaltd/debate-hall-mcp/issues/195).
 
-Estimated scope: ~400–600 lines of code + tests, plus prompt edits. ~1–2 days of focused work.
+Estimated scope: ~500–700 lines of code + tests, plus prompt edits and the simulation. ~2 days of focused work, with the pre-build simulation potentially adding a prompt-iteration loop before code starts.
 
 ---
 
 ## 12. Decision
 
-Pending user review.
+Pending user review. Review feedback (2026-05-02) incorporated:
+- Schema is now explicitly **append-only** with per-field revision history and ownership rules (§3.1).
+- Door's citation rule is now **conditional** (cite non-empty categories; require reframe-or-terminal only when HARD_fail exists) — avoiding forced novelty (§5.4).
+- Validator failures are recorded as events for measurement (§6).
+- A/B metrics expanded with invalid-contract rate, citation accuracy, bogus-reframing rate, and Wind-originality-preservation regression check (§7.3).
+- Flag-off byte-identity, citation accuracy, and invalid-contract rate are **hard gates** before A/B is considered valid (§7.4).
+- A pre-build no-code simulation gates the build (§11.1).

--- a/docs/rfc-0001-path-contract-wind-learning-loop.md
+++ b/docs/rfc-0001-path-contract-wind-learning-loop.md
@@ -3,6 +3,7 @@
 **Status**: Proposed (awaiting decision)
 **Date**: 2026-05-02
 **Branch**: `claude/review-debate-agent-flow-DzSFX`
+**Tracking**: [#195](https://github.com/elevanaltd/debate-hall-mcp/issues/195) (parent) — sub-issues [#196](https://github.com/elevanaltd/debate-hall-mcp/issues/196)–[#203](https://github.com/elevanaltd/debate-hall-mcp/issues/203)
 **Author**: Generated via meta-debate (Wind→Wall→Wind-Revise→Door) on the question itself
 
 ---
@@ -239,14 +240,18 @@ References:
 
 ## 11. Implementation plan (if accepted)
 
-1. **Schema + types** (`src/debate_hall_mcp/orchestrator.py` or new `types.py`): `PathContract`, `PathFrame`, `InvariantVerdict`, `PathDiff`, `HardInvariant`. Default-empty so existing flows degrade gracefully.
-2. **State serialization**: extend `state.py` to persist contracts alongside transcripts.
-3. **Prompt updates**: four prompt templates in `src/debate_hall_mcp/prompts/__init__.py` (Wind initial, Wall, Wind consensus, Door).
-4. **Context compiler** (`context_compiler.py`): inject `<PATH_CONTRACTS>` sub-block into the `<DEBATE_STATE>` envelope.
-5. **Orchestrator guard**: validation in `_execute_consensus_loop` for non-empty `diff` when HARD_fail exists.
-6. **Feature flag**: `tier_config.settings.path_contract_enabled` (default off in v1, on in A/B treatment build).
-7. **Tests**: golden-file tests for (a) Wall HARD_fail forces non-empty diff, (b) Door synthesis cites all three diff categories, (c) feature-flag-off path is byte-identical to current behaviour.
-8. **A/B harness**: a small script or doc explaining how to run identical topics on two machines and collect transcripts for blind review.
+| # | Task | Issue |
+|---|---|---|
+| 1 | Schema + types (`PathContract`, `PathFrame`, `InvariantVerdict`, `PathDiff`, `HardInvariant`) — default-empty so existing flows degrade gracefully | [#196](https://github.com/elevanaltd/debate-hall-mcp/issues/196) |
+| 2 | State serialization — extend `state.py` to persist contracts alongside transcripts | [#197](https://github.com/elevanaltd/debate-hall-mcp/issues/197) |
+| 3 | Prompt updates — four templates in `prompts/__init__.py` (Wind initial, Wall, Wind consensus, Door) | [#198](https://github.com/elevanaltd/debate-hall-mcp/issues/198) |
+| 4 | Context compiler — inject `<PATH_CONTRACTS>` sub-block into `<DEBATE_STATE>` | [#199](https://github.com/elevanaltd/debate-hall-mcp/issues/199) |
+| 5 | Orchestrator guard — validation in `_execute_consensus_loop` for non-empty `diff` when HARD_fail exists | [#200](https://github.com/elevanaltd/debate-hall-mcp/issues/200) |
+| 6 | Feature flag `tier_config.settings.path_contract_enabled` (default off; A/B treatment sets on) | [#201](https://github.com/elevanaltd/debate-hall-mcp/issues/201) |
+| 7 | Tests — golden files; flag-off byte-identity; HARD_fail forces non-empty diff; Door cites all three diff categories | [#202](https://github.com/elevanaltd/debate-hall-mcp/issues/202) |
+| 8 | A/B harness — script + operator guide for the two-machine comparison | [#203](https://github.com/elevanaltd/debate-hall-mcp/issues/203) |
+
+Parent tracker: [#195](https://github.com/elevanaltd/debate-hall-mcp/issues/195).
 
 Estimated scope: ~400–600 lines of code + tests, plus prompt edits. ~1–2 days of focused work.
 

--- a/docs/rfc-0001-path-contract-wind-learning-loop.md
+++ b/docs/rfc-0001-path-contract-wind-learning-loop.md
@@ -195,11 +195,12 @@ Add:
 
 ## 6. Orchestrator changes
 
-Three:
+Four:
 
 1. **`PathContract` is part of the debate state**, persisted alongside transcripts. The `<DEBATE_STATE>` block in prompts includes a `<PATH_CONTRACTS>` sub-block with the **latest revision** per field plus revision counts (full history available in storage but not pushed into prompts on every turn).
 2. **Validation guard** in `_execute_consensus_loop` (`orchestrator.py:482-560`): when Wind votes (line 485), enforce the **required content rule** from §3.2 — every `HARD_fail` invariant must appear in either `diff.accepted` (with `terminal_rationale`) or `diff.reframed`. Violations → reject and retry once, then existing error path. Symmetrically, when Door's synthesis is produced, validate that every cited entry exists in the contract (no fabricated citations).
-3. **Validator failures recorded as events** via the existing `events.py` system. Failure types: empty/insufficient `diff` when HARD_fail exists, write from non-owning role (ownership rule §3.1), Door citation of non-existent contract entry, schema-shape violations. This makes the A/B "invalid contract rate" metric directly measurable.
+3. **Validator failures recorded as events** via the existing `events.py` system — extend `EventType` (`events.py:41`) with a new `VALIDATOR_FAILURE = "validator_failure"` value. Failure types: empty/insufficient `diff` when HARD_fail exists, write from non-owning role (ownership rule §3.1), Door citation of non-existent contract entry, schema-shape violations. This makes the A/B "invalid contract rate" metric directly measurable.
+4. **`features.is_enabled()` wrapper module** (`src/debate_hall_mcp/features.py`, new). All flag checks for path_contract behaviour go through `features.is_enabled("path_contract", context)`. Today the wrapper delegates to `TierSettings.path_contract_enabled`; when ADR-0003's Unified SDK lands, only the wrapper internals change. Each flag carries a `lifecycle_policy` dict (layer, owner, sunset_date, classification) so ADR-0003's future Policy Engine can route it to Layer 3 / Experimentation. Tracked in [#205](https://github.com/elevanaltd/debate-hall-mcp/issues/205); gates [#201](https://github.com/elevanaltd/debate-hall-mcp/issues/201).
 
 The consensus loop itself, `max_refinement_loops`, and the Wall re-approval invariant at line 507 are unchanged.
 
@@ -255,13 +256,17 @@ Otherwise iterate prompts or revert.
 
 ---
 
-## 8. Open questions for the user
+## 8. Decisions (locked, 2026-05-02)
 
-1. **`hard_invariants_touched` enum vs free-text?** Closed enum (proposed) is safer and lets Wall write structured verdicts; free-text is more expressive but risks Wall and Wind drifting in vocabulary. Recommend closed for v1.
-2. **Door's "cite ≥1 accepted/disputed/reframed" rule — prompt-enforced or post-hoc validator?** Prompt-only is cheaper but probabilistic; validator is more reliable but adds a fail-and-retry path. Recommend prompt for v1, add validator if Door cheats.
-3. **Token-budget ceiling for `path_contract`?** Each contract adds ~200–400 tokens per path on later turns. With 3 paths and 3 roles writing, worst case ~3.6k tokens of contract state. Acceptable on Premium tier; Fast tier may need a truncation policy.
-4. **A/B test corpus** — should we generate fresh topics or replay historical `debates/`? Replay gives baseline comparison; fresh avoids overfit. Recommend ~70/30 replay/fresh.
-5. **Feature flag mechanism** — add a `tier_config.settings.path_contract_enabled: bool`, or use existing stratified flag architecture from ADR-0003?
+All five originally-open questions are now decided.
+
+1. **`hard_invariants_touched`**: **closed enum** (no free-text invariant IDs anywhere). Locks Wall and Wind into a shared vocabulary; ownership rule §3.1 enforces it.
+2. **Door citation rule**: **prompt-only enforcement** for v1. The conditional rule in §5.4 (cite every non-empty category; reframe-or-terminal-accepted only when HARD_fail exists) goes in the prompt; the orchestrator's citation-existence check (§6) catches hallucinated citations as validator-failure events. If post-hoc telemetry shows Door cheating frequently, add a strict validator in v2.
+3. **Token-budget ceiling for `path_contract`**: **5–10k tokens per path** is acceptable. Current models run 200k–1M context; a worst-case ~30k tokens of contract state (3 paths × 10k) is a small fraction of context and a fair price for provenance. No truncation policy in v1.
+4. **A/B test corpus**: **~70/30 replay/fresh**, ~20–50 topics total (per RFC §7.2).
+5. **Feature flag mechanism**: **`TierSettings` flag PLUS thin `features.is_enabled()` wrapper module with ADR-0003-aligned lifecycle metadata.** This is the migration-compatible-shape interpretation: the flag lives in TierSettings today (cheap, fits existing infrastructure); call sites go through `features.is_enabled("path_contract", context)` (so when ADR-0003's Unified SDK ships, only the wrapper internals change); each flag carries `lifecycle_policy` metadata per ADR-0003's requirement (so the future Policy Engine can route it to Layer 3 / Experimentation). New issue [#205](https://github.com/elevanaltd/debate-hall-mcp/issues/205) tracks the wrapper.
+
+   ADR-0003 is itself unimplemented (`grep` confirmed no scaffolding present); building the full architecture is out of scope (~7 weeks per its own implementation path). The wrapper costs ~100 LOC and prevents call-site rework when ADR-0003 lands.
 
 ---
 
@@ -299,7 +304,7 @@ References:
 
 | # | Task | Issue |
 |---|---|---|
-| 0 | **No-code prompt simulation** — pick 5 historical debates from `debates/`. Manually inject the proposed `<PATH_CONTRACTS>` block and the new prompt text (§5) into a fresh debate run, no orchestrator changes. Read whether Wind's `diff` substantively engages Wall's verdict or just restates the originals. **Gate**: if 4/5 produce restatement, the prompt design is wrong — iterate prompts and re-run before opening any other sub-issue. | [#204](https://github.com/elevanaltd/debate-hall-mcp/issues/204) |
+| 0 | **No-code prompt simulation** — run on the 5 historical debates in `debates/` (3 in-repo: `2026-01-30-rundebate-reliability-analysis`, `2026-01-30-virtualprovider-vs-timebudget`, `2026-02-03-cognitive-notary-architecture`; plus 2 added 2026-05-02 from other projects: `2026-04-28-decision-governance-synthesis`, `2026-02-22-mythology-in-octave-assessment`). Manually inject the proposed `<PATH_CONTRACTS>` block and the new prompt text (§5) into a fresh debate run, no orchestrator changes. Read whether Wind's `diff` substantively engages Wall's verdict or just restates the originals. **Gate**: if 4/5 produce restatement, the prompt design is wrong — iterate prompts and re-run before opening any other sub-issue. | [#204](https://github.com/elevanaltd/debate-hall-mcp/issues/204) |
 
 ### 11.2 Build sub-issues
 
@@ -310,7 +315,8 @@ References:
 | 3 | Prompt updates — four templates in `prompts/__init__.py`; Door's citation rule is **conditional** per §5.4 (cite every non-empty category; require reframed-or-terminal-accepted only when HARD_fail exists) | [#198](https://github.com/elevanaltd/debate-hall-mcp/issues/198) |
 | 4 | Context compiler — inject `<PATH_CONTRACTS>` showing latest revision per field plus revision counts | [#199](https://github.com/elevanaltd/debate-hall-mcp/issues/199) |
 | 5 | Orchestrator guards — required-content rule for `diff` (§3.2); Door citation existence check; ownership-violation check; emit validator-failure events | [#200](https://github.com/elevanaltd/debate-hall-mcp/issues/200) |
-| 6 | Feature flag `tier_config.settings.path_contract_enabled` (default OFF; A/B treatment sets ON). **Rollout sequence**: flag-off in main → A/B run → review metrics → decision. No "broad ship" stage exists by design. | [#201](https://github.com/elevanaltd/debate-hall-mcp/issues/201) |
+| 6 | Feature flag `tier_config.settings.path_contract_enabled` (default OFF; A/B treatment sets ON), accessed via the new `features.is_enabled()` wrapper from #205. **Rollout sequence**: flag-off in main → A/B run → review metrics → decision. No "broad ship" stage exists by design. | [#201](https://github.com/elevanaltd/debate-hall-mcp/issues/201) |
+| 6.5 | **`features.is_enabled()` wrapper module** (`src/debate_hall_mcp/features.py`, new) with ADR-0003-aligned `lifecycle_policy` metadata per flag. Gates #201. | [#205](https://github.com/elevanaltd/debate-hall-mcp/issues/205) |
 | 7 | Tests — golden files; **flag-off byte-identical to control** (hard gate); required-content rule enforced; ownership rule enforced; Door citation existence enforced; round-trip serialization | [#202](https://github.com/elevanaltd/debate-hall-mcp/issues/202) |
 | 8 | A/B harness — script + operator guide for two-machine comparison; captures all metrics from §7.3 (incl. invalid contract rate, citation accuracy, originality preservation, bogus reframing) | [#203](https://github.com/elevanaltd/debate-hall-mcp/issues/203) |
 

--- a/docs/rfc-0001-path-contract-wind-learning-loop.md
+++ b/docs/rfc-0001-path-contract-wind-learning-loop.md
@@ -101,8 +101,11 @@ class DiffRevision(TypedDict):
     written_at: datetime
     written_by: Literal["Wind"]             # consensus-phase Wind
     value: PathDiff
-    # Sentinel for paths Wind has nothing new to add. When set, `value` MUST contain
-    # empty accepted/disputed/reframed lists — divergence_marker is the only signal.
+    # Sentinel for paths Wind has nothing new to add. ONLY VALID when the corresponding
+    # `verdict_history` latest revision contains zero `HARD_fail` entries for this path
+    # (every invariant verdict is HARD_pass or SOFT_disputed). When set, `value` MUST
+    # contain empty accepted/disputed/reframed lists — divergence_marker is the only
+    # signal. Emitting NO_NEW_DIVERGENCE on a HARD_fail path is a validator-failure event.
     divergence_marker: NotRequired[Literal["NO_NEW_DIVERGENCE"]]
 
 class PathContract(TypedDict):
@@ -133,7 +136,7 @@ class PathContract(TypedDict):
 | 4+ | Wall (re-approval after Door refines) | `verdict_history.append(rev=N+1, …)` | Wall re-validates against the refined synthesis; previous verdict revisions remain visible for provenance |
 | 4+ | Door (refinement) | (reads full contract history) | Synthesis citation rule per §5.4 |
 
-**Required content rule for `diff` revisions**: for every entry in the latest `verdict` revision with `status == HARD_fail`, the corresponding invariant must appear in `diff.accepted` (with a `terminal_rationale` explaining why no creative reframe is possible) **or** in `diff.reframed` (with the new possibility it opens). Silent omission is invalid.
+**Required content rule for `diff` revisions**: for every entry in the latest `verdict` revision with `status == HARD_fail`, the corresponding invariant must appear in `diff.accepted` (with a `terminal_rationale` explaining why no creative reframe is possible) **or** in `diff.reframed` (with the new possibility it opens). Silent omission is invalid. A `DiffRevision` with `divergence_marker = NO_NEW_DIVERGENCE` on a path whose latest verdict contains any `HARD_fail` is rejected as a validator-failure event — the sentinel may only be used when every invariant verdict for the path is `HARD_pass` or `SOFT_disputed`.
 
 The state machine arc is unchanged; only the payload schema thickens.
 

--- a/docs/rfc-0001-path-contract-wind-learning-loop.md
+++ b/docs/rfc-0001-path-contract-wind-learning-loop.md
@@ -3,7 +3,7 @@
 **Status**: Proposed (awaiting decision)
 **Date**: 2026-05-02
 **Branch**: `claude/review-debate-agent-flow-DzSFX`
-**Tracking**: [#195](https://github.com/elevanaltd/debate-hall-mcp/issues/195) (parent) — sub-issues [#196](https://github.com/elevanaltd/debate-hall-mcp/issues/196)–[#203](https://github.com/elevanaltd/debate-hall-mcp/issues/203)
+**Tracking**: [#195](https://github.com/elevanaltd/debate-hall-mcp/issues/195) (parent) — sub-issues [#196](https://github.com/elevanaltd/debate-hall-mcp/issues/196)–[#205](https://github.com/elevanaltd/debate-hall-mcp/issues/205)
 **Author**: Generated via meta-debate (Wind→Wall→Wind-Revise→Door) on the question itself
 
 ---
@@ -72,13 +72,16 @@ class InvariantVerdict(TypedDict):
     rationale: str
 
 class PathDiff(TypedDict):
-    accepted: list[InvariantEntry]   # invariant keys Wind accepts (with terminal_rationale if HARD_fail)
+    accepted: list[InvariantEntry]   # invariant keys Wind accepts; HARD_fail entries MUST set terminal_rationale
     disputed: list[InvariantEntry]   # SOFT keys Wind still pushes back on, with rationale
-    reframed: list[InvariantEntry]   # invariant keys whose reframing opens a new possibility
+    reframed: list[InvariantEntry]   # invariant keys whose reframing opens a new possibility (set new_possibility)
 
 class InvariantEntry(TypedDict):
     invariant: HardInvariant
     rationale: str
+    # Optional fields — variant-specific (NotRequired = absent unless populated by the owning category):
+    terminal_rationale: NotRequired[str]   # required on `accepted` items where the verdict was HARD_fail and no creative reframe is possible
+    new_possibility: NotRequired[str]      # required on `reframed` items — the catalyst-opened possibility this constraint reveals
 
 # Append-only revision wrappers — written exactly once each, by the owning role
 class FrameRevision(TypedDict):
@@ -98,6 +101,9 @@ class DiffRevision(TypedDict):
     written_at: datetime
     written_by: Literal["Wind"]             # consensus-phase Wind
     value: PathDiff
+    # Sentinel for paths Wind has nothing new to add. When set, `value` MUST contain
+    # empty accepted/disputed/reframed lists — divergence_marker is the only signal.
+    divergence_marker: NotRequired[Literal["NO_NEW_DIVERGENCE"]]
 
 class PathContract(TypedDict):
     path_id: str

--- a/docs/rfc-0001-path-contract-wind-learning-loop.md
+++ b/docs/rfc-0001-path-contract-wind-learning-loop.md
@@ -1,0 +1,257 @@
+# RFC-0001: `path_contract` — Iterative Wind Learning Loop
+
+**Status**: Proposed (awaiting decision)
+**Date**: 2026-05-02
+**Branch**: `claude/review-debate-agent-flow-DzSFX`
+**Author**: Generated via meta-debate (Wind→Wall→Wind-Revise→Door) on the question itself
+
+---
+
+## 1. Problem
+
+The current `run_debate` flow is Wind → Wall → Door (one-shot), with Wind subsequently downgraded to a yes/no voter in the consensus phase. Wind never gets a turn to **react to Wall's critique and push innovation further within the validated boundaries**. Door alone integrates Wall's constraints into Wind's ideas, which means the system never benefits from the well-documented Self-Refine pattern (FEEDBACK→REFINE; ~20% gain in published benchmarks) on the *creative* side of the debate.
+
+### 1.1 Current behaviour, cited
+
+| Concern | File / lines | Effect |
+|---|---|---|
+| Hard-coded one-shot sequence | `src/debate_hall_mcp/orchestrator.py:578-743` | No Wind re-ideation phase exists |
+| Refinement is Door-only | `src/debate_hall_mcp/orchestrator.py:482-560` | Wind/Wall vote APPROVE/REJECT; only Door rewrites |
+| Wind consensus prompt forbids ideation | `src/debate_hall_mcp/prompts/__init__.py:540-584` | "Do NOT provide new possibilities or expand the discussion." |
+| Wall re-approval reset on Wind reject | `src/debate_hall_mcp/orchestrator.py:507` | `final_wall_approved = None` — Wall re-validates every Wind reject |
+
+### 1.2 What "innovation pushed further" means concretely
+
+The user wants the loop to demonstrate **constraint-as-catalyst**: ideas that are *only visible after* Wall's critique, not ideas that retreat from it. This was tested in the meta-debate (§4) — the prompt design that produced this behaviour is included verbatim in §5.
+
+---
+
+## 2. Goals and non-goals
+
+### Goals
+
+1. Wind reacts to Wall's critique with new/refined ideas, by structured reference (not free prose).
+2. Door's synthesis traces every claim back to a recorded role contribution (provenance).
+3. The consensus-from-all-agents requirement is preserved.
+4. Halting guarantees on the consensus loop are preserved.
+5. The change is amenable to **two-machine A/B testing** against the current flow on identical inputs.
+
+### Non-goals
+
+- No agent swarms, parallel Winds, or speculative meta-cognitive move markets (all blocked in §4 for halting / coherence reasons).
+- No new orchestrator phases or new turn types.
+- No changes to `agents/*.oct.md` persona files.
+- No model/tier changes.
+
+---
+
+## 3. Proposed design (one-line summary)
+
+Add a single typed field, **`path_contract`**, attached to each Wind path. It is **mutated, not replaced** by each role as the path traverses Wind → Wall → (consensus-Wind) → Door. No new turn types, no new orchestrator phases.
+
+### 3.1 Schema
+
+```python
+# src/debate_hall_mcp/orchestrator.py (or a new types module)
+
+class HardInvariant(str, Enum):
+    HALTING = "halting"
+    SINGLE_WALL_COHERENCE = "single_wall_coherence"
+    RE_APPROVAL = "re_approval"
+    PER_TURN_ROLE_CONTRACT = "per_turn_role_contract"
+
+class PathFrame(TypedDict):
+    assumed_problem: str
+    success_criterion: str
+    accepted_failure_mode: str
+    hard_invariants_touched: list[HardInvariant]
+
+class InvariantVerdict(TypedDict):
+    status: Literal["HARD_pass", "HARD_fail", "SOFT_disputed"]
+    rationale: str
+
+class PathDiff(TypedDict):
+    accepted: list[str]      # invariant keys Wind now accepts
+    disputed: list[str]      # SOFT keys Wind still pushes back on, with rationale
+    reframed: list[str]      # invariant keys whose reframing opens a new possibility
+
+class PathContract(TypedDict):
+    path_id: str
+    frame: PathFrame                          # written by Wind (turn 1)
+    verdict: dict[str, InvariantVerdict]      # written by Wall (turn 2), keyed by invariant
+    diff: PathDiff | None                     # written by Wind in consensus phase
+```
+
+### 3.2 Lifecycle
+
+| Stage | Role | Field written | Notes |
+|---|---|---|---|
+| 1 | Wind | `frame` per path | Includes `hard_invariants_touched` from a closed enum (safer; see §8 Q1) |
+| 2 | Wall | `verdict[invariant]` | Per path, every invariant Wind flagged is scored HARD_pass / HARD_fail / SOFT_disputed |
+| 3 | Door | (reads only) | Initial synthesis; can be skipped for A/B variant where Wind always re-engages |
+| 4+ | Wind (consensus) | `diff` | Must reference Wall's verdict entries by invariant key. **Empty `diff` is invalid** when any HARD_fail exists. |
+| 4+ | Door (refinement) | (reads full contract history) | Synthesis must cite ≥1 `accepted`, ≥1 `disputed`, ≥1 `reframed` entry across paths |
+
+The state machine arc is unchanged; only the payload schema thickens.
+
+---
+
+## 4. Evidence the design works (meta-debate result)
+
+A 4-turn debate was run on this very question, using the proposed flow:
+
+- **Wind (initial)** — proposed three options: a `WIND_REVISE` turn (Obvious), a Wind swarm (Adjacent), a meta-cognitive move-set market (Heretical).
+- **Wall** — CONDITIONAL GO on Obvious; **BLOCKED** on Adjacent (non-composable cross-critique, breaks `final_wall_approved` invariant) and Heretical (no halting proof, unvalidated referee oracle).
+- **Wind-Revise** (the experimental new turn) — accepted Wall's HARD constraints, then produced **Refined-C: "co-opt Wall by enriching Wall's input, not by changing Wall's process"** — a path that was *only visible after Wall's critique*.
+- **Door** — recognised that the three Refined paths were not three options but three *lifecycle stages of one artifact* — collapsing the recommendation from "add a new turn" to "thicken the payload". This is the `path_contract` design.
+
+This is the strongest evidence available short of an A/B test: the proposed flow, executed once on its own design problem, produced an emergent insight that no individual turn predicted. Full transcript available on request.
+
+---
+
+## 5. Prompt changes (verbatim)
+
+### 5.1 Wind initial prompt (`prompts/__init__.py:433`)
+
+Add to the existing Wind prompt:
+
+> For each of your three paths, emit a `path_contract.frame` with:
+> - `assumed_problem`: the version of the problem this path addresses
+> - `success_criterion`: how we'd know this path worked
+> - `accepted_failure_mode`: what this path explicitly trades away
+> - `hard_invariants_touched`: from this enum: {halting, single_wall_coherence, re_approval, per_turn_role_contract}
+
+### 5.2 Wall prompt (`prompts/__init__.py:468`)
+
+Add:
+
+> For each Wind path, write `path_contract.verdict[invariant]` for every invariant the path touched. Each entry: `status` (HARD_pass / HARD_fail / SOFT_disputed) and `rationale` (one sentence of evidence). HARD verdicts are non-negotiable. SOFT_disputed verdicts are tradeable and Wind may push back on them.
+
+### 5.3 Wind consensus prompt (`prompts/__init__.py:540-584`) — the critical change
+
+Replace:
+> Do NOT provide new possibilities or expand the discussion. Your role now is to VALIDATE the synthesis from Wind's perspective.
+
+With:
+
+> Wall has critiqued each of your paths. Wall has authority over HARD invariants — accept these as the new floor of possibility. Wall does NOT have authority over SOFT_disputed entries — you may push back on them with rationale.
+>
+> Your task is NOT to defend, NOT to re-pitch your originals, NOT to retreat. Your task is to TAKE WALL'S CRITIQUE ON BOARD AND PUSH INNOVATION FURTHER. Specifically:
+>
+> 1. ACCEPT every HARD_fail. Treat it as a creative catalyst.
+> 2. For each accepted HARD_fail, ask: "Given this is true, what new possibility opens up that I couldn't see before?"
+> 3. For SOFT_disputed entries, you may DISPUTE — but only if disputing opens a richer path.
+> 4. Emit `path_contract.diff` for each path: `{accepted: [...], disputed: [...], reframed: [...]}`, keyed to Wall's verdict entries by invariant name.
+> 5. If you genuinely have nothing new to add, emit `NO_NEW_DIVERGENCE` for that path. Honesty over performative ideation.
+>
+> Then APPROVE / REJECT Door's synthesis as before.
+
+### 5.4 Door synthesis prompt (`prompts/__init__.py:504`)
+
+Add:
+
+> Your synthesis must cite **at least one** `accepted` entry, **at least one** `disputed` entry, and **at least one** `reframed` entry across the paths' contracts. This forces genuine integration — averaging or compromise will fail validation.
+
+---
+
+## 6. Orchestrator changes
+
+Minimal. Only two:
+
+1. **`PathContract` is part of the debate state**, persisted alongside transcripts. The `<DEBATE_STATE>` block in prompts includes a `<PATH_CONTRACTS>` sub-block with the contracts to date.
+2. **Validation guard** in `_execute_consensus_loop` (`orchestrator.py:482-560`): when Wind votes (line 485), assert that for every path with `verdict` entries containing `HARD_fail`, the corresponding `diff` is non-empty. If empty → reject the Wind output and retry once before treating it as a malformed turn (existing error path).
+
+The consensus loop itself, `max_refinement_loops`, and the Wall re-approval invariant at line 507 are unchanged.
+
+---
+
+## 7. A/B test design
+
+Since the user is running two machines:
+
+### 7.1 Setup
+
+- **Machine A (control)**: current `main` (or `claude/review-debate-agent-flow-DzSFX` with this RFC merged but `path_contract` feature flag OFF).
+- **Machine B (treatment)**: same branch with `path_contract` ON.
+- Identical: tier config, model versions, prompts otherwise, `max_refinement_loops`, RNG seed where supported.
+
+### 7.2 Inputs
+
+- A fixed corpus of 20–50 debate topics, ideally drawn from `debates/` historical runs so we can compare to existing transcripts.
+- Same topic delivered to both machines; same `thread_id` is **not** shared (different state dirs).
+
+### 7.3 Metrics
+
+Quantitative:
+- **Turn count to consensus** (lower or equal = good, with caveats).
+- **Stalemate rate** over the corpus.
+- **Token cost** per debate (treatment will be higher; we want to know by how much).
+- **Wall reject rate** in consensus phase (treatment should fall — better-grounded ideas pass faster).
+
+Qualitative (blind review by the user, ideally double-blind):
+- **Synthesis novelty** — does Door's output contain ideas not present verbatim in Wind's initial paths? (Treatment should win.)
+- **Constraint-as-catalyst evidence** — count of Door synthesis claims that cite a `reframed` path_contract entry.
+- **Provenance auditability** — can a reader trace each Door claim to a role contribution?
+
+### 7.4 Decision rule
+
+Ship treatment if: (a) qualitative novelty wins ≥60% of blind comparisons, (b) stalemate rate doesn't increase, (c) token cost increase <40%. Otherwise iterate or revert.
+
+---
+
+## 8. Open questions for the user
+
+1. **`hard_invariants_touched` enum vs free-text?** Closed enum (proposed) is safer and lets Wall write structured verdicts; free-text is more expressive but risks Wall and Wind drifting in vocabulary. Recommend closed for v1.
+2. **Door's "cite ≥1 accepted/disputed/reframed" rule — prompt-enforced or post-hoc validator?** Prompt-only is cheaper but probabilistic; validator is more reliable but adds a fail-and-retry path. Recommend prompt for v1, add validator if Door cheats.
+3. **Token-budget ceiling for `path_contract`?** Each contract adds ~200–400 tokens per path on later turns. With 3 paths and 3 roles writing, worst case ~3.6k tokens of contract state. Acceptable on Premium tier; Fast tier may need a truncation policy.
+4. **A/B test corpus** — should we generate fresh topics or replay historical `debates/`? Replay gives baseline comparison; fresh avoids overfit. Recommend ~70/30 replay/fresh.
+5. **Feature flag mechanism** — add a `tier_config.settings.path_contract_enabled: bool`, or use existing stratified flag architecture from ADR-0003?
+
+---
+
+## 9. Alternatives considered (and rejected by Wall)
+
+| Alternative | Why rejected | Source |
+|---|---|---|
+| Add a new `WIND_REVISE` turn type | Works but requires new orchestrator dispatch, new prompt template, halting bound; payload-thickening achieves the same goal in-band | Wall turn 2 |
+| Wind swarm (Pragmatic / Heretical / Adjacent) with cross-critique matrix | Stochastic cross-critiques are non-composable; Wall cannot coherently judge three ideation sets in one turn; "majority across swarm" breaks `final_wall_approved` invariant at `orchestrator.py:507` | Wall turn 2 (BLOCKED) |
+| Meta-cognitive move-set market (steelman / frame-shift / constraint-audit) with budgeted moves | No halting proof; "referee model measuring semantic drift" is an unvalidated probabilistic oracle proposed to replace deterministic state machine; requires whole new orchestrator | Wall turn 2 (BLOCKED) |
+| Self-Refine on Wind alone (no Wall grounding) | 2025 literature (Free-MAD, ICLR blog) warns over-confident agents degrade output; Wind self-critique without external grounding repeats the over-confidence trap | Research §10 |
+
+These options remain accessible as future work — `path_contract` makes them prototype-able as frame variants without orchestrator surgery.
+
+---
+
+## 10. Research backing
+
+- **Self-Refine** (Madaan et al.): FEEDBACK→REFINE produces ~20% absolute gain on average across tasks. The proposed Wind-consensus prompt is a direct application, with critique grounded in Wall's text rather than self-reflection.
+- **ReConcile** (ACL 2024): round-table multi-LLM consensus — preserved as-is in the consensus loop.
+- **Free-MAD / CortexDebate** (2025): warn that strict consensus has cost and that over-confident agents degrade output. Mitigated here by HARD/SOFT verdict tagging, which lets Wall keep authority over invariants without veto on creative direction.
+- **Multi-Agent Reflexion (MAR, 2025)**: structured reflection by reference (not free prose) outperforms free reflection. The `diff` field's keyed-by-invariant requirement implements this.
+
+References:
+- [Self-Refine (arXiv 2303.17651)](https://arxiv.org/abs/2303.17651)
+- [Free-MAD (arXiv 2509.11035)](https://arxiv.org/html/2509.11035v1)
+- [ICLR 2025 MAD blog](https://d2jud02ci9yv69.cloudfront.net/2025-04-28-mad-159/blog/mad/)
+- [Agent-R (arXiv 2501.11425)](https://arxiv.org/abs/2501.11425)
+
+---
+
+## 11. Implementation plan (if accepted)
+
+1. **Schema + types** (`src/debate_hall_mcp/orchestrator.py` or new `types.py`): `PathContract`, `PathFrame`, `InvariantVerdict`, `PathDiff`, `HardInvariant`. Default-empty so existing flows degrade gracefully.
+2. **State serialization**: extend `state.py` to persist contracts alongside transcripts.
+3. **Prompt updates**: four prompt templates in `src/debate_hall_mcp/prompts/__init__.py` (Wind initial, Wall, Wind consensus, Door).
+4. **Context compiler** (`context_compiler.py`): inject `<PATH_CONTRACTS>` sub-block into the `<DEBATE_STATE>` envelope.
+5. **Orchestrator guard**: validation in `_execute_consensus_loop` for non-empty `diff` when HARD_fail exists.
+6. **Feature flag**: `tier_config.settings.path_contract_enabled` (default off in v1, on in A/B treatment build).
+7. **Tests**: golden-file tests for (a) Wall HARD_fail forces non-empty diff, (b) Door synthesis cites all three diff categories, (c) feature-flag-off path is byte-identical to current behaviour.
+8. **A/B harness**: a small script or doc explaining how to run identical topics on two machines and collect transcripts for blind review.
+
+Estimated scope: ~400–600 lines of code + tests, plus prompt edits. ~1–2 days of focused work.
+
+---
+
+## 12. Decision
+
+Pending user review.

--- a/docs/rfc-0001-simulation-harness.md
+++ b/docs/rfc-0001-simulation-harness.md
@@ -1,0 +1,189 @@
+# RFC-0001 Simulation Harness — Pre-build Gate (#204)
+
+**Purpose**: A paste-and-run template for the no-code prompt simulation that gates RFC-0001 implementation. No orchestrator changes; just human-in-the-loop testing of whether the proposed Wind-consensus and Door-synthesis prompts actually produce constraint-as-catalyst behavior on real historical debates.
+
+**Pass criteria**: ≥4/5 debates produce diffs where `reframed` (or `accepted` with `terminal_rationale`) content is substantively different from Wind's original path AND meaningfully engages a Wall verdict entry, AND Door's citations exist in the contract.
+
+**Fail action**: iterate the Wind-consensus prompt (RFC §5.3) and re-run. Do not open #196–#205 until pass.
+
+---
+
+## How to use
+
+For each of the 5 debates below:
+
+1. Open a fresh Claude session (no carry-over context).
+2. **Paste once at the top**: the system prompt block from §A below.
+3. **Paste the per-debate scenario block**: the historical Wind paths and Wall verdicts (extracted from the transcript) wrapped in the `<PATH_CONTRACTS>` shape (RFC §3.1) plus the Wind-consensus prompt (RFC §5.3).
+4. **Capture Wind's response** in the "Wind diff output" section below.
+5. **Continue the session**: paste the Door-synthesis prompt (RFC §5.4) and capture Door's response.
+6. **Score against the pass criteria** and fill in the verdict table at the bottom.
+
+If a debate transcript doesn't cleanly map to three paths, pick the closest framing (often Wind expanded N paths, Wall verdict-ed each — use as many as exist).
+
+---
+
+## §A. System prompt block (paste once per session)
+
+```
+You are roleplaying as the WIND agent (PATHOS) in a Wind/Wall/Door debate.
+Persona rules: prime directive "Seek what could be"; signature phrase "What if...";
+must NOT pick a winner; must NOT defend prior ideas reflexively.
+
+You will be given:
+- A topic
+- Your prior frame (Turn 1)
+- Wall's verdict on each of your paths (Turn 2)
+- A <PATH_CONTRACTS> block showing the structured state
+- Instructions for the new WIND_CONSENSUS turn
+
+Your output must be valid JSON conforming to the path_contract.diff schema.
+```
+
+When testing Door, replace the persona block with Door's (LOGOS, "Therefore...") and use the Door synthesis prompt from §5.4.
+
+---
+
+## §B. Per-debate scenarios
+
+Five sections, one per debate. Each has:
+- **Source**: file path
+- **Topic**: short summary
+- **Constructed `<PATH_CONTRACTS>`**: extracted from the historical transcript, formatted in the proposed shape
+- **Wind diff output**: blank — fill from session
+- **Door synthesis output**: blank — fill from session
+- **Verdict**: pass/fail with one-line evidence
+
+---
+
+### B1. Debate: rundebate-reliability-analysis
+
+- **Source**: `debates/2026-01-30-rundebate-reliability-analysis.oct.md`
+- **Topic**: (extract from file)
+- **Wind paths** (Turn 1): _extract from transcript_
+- **Wall verdicts** (Turn 2): _extract from transcript; tag each invariant HARD_pass / HARD_fail / SOFT_disputed_
+
+```xml
+<PATH_CONTRACTS>
+  <path id="path_1">
+    <frame_history>
+      <rev index="0" written_by="Wind">
+        <assumed_problem>...</assumed_problem>
+        <success_criterion>...</success_criterion>
+        <accepted_failure_mode>...</accepted_failure_mode>
+        <hard_invariants_touched>[halting, single_wall_coherence, ...]</hard_invariants_touched>
+      </rev>
+    </frame_history>
+    <verdict_history>
+      <rev index="0" written_by="Wall">
+        <verdict invariant="halting" status="HARD_pass" rationale="..." />
+        <verdict invariant="single_wall_coherence" status="HARD_fail" rationale="..." />
+      </rev>
+    </verdict_history>
+  </path>
+  <!-- repeat for path_2, path_3 -->
+</PATH_CONTRACTS>
+```
+
+#### Wind consensus prompt (paste verbatim, RFC §5.3)
+
+> Wall has critiqued each of your paths. Wall has authority over HARD invariants — accept these as the new floor of possibility. Wall does NOT have authority over SOFT_disputed entries — you may push back on them with rationale.
+>
+> Your task is NOT to defend, NOT to re-pitch your originals, NOT to retreat. Your task is to TAKE WALL'S CRITIQUE ON BOARD AND PUSH INNOVATION FURTHER. Specifically:
+> 1. ACCEPT every HARD_fail. Treat it as a creative catalyst.
+> 2. For each accepted HARD_fail, ask: "Given this is true, what new possibility opens up that I couldn't see before?"
+> 3. For SOFT_disputed entries, you may DISPUTE — but only if disputing opens a richer path.
+> 4. Emit `path_contract.diff` for each path: `{accepted: [...], disputed: [...], reframed: [...]}`, keyed to Wall's verdict entries by invariant name.
+> 5. If you genuinely have nothing new to add, emit `NO_NEW_DIVERGENCE` for that path. Honesty over performative ideation.
+
+#### Wind diff output
+
+```json
+// PASTE Wind's response here
+```
+
+#### Door synthesis prompt (paste, RFC §5.4)
+
+> Your synthesis must cite every non-empty category (`accepted` / `disputed` / `reframed`) across the paths' contracts. If a category is empty for all paths, do not invent entries — instead, briefly note its absence.
+> Additional rule: when any path has a `HARD_fail` verdict, your synthesis must cite, for that path, either a `reframed` entry that addresses the failure or an `accepted` entry whose `terminal_rationale` explains why the failure is unreframeable.
+
+#### Door synthesis output
+
+```
+// PASTE Door's response here
+```
+
+#### Scorecard
+
+| Check | Pass? | Note |
+|---|---|---|
+| Wind diff references Wall verdict entries by invariant key | ☐ | |
+| `reframed` entries are substantively new (not restatements) | ☐ | |
+| `accepted` entries with HARD_fail include honest `terminal_rationale` | ☐ | |
+| No fake `disputed` entries when Wall HARD_passed everything | ☐ | |
+| Door cites every non-empty category | ☐ | |
+| All Door citations exist in the contract (no hallucination) | ☐ | |
+
+**Verdict**: ☐ PASS / ☐ FAIL
+
+**Evidence**: _one quote demonstrating reframe quality (or its failure)_
+
+---
+
+### B2. Debate: virtualprovider-vs-timebudget
+
+- **Source**: `debates/2026-01-30-virtualprovider-vs-timebudget.oct.md`
+- (Same template as B1 — fill in extracted paths and verdicts)
+
+---
+
+### B3. Debate: cognitive-notary-architecture
+
+- **Source**: `debates/2026-02-03-cognitive-notary-architecture.oct.md`
+- (Same template as B1)
+
+---
+
+### B4. Debate: decision-governance-synthesis
+
+- **Source**: `debates/2026-04-28-decision-governance-synthesis.oct.md`
+- **Topic**: ADR-0060 governance — should every decision originate from a GitHub Issue, or do we need a tiered model?
+- **Note**: this debate's transcript is a synthesis (post-hoc), not three-turn raw. Construct the three Wind paths by reading §1::QUESTION_DEBATED and §2a::THREE_TIERS as if Wind originally proposed three governance tiers; construct Wall's verdicts from §4::PRACTICAL_CAVEAT (which is the closest thing to a Wall pushback in the synthesis).
+
+---
+
+### B5. Debate: mythology-in-octave-assessment
+
+- **Source**: `debates/2026-02-22-mythology-in-octave-assessment.oct.md`
+- **Topic**: How should OCTAVE lean into mythological vocabulary? Permission vs formalization.
+- **Note**: this debate has the cleanest Wind/Wall/Door structure — use it as the canonical extraction template. `RATIONALE.WIND_PERSPECTIVES` → Wind paths; `RATIONALE.WALL_CONSTRAINTS` (E1–E5) → Wall verdicts; `RATIONALE.DOOR_REFINEMENTS` → Door's original synthesis.
+- **Strongest test case** for whether the new Wind-consensus prompt produces a substantively new reframe vs. just restating Wind's original "Mythology as Native Compression Layer" claim.
+
+---
+
+## §C. Final verdict table
+
+Fill in after running all five.
+
+| # | Debate | Verdict | Key evidence |
+|---|---|---|---|
+| 1 | rundebate-reliability-analysis | ☐ PASS / ☐ FAIL | |
+| 2 | virtualprovider-vs-timebudget | ☐ PASS / ☐ FAIL | |
+| 3 | cognitive-notary-architecture | ☐ PASS / ☐ FAIL | |
+| 4 | decision-governance-synthesis | ☐ PASS / ☐ FAIL | |
+| 5 | mythology-in-octave-assessment | ☐ PASS / ☐ FAIL | |
+
+**Gate**: ≥4/5 PASS → open build sub-issues #196–#205. ≤3/5 → iterate Wind-consensus prompt and re-run.
+
+**Decision**: ☐ Proceed to build / ☐ Iterate prompts (record changes in §D)
+
+---
+
+## §D. Prompt iteration log
+
+If the gate fails, record each prompt change here with the diff between iterations and the rerun verdict.
+
+| Iteration | Date | Change to RFC §5.3 | Re-run verdict | Notes |
+|---|---|---|---|---|
+| 1 | (initial) | — | filled in §C above | |
+| 2 | | | | |

--- a/docs/rfc-0001-simulation-harness.md
+++ b/docs/rfc-0001-simulation-harness.md
@@ -94,7 +94,7 @@ Five sections, one per debate. Each has:
 > 2. For each accepted HARD_fail, ask: "Given this is true, what new possibility opens up that I couldn't see before?"
 > 3. For SOFT_disputed entries, you may DISPUTE — but only if disputing opens a richer path.
 > 4. Emit `path_contract.diff` for each path: `{accepted: [...], disputed: [...], reframed: [...]}`, keyed to Wall's verdict entries by invariant name.
-> 5. If you genuinely have nothing new to add, emit `NO_NEW_DIVERGENCE` for that path. Honesty over performative ideation.
+> 5. If you genuinely have nothing new to add for a path, emit a JSON-compatible sentinel diff with empty lists and the `divergence_marker` field set: `{"path_id": "path_N", "accepted": [], "disputed": [], "reframed": [], "divergence_marker": "NO_NEW_DIVERGENCE"}`. Honesty over performative ideation. (The `divergence_marker` field on `DiffRevision` is the schema-level signal; see RFC §3.1.)
 
 #### Wind diff output
 

--- a/src/debate_hall_mcp/orchestrator.py
+++ b/src/debate_hall_mcp/orchestrator.py
@@ -49,6 +49,7 @@ from debate_hall_mcp.prompts import (
     RACI_CONSULTED_PROMPT,
     RACI_INFORMED_PROMPT,
     RACI_RESPONSIBLE_PROMPT,
+    format_door_consensus_prompt,
     format_door_user_prompt,
     format_raci_advice_prompt,
     format_raci_observation_prompt,
@@ -305,6 +306,12 @@ class DebateOrchestrator:
     ) -> str:
         """Create a prompt for Door to refine synthesis based on feedback.
 
+        Delegates to ``format_door_consensus_prompt`` (RFC-0001) which carries the
+        consensus-phase path_contract citation rule. This is the only place where
+        Door is asked to cite PATH_CONTRACT_DIFF entries; the initial Door prompt
+        (``format_door_user_prompt``) deliberately omits the citation rule because
+        no DIFF exists yet at that turn.
+
         Args:
             topic: The debate topic
             thread_id: Thread ID for state access
@@ -312,29 +319,9 @@ class DebateOrchestrator:
             feedback: Feedback from the rejector (may be None)
 
         Returns:
-            Formatted prompt for Door to refine synthesis
+            Formatted prompt for Door to refine synthesis (consensus phase)
         """
-        feedback_text = feedback if feedback else "No specific feedback provided."
-        return f"""You are participating in a Wind/Wall/Door debate REFINEMENT PHASE.
-
-Topic: {topic}
-Thread ID: {thread_id}
-Your Role: Door (LOGOS) - Synthesis Refiner
-
-The current debate state is provided above in <DEBATE_STATE> tags.
-
-{rejector} has REJECTED your synthesis with the following feedback:
-{feedback_text}
-
-Your task: Refine your synthesis to address {rejector}'s concerns.
-
-As Door (LOGOS), create a refined synthesis that:
-- Addresses the specific feedback from {rejector}
-- Maintains integration of Wind's possibilities and Wall's constraints
-- Demonstrates how this refinement improves the emergent solution
-- Preserves concrete, actionable implementation steps
-
-Respond with your refined synthesis using the OCTAVE response format."""
+        return format_door_consensus_prompt(topic, thread_id, rejector, feedback)
 
     async def _execute_role_turn(
         self,

--- a/src/debate_hall_mcp/prompts/__init__.py
+++ b/src/debate_hall_mcp/prompts/__init__.py
@@ -462,6 +462,26 @@ As Wind, you bring PATHOS - divergent thinking and creative expansion:
 Do NOT provide a single final answer or render judgment on which option is best.
 Your role is to EXPAND possibilities before Wall validates and Door synthesizes.
 
+[RFC-0001 — path_contract additions]
+At the end of your response, for EACH path you proposed, append a fenced JSON block
+labeled with a heading. Use this exact shape so Wall and Door can parse it:
+
+### PATH_CONTRACT_FRAME (path_1)
+```json
+{{
+  "path_id": "path_1",
+  "path_label": "Obvious | Adjacent | Heretical",
+  "assumed_problem": "the version of the problem this path addresses",
+  "success_criterion": "how we'd know this path worked",
+  "accepted_failure_mode": "what this path explicitly trades away",
+  "hard_invariants_touched": ["pick from: halting, single_wall_coherence, re_approval, per_turn_role_contract — only those that genuinely apply"]
+}}
+```
+
+Repeat the heading + JSON block for path_2 and path_3. Use the closed enum values
+verbatim for hard_invariants_touched. Empty list is allowed if a path touches no
+invariant.
+
 Respond using the OCTAVE response format defined in your system prompt."""
 
 
@@ -497,6 +517,29 @@ As Wall, you bring ETHOS - rigorous validation and constraint identification:
 
 Do NOT explore new possibilities or synthesize solutions.
 Your role is to VALIDATE before Door synthesizes.
+
+[RFC-0001 — path_contract additions]
+Wind's response includes one PATH_CONTRACT_FRAME JSON block per path. For EACH path,
+append a fenced JSON block labeled with a heading, scoring every invariant Wind
+flagged in that path's `hard_invariants_touched` list.
+
+IMPORTANT — heading format: use the LITERAL heading text below exactly. Do not
+substitute the path's label (Obvious / Adjacent / Heretical) for the heading;
+downstream tooling locates these blocks by the literal `PATH_CONTRACT_VERDICT
+(path_N)` heading.
+
+### PATH_CONTRACT_VERDICT (path_1)
+```json
+{{
+  "path_id": "path_1",
+  "verdicts": [
+    {{"invariant": "halting", "status": "HARD_pass | HARD_fail | SOFT_disputed", "rationale": "one sentence of evidence"}}
+  ]
+}}
+```
+
+Status values are a closed set: HARD_pass, HARD_fail, SOFT_disputed.
+HARD verdicts are non-negotiable. SOFT_disputed are tradeable — Wind may push back.
 
 Respond using the OCTAVE response format defined in your system prompt."""
 
@@ -534,6 +577,25 @@ As Door, you bring LOGOS - convergent integration and structural synthesis:
 Do NOT simply average or compromise between positions.
 Your role is to INTEGRATE and create something that honors both while transcending the apparent conflict.
 
+[RFC-0001 — path_contract citation rule]
+Wind has emitted PATH_CONTRACT_FRAME blocks; Wall has emitted PATH_CONTRACT_VERDICT blocks;
+in the consensus phase Wind will emit PATH_CONTRACT_DIFF blocks containing accepted /
+disputed / reframed entries.
+
+Your synthesis must cite EVERY non-empty category (accepted / disputed / reframed) across
+the paths' contracts. If a category is empty for all paths, do NOT invent entries —
+instead briefly note its absence (e.g. "no constraints disputed; Wind accepted Wall's
+verdict in full").
+
+Additional rule: when any path has a HARD_fail verdict in Wall's output, your synthesis
+must cite, for that path, EITHER a `reframed` entry that addresses the failure OR an
+`accepted` entry whose rationale explains why the failure is unreframeable. Silent
+omission is invalid — this is the constraint-as-catalyst proof.
+
+Reference contract entries explicitly in your synthesis text using the form
+`[path_N.accepted: <invariant>]`, `[path_N.disputed: <invariant>]`, or
+`[path_N.reframed: <invariant>]` so a reader can verify the citation.
+
 Respond using the OCTAVE response format defined in your system prompt."""
 
 
@@ -554,34 +616,72 @@ def format_wind_approval_prompt(topic: str, thread_id: str) -> str:
 
 Topic: {topic}
 Thread ID: {thread_id}
-Your Role: Wind (PATHOS) - Consensus Reviewer
+Your Role: Wind (PATHOS) - Consensus Reviewer + Path Refiner
 
-The current debate state including Door's synthesis is provided above in <DEBATE_STATE> tags.
+The current debate state including your prior PATH_CONTRACT_FRAME blocks, Wall's
+PATH_CONTRACT_VERDICT blocks, and Door's synthesis is provided above in <DEBATE_STATE> tags.
 
-Your task: Review Door's synthesis and vote APPROVE or REJECT.
+[RFC-0001 — constraint-as-catalyst behaviour]
+Wall has critiqued each of your paths. Wall has authority over HARD invariants — accept
+these as the new floor of possibility. Wall does NOT have authority over SOFT_disputed
+entries — you may push back on them with rationale.
 
-As Wind (PATHOS), evaluate whether the synthesis:
-- Preserves the creative possibilities you expanded
-- Honors the spirit of innovation and exploration
-- Maintains the vision while addressing constraints
-- Enables emergent capabilities beyond either/or
+Your task is NOT to defend, NOT to re-pitch your originals, NOT to retreat. Your task is
+to TAKE WALL'S CRITIQUE ON BOARD AND PUSH INNOVATION FURTHER. Specifically:
+
+1. ACCEPT every HARD_fail. Treat it as a creative catalyst, not a defeat.
+2. For each accepted HARD_fail, ask: "Given this is true, what NEW possibility opens up
+   that I couldn't see before?" If a genuinely new possibility emerges, put it in
+   `reframed`. If none does, put it in `accepted` with an honest `terminal_rationale`.
+3. For SOFT_disputed entries, you MAY DISPUTE — but only if disputing opens a richer path,
+   not to win an argument.
+
+For EACH path, append a fenced JSON block labeled with a heading:
+
+### PATH_CONTRACT_DIFF (path_1)
+```json
+{{
+  "path_id": "path_1",
+  "accepted": [
+    {{"invariant": "halting", "rationale": "...", "terminal_rationale": "<only when accepting a HARD_fail with no creative reframe>"}}
+  ],
+  "disputed": [
+    {{"invariant": "single_wall_coherence", "rationale": "why this SOFT_disputed verdict opens a richer path if relaxed"}}
+  ],
+  "reframed": [
+    {{"invariant": "re_approval", "new_possibility": "the NEW possibility this constraint reveals — must be substantively different from the original path"}}
+  ]
+}}
+```
+
+If you genuinely have nothing new to add for a path, output:
+
+### PATH_CONTRACT_DIFF (path_N)
+NO_NEW_DIVERGENCE — <one sentence on why>
+
+Honesty over performative ideation.
+
+REQUIRED CONTENT RULE: For every HARD_fail invariant in Wall's verdict for a path, the
+corresponding invariant must appear in either `accepted` (with `terminal_rationale`) or
+`reframed` (with `new_possibility`). Silent omission is invalid.
+
+Then APPROVE / REJECT Door's synthesis as before:
 
 RESPONSE FORMAT:
 Start your response with exactly one of:
-- APPROVE - if the synthesis honors Wind's expansion
-- REJECT - if the synthesis fails to capture creative potential
+- APPROVE - if Door's synthesis honors Wind's expansion AND cites your diff entries
+- REJECT - if the synthesis fails to capture creative potential or ignores your reframes
 
 If you REJECT, provide specific feedback on what is missing or needs refinement.
 Door will use your feedback to create a refined synthesis.
 
-Do NOT provide new possibilities or expand the discussion.
-Your role now is to VALIDATE the synthesis from Wind's perspective.
-
 Example:
 APPROVE
 
-The synthesis successfully integrates Wind's heretical path while respecting constraints.
-The emergent capabilities enable the innovation we sought."""
+[your three PATH_CONTRACT_DIFF blocks here]
+
+The synthesis successfully integrates the reframed possibilities while respecting
+Wall's HARD constraints."""
 
 
 def format_wall_approval_prompt(topic: str, thread_id: str) -> str:

--- a/src/debate_hall_mcp/prompts/__init__.py
+++ b/src/debate_hall_mcp/prompts/__init__.py
@@ -712,9 +712,11 @@ For EACH path, append a fenced JSON block labeled with a heading:
 }}
 ```
 
-If you genuinely have nothing new to add for a path, emit a JSON-compatible sentinel
-diff with empty lists and the `divergence_marker` field set (this aligns with the
-`DiffRevision.divergence_marker` schema field in RFC-0001 §3.1):
+If a path has no HARD_fail verdicts and you genuinely have nothing new to add, emit
+a JSON-compatible sentinel diff with empty lists and the `divergence_marker` field
+set (this aligns with the `DiffRevision.divergence_marker` schema field in RFC-0001
+§3.1). The sentinel is ONLY valid when every verdict for the path is HARD_pass or
+SOFT_disputed — never when any verdict is HARD_fail.
 
 ### PATH_CONTRACT_DIFF (path_N)
 ```json
@@ -732,7 +734,11 @@ Honesty over performative ideation.
 
 REQUIRED CONTENT RULE: For every HARD_fail invariant in Wall's verdict for a path, the
 corresponding invariant must appear in either `accepted` (with `terminal_rationale`) or
-`reframed` (with `new_possibility`). Silent omission is invalid.
+`reframed` (with `new_possibility`). Silent omission is invalid. NO_NEW_DIVERGENCE is
+INVALID for HARD_fail paths — for any path with one or more HARD_fail verdicts you MUST
+produce a real diff (an `accepted` entry with `terminal_rationale` explaining why the
+failure is unreframeable, OR a `reframed` entry with `new_possibility` that addresses
+the failure). The sentinel cannot substitute for constraint-as-catalyst proof.
 
 Then APPROVE / REJECT Door's synthesis as before:
 

--- a/src/debate_hall_mcp/prompts/__init__.py
+++ b/src/debate_hall_mcp/prompts/__init__.py
@@ -577,26 +577,84 @@ As Door, you bring LOGOS - convergent integration and structural synthesis:
 Do NOT simply average or compromise between positions.
 Your role is to INTEGRATE and create something that honors both while transcending the apparent conflict.
 
-[RFC-0001 — path_contract citation rule]
-Wind has emitted PATH_CONTRACT_FRAME blocks; Wall has emitted PATH_CONTRACT_VERDICT blocks;
-in the consensus phase Wind will emit PATH_CONTRACT_DIFF blocks containing accepted /
-disputed / reframed entries.
+[RFC-0001 — path_contract awareness, INITIAL synthesis]
+Wind has emitted PATH_CONTRACT_FRAME blocks; Wall has emitted PATH_CONTRACT_VERDICT blocks.
+At this initial synthesis turn, no PATH_CONTRACT_DIFF exists yet (Wind emits it later in the
+consensus phase). Read FRAME and VERDICT for context, but DO NOT cite or invent
+`accepted`/`disputed`/`reframed` entries — those become available only in the consensus
+refinement turn, where a separate synthesis prompt enforces the citation rule.
 
-Your synthesis must cite EVERY non-empty category (accepted / disputed / reframed) across
-the paths' contracts. If a category is empty for all paths, do NOT invent entries —
-instead briefly note its absence (e.g. "no constraints disputed; Wind accepted Wall's
-verdict in full").
+Respond using the OCTAVE response format defined in your system prompt."""
 
-Additional rule: when any path has a HARD_fail verdict in Wall's output, your synthesis
-must cite, for that path, EITHER a `reframed` entry that addresses the failure OR an
-`accepted` entry whose rationale explains why the failure is unreframeable. Silent
-omission is invalid — this is the constraint-as-catalyst proof.
+
+def format_door_consensus_prompt(
+    topic: str, thread_id: str, rejector: str, feedback: str | None
+) -> str:
+    """Format user prompt for Door (LOGOS) refinement in the CONSENSUS phase.
+
+    This is the consensus-phase Door synthesis prompt. Unlike
+    ``format_door_user_prompt`` (which produces the INITIAL synthesis before any
+    PATH_CONTRACT_DIFF exists), this prompt fires after Wind has emitted
+    PATH_CONTRACT_DIFF blocks during consensus review. It carries the full
+    RFC-0001 path_contract citation rule:
+
+    - cite every non-empty category (accepted / disputed / reframed) across paths
+    - when any path has HARD_fail, cite either a `reframed` entry or an
+      `accepted` entry whose `terminal_rationale` explains unreframeability
+    - reference contract entries inline as ``[path_N.accepted: <invariant>]``,
+      ``[path_N.disputed: <invariant>]``, ``[path_N.reframed: <invariant>]``
+
+    Args:
+        topic: The debate topic being synthesized
+        thread_id: Thread ID for state access (VTP)
+        rejector: The role that rejected (Wind or Wall)
+        feedback: Feedback from the rejector (may be None)
+
+    Returns:
+        Formatted user prompt for Door's consensus-phase refinement turn
+    """
+    feedback_text = feedback if feedback else "No specific feedback provided."
+    return f"""You are participating in a Wind/Wall/Door debate REFINEMENT PHASE (consensus).
+
+Topic: {topic}
+Thread ID: {thread_id}
+Your Role: Door (LOGOS) - Synthesis Refiner
+
+The current debate state is provided above in <DEBATE_STATE> tags.
+
+{rejector} has REJECTED your synthesis with the following feedback:
+{feedback_text}
+
+Your task: Refine your synthesis to address {rejector}'s concerns.
+
+As Door (LOGOS), create a refined synthesis that:
+- Addresses the specific feedback from {rejector}
+- Maintains integration of Wind's possibilities and Wall's constraints
+- Demonstrates how this refinement improves the emergent solution
+- Preserves concrete, actionable implementation steps
+
+[RFC-0001 — path_contract citation rule, CONSENSUS phase]
+Wind has now emitted PATH_CONTRACT_DIFF blocks containing accepted / disputed /
+reframed entries (in addition to the earlier PATH_CONTRACT_FRAME and PATH_CONTRACT_VERDICT
+blocks). Your refined synthesis must cite EVERY non-empty category (accepted /
+disputed / reframed) across the paths' contracts. If a category is empty for all
+paths, do NOT invent entries — instead briefly note its absence (e.g. "no constraints
+disputed; Wind accepted Wall's verdict in full").
+
+Additional rule: when any path has a HARD_fail verdict in Wall's output, your
+synthesis must cite, for that path, EITHER a `reframed` entry that addresses the
+failure OR an `accepted` entry whose `terminal_rationale` explains why the failure
+is unreframeable. Silent omission is invalid — this is the constraint-as-catalyst proof.
 
 Reference contract entries explicitly in your synthesis text using the form
 `[path_N.accepted: <invariant>]`, `[path_N.disputed: <invariant>]`, or
 `[path_N.reframed: <invariant>]` so a reader can verify the citation.
 
-Respond using the OCTAVE response format defined in your system prompt."""
+If a path's PATH_CONTRACT_DIFF carries `divergence_marker: NO_NEW_DIVERGENCE`,
+acknowledge it explicitly (e.g. "path_N had no new divergence; original frame stands")
+rather than fabricating citations for empty categories.
+
+Respond with your refined synthesis using the OCTAVE response format."""
 
 
 def format_wind_approval_prompt(topic: str, thread_id: str) -> str:
@@ -654,10 +712,21 @@ For EACH path, append a fenced JSON block labeled with a heading:
 }}
 ```
 
-If you genuinely have nothing new to add for a path, output:
+If you genuinely have nothing new to add for a path, emit a JSON-compatible sentinel
+diff with empty lists and the `divergence_marker` field set (this aligns with the
+`DiffRevision.divergence_marker` schema field in RFC-0001 §3.1):
 
 ### PATH_CONTRACT_DIFF (path_N)
-NO_NEW_DIVERGENCE — <one sentence on why>
+```json
+{{
+  "path_id": "path_N",
+  "accepted": [],
+  "disputed": [],
+  "reframed": [],
+  "divergence_marker": "NO_NEW_DIVERGENCE",
+  "rationale": "<one sentence on why no new possibility opens>"
+}}
+```
 
 Honesty over performative ideation.
 

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -162,6 +162,36 @@ class TestDoorUserPrompt:
         assert len(prompt) > 100
 
 
+class TestInitialDoorOmitsPathContractCitation:
+    """RFC-0001 Fix 4: the INITIAL Door synthesis prompt MUST NOT mandate citation
+    of PATH_CONTRACT_DIFF entries — those entries do not exist yet at the initial
+    Door turn (Wind emits PATH_CONTRACT_DIFF only in the consensus phase). This
+    test guards against the prior bug where the initial prompt forced fabrication.
+    """
+
+    def test_initial_door_prompt_does_not_demand_path_contract_diff_citation(self) -> None:
+        """Initial Door prompt MUST NOT mandate citation of PATH_CONTRACT_DIFF entries.
+
+        The prompt MAY mention PATH_CONTRACT_DIFF to explain that it does not exist
+        yet (educational), but it MUST NOT carry the citation syntax or the
+        accepted/disputed/reframed mandate that forces fabrication.
+        """
+        prompt = format_door_user_prompt(topic="Test", thread_id="2026-01-30-test")
+        # The citation syntax for diff entries belongs only to the consensus prompt.
+        assert "[path_N.accepted:" not in prompt
+        assert "[path_N.disputed:" not in prompt
+        assert "[path_N.reframed:" not in prompt
+        # And the explicit "must cite EVERY non-empty category" mandate must be absent.
+        assert "must cite EVERY non-empty category" not in prompt
+        assert "must cite, for that path" not in prompt
+
+    def test_initial_door_prompt_still_acknowledges_frame_and_verdict(self) -> None:
+        """Initial Door prompt should still note that FRAME and VERDICT exist (those are emitted by turn 1 / turn 2)."""
+        prompt = format_door_user_prompt(topic="Test", thread_id="2026-01-30-test")
+        assert "PATH_CONTRACT_FRAME" in prompt
+        assert "PATH_CONTRACT_VERDICT" in prompt
+
+
 class TestPromptConsistency:
     """Tests for consistency across all prompt functions."""
 

--- a/tests/unit/test_prompts_consensus.py
+++ b/tests/unit/test_prompts_consensus.py
@@ -11,7 +11,10 @@ the prompt via <DEBATE_STATE> tags. Agents receive state passively instead
 of needing to call get_debate() themselves.
 """
 
+import json
+
 from debate_hall_mcp.prompts import (
+    format_door_consensus_prompt,
     format_wall_approval_prompt,
     format_wind_approval_prompt,
 )
@@ -115,3 +118,106 @@ class TestPromptsDifferentiate:
         wind_prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
         wall_prompt = format_wall_approval_prompt(topic="Test", thread_id="2026-01-30-test")
         assert wind_prompt != wall_prompt
+
+
+class TestConsensusDoorCarriesPathContractCitation:
+    """RFC-0001 Fix 4: the CONSENSUS-phase Door prompt MUST carry the citation
+    rule for PATH_CONTRACT_DIFF entries (accepted/disputed/reframed). This is the
+    counterpart to TestInitialDoorOmitsPathContractCitation in test_prompts.py.
+    """
+
+    def test_consensus_door_prompt_demands_path_contract_diff_citation(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="Test", thread_id="2026-01-30-test", rejector="Wind", feedback="needs more rigor"
+        )
+        assert "PATH_CONTRACT_DIFF" in prompt
+        assert "accepted" in prompt
+        assert "disputed" in prompt
+        assert "reframed" in prompt
+
+    def test_consensus_door_prompt_includes_citation_syntax_example(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="Test", thread_id="2026-01-30-test", rejector="Wall", feedback=None
+        )
+        # The bracketed citation syntax that lets a reader verify each claim.
+        assert "[path_N.accepted:" in prompt
+        assert "[path_N.disputed:" in prompt
+        assert "[path_N.reframed:" in prompt
+
+    def test_consensus_door_prompt_enforces_hard_fail_rule(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="Test", thread_id="2026-01-30-test", rejector="Wind", feedback="x"
+        )
+        # The constraint-as-catalyst proof obligation.
+        assert "HARD_fail" in prompt
+        assert "terminal_rationale" in prompt
+
+    def test_consensus_door_prompt_includes_topic_thread_and_feedback(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="Governance",
+            thread_id="2026-01-30-gov",
+            rejector="Wall",
+            feedback="risk surface incomplete",
+        )
+        assert "Governance" in prompt
+        assert "2026-01-30-gov" in prompt
+        assert "Wall" in prompt
+        assert "risk surface incomplete" in prompt
+
+    def test_consensus_door_prompt_handles_none_feedback(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="Test", thread_id="2026-01-30-test", rejector="Wind", feedback=None
+        )
+        assert "No specific feedback provided." in prompt
+
+    def test_consensus_door_prompt_acknowledges_divergence_marker(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="Test", thread_id="2026-01-30-test", rejector="Wind", feedback=None
+        )
+        # Door must know how to react to NO_NEW_DIVERGENCE rather than fabricating citations.
+        assert "NO_NEW_DIVERGENCE" in prompt
+        assert "divergence_marker" in prompt
+
+
+class TestWindConsensusSentinelIsJsonCompatible:
+    """RFC-0001 Fix 3: the NO_NEW_DIVERGENCE sentinel must be emitted in a
+    JSON-compatible form so it does not collide with the JSON path_contract.diff
+    output mandated elsewhere in the prompt. The schema-level signal is the
+    `divergence_marker` field on `DiffRevision` (RFC §3.1).
+    """
+
+    def test_wind_consensus_prompt_emits_sentinel_inside_json(self) -> None:
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        # The schema field carries the sentinel; raw NO_NEW_DIVERGENCE without JSON
+        # framing is the bug being fixed.
+        assert "divergence_marker" in prompt
+        assert "NO_NEW_DIVERGENCE" in prompt
+
+    def test_wind_consensus_prompt_sentinel_block_parses_as_json(self) -> None:
+        """The example sentinel block in the prompt must be valid JSON when
+        extracted (after str.format brace-escaping is applied)."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        # Locate a JSON object containing divergence_marker and ensure it parses.
+        # The prompt embeds the example with literal braces (already unescaped by f-string).
+        marker_idx = prompt.find('"divergence_marker"')
+        assert marker_idx != -1, "divergence_marker example missing from prompt"
+        # Walk back to the nearest '{' and forward to its matching '}' to extract the object.
+        start = prompt.rfind("{", 0, marker_idx)
+        depth = 0
+        end = -1
+        for i in range(start, len(prompt)):
+            ch = prompt[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        assert end != -1, "could not find balanced JSON object around divergence_marker"
+        snippet = prompt[start:end]
+        parsed = json.loads(snippet)
+        assert parsed["divergence_marker"] == "NO_NEW_DIVERGENCE"
+        assert parsed["accepted"] == []
+        assert parsed["disputed"] == []
+        assert parsed["reframed"] == []

--- a/tests/unit/test_prompts_consensus.py
+++ b/tests/unit/test_prompts_consensus.py
@@ -221,3 +221,28 @@ class TestWindConsensusSentinelIsJsonCompatible:
         assert parsed["accepted"] == []
         assert parsed["disputed"] == []
         assert parsed["reframed"] == []
+
+
+class TestWindConsensusSentinelGatedOnHardFail:
+    """RFC-0001 follow-up: Wind's NO_NEW_DIVERGENCE sentinel must be gated on
+    the absence of HARD_fail verdicts for the path. Otherwise it conflicts with
+    Door's HARD_fail coverage rule (Door cannot cite a reframed/accepted entry
+    that does not exist), violating the constraint-as-catalyst proof.
+    """
+
+    def test_wind_consensus_prompt_gates_sentinel_on_no_hard_fail(self) -> None:
+        """Sentinel instruction must explicitly require zero HARD_fail verdicts."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        # The precondition language must be present in some form.
+        assert (
+            "no HARD_fail" in prompt
+        ), "Sentinel instruction must gate NO_NEW_DIVERGENCE on absence of HARD_fail verdicts"
+
+    def test_wind_consensus_prompt_forbids_sentinel_on_hard_fail_paths(self) -> None:
+        """Prompt must explicitly state that NO_NEW_DIVERGENCE is invalid for
+        any path with one or more HARD_fail verdicts."""
+        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        # The counterpart prohibition must be present.
+        assert (
+            "INVALID for HARD_fail paths" in prompt
+        ), "Prompt must explicitly mark NO_NEW_DIVERGENCE as INVALID for HARD_fail paths"


### PR DESCRIPTION
## Summary

Implements the `path_contract` design from RFC-0001, enabling Wind to refine ideas in response to Wall's critique within validated boundaries. This adds structured metadata fields to debate state and updates prompts to guide agents through a constraint-as-catalyst workflow, without changing orchestrator phases or turn types.

## Key Changes

### Prompt Updates (`src/debate_hall_mcp/prompts/__init__.py`)

- **Wind initial prompt**: Added instruction to emit `PATH_CONTRACT_FRAME` JSON blocks for each path, capturing `assumed_problem`, `success_criterion`, `accepted_failure_mode`, and `hard_invariants_touched` (closed enum: halting, single_wall_coherence, re_approval, per_turn_role_contract).

- **Wall prompt**: Added instruction to emit `PATH_CONTRACT_VERDICT` JSON blocks scoring each invariant Wind flagged with status (HARD_pass / HARD_fail / SOFT_disputed) and rationale.

- **Wind consensus prompt** (critical change): Replaced "do NOT provide new possibilities" instruction with explicit constraint-as-catalyst guidance:
  - Accept HARD_fail verdicts as creative catalysts
  - For each HARD_fail, ask "what new possibility opens up?"
  - Emit `PATH_CONTRACT_DIFF` blocks with `accepted` / `disputed` / `reframed` entries keyed to Wall's verdicts
  - Enforce required content rule: every HARD_fail must appear in either `accepted` (with `terminal_rationale`) or `reframed` (with `new_possibility`)
  - Allow honest `NO_NEW_DIVERGENCE` when no reframe exists

- **Door synthesis prompt**: Added citation rule requiring Door to reference every non-empty contract category and cite either a `reframed` entry or `accepted` entry with `terminal_rationale` for each HARD_fail verdict.

### Documentation

- **RFC-0001 (path_contract)**: Complete specification including schema (TypedDict definitions for PathFrame, InvariantVerdict, PathDiff, and append-only revision wrappers), lifecycle, ownership rules, A/B test design, and decision log.

- **RFC-0001 Simulation Harness**: Pre-build gate template for no-code prompt validation on 5 historical debates before orchestrator implementation begins. Pass criteria: ≥4/5 debates produce substantively novel reframes that engage Wall verdicts.

- **Decision Governance Synthesis** (`debates/2026-04-28-decision-governance-synthesis.oct.md`): Example debate synthesis in OCTAVE format demonstrating the tiered governance model (Architectural / Convention / Micro) that motivated the path_contract design.

- **Mythology Assessment** (`debates/2026-02-22-mythology-in-octave-assessment.oct.md`): Canonical debate transcript showing Wind/Wall/Door structure for extraction into simulation harness test cases.

### Configuration

- Updated `.gitignore` to exclude debate state files (`.json`, `.jsonl`, `.lock`, `.events.jsonl`) at all nesting levels under `debates/`.

## Implementation Notes

- **No orchestrator changes in this PR**: The schema and prompts are additive; the consensus loop state machine remains unchanged. Orchestrator validation, storage, and feature-flag integration are deferred to follow-up issues (#196–#205).

- **Append-only design**: Contract fields are write-once per role per turn, with full revision history preserved for provenance. Ownership is enforced by prompt instruction (v1) and will be validated by orchestrator in v2.

- **Closed enum for invariants**: `hard_invariants_touched` uses only the four predefined values to lock Wind and Wall into a shared vocabulary and enable structured Wall verdicts.

- **Simulation harness as gate**: The RFC includes a detailed template for human-in-the-loop testing of the new Wind-consensus and Door-synthesis prompts on real historical debates before any code changes. This validates prompt design before implementation risk.

## Related Issues

- Tracking: #195 (parent) — sub-issues #196–#205 (orchestrator, validation, storage, feature flag)
- Gated by: Simulation harness pass criteria (≥4/5 debates show constraint-

https://claude.ai/code/session_018g6fPjUhH7YJPjWXQ9Kuxz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements RFC‑0001 `path_contract` so Wind can refine ideas against Wall’s critique using structured JSON, and moves Door’s citation rule to the consensus phase. Adds docs and a paste‑and‑run simulation harness; minimal orchestrator wiring only. Tracks to #195 and sub‑issues #196–#205.

- **New Features**
  - Prompts now emit/consume `PATH_CONTRACT_FRAME`, `PATH_CONTRACT_VERDICT`, and `PATH_CONTRACT_DIFF`; Wind must cover every `HARD_fail` via `accepted` (with `terminal_rationale`) or `reframed` (with `new_possibility`), and may use `divergence_marker: "NO_NEW_DIVERGENCE"` only when a path has no `HARD_fail`.
  - Added consensus‑phase Door prompt (`format_door_consensus_prompt`) that cites non‑empty `accepted`/`disputed`/`reframed` and requires reframe‑or‑terminal coverage when `HARD_fail` exists; the initial Door prompt now reads only FRAME/VERDICT.
  - Orchestrator: `_create_refinement_prompt` delegates to `format_door_consensus_prompt`; no phase or state‑machine changes. Docs include RFC‑0001 and a 5‑debate simulation harness; two debate synthesis files added. `.gitignore` ignores nested `debates/**` JSON state files.

- **Bug Fixes**
  - Removed premature `PATH_CONTRACT_DIFF` citation from the initial Door prompt; added tests to enforce prompt boundaries and JSON‑valid Wind sentinel blocks.
  - Fixed literal heading guidance for Wall verdict blocks (`PATH_CONTRACT_VERDICT (path_N)`).
  - Gated `NO_NEW_DIVERGENCE` on the absence of `HARD_fail` verdicts in prompts and tests.
  - Corrected a debate transcript to use repo‑relative references in §9.

<sup>Written for commit 3563fc75c921aae5d0bdca5676e27bd74fcd9590. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

