### PR TITLE
docs(rfc-0001): ratify and align simulation-harness with HARD_fail gate

### DIFF
--- a/docs/rfc-0001-path-contract-wind-learning-loop.md
+++ b/docs/rfc-0001-path-contract-wind-learning-loop.md
@@ -1,8 +1,8 @@
 # RFC-0001: `path_contract` — Iterative Wind Learning Loop
 
-**Status**: Proposed (awaiting decision)
-**Date**: 2026-05-02
-**Branch**: `claude/review-debate-agent-flow-DzSFX`
+**Status**: Ratified (2026-05-07)
+**Date**: 2026-05-02 (proposed); 2026-05-07 (ratified)
+**Ratification**: Approved on PR #212 by CE/CRS/SR/TMG at HEAD `3563fc7`; merged to main as `1dc1c57`. Implementation deferred to issues #196–#205 (validator, storage, feature flag, A/B harness).
 **Tracking**: [#195](https://github.com/elevanaltd/debate-hall-mcp/issues/195) (parent) — sub-issues [#196](https://github.com/elevanaltd/debate-hall-mcp/issues/196)–[#205](https://github.com/elevanaltd/debate-hall-mcp/issues/205)
 **Author**: Generated via meta-debate (Wind→Wall→Wind-Revise→Door) on the question itself
 

--- a/docs/rfc-0001-simulation-harness.md
+++ b/docs/rfc-0001-simulation-harness.md
@@ -94,7 +94,9 @@ Five sections, one per debate. Each has:
 > 2. For each accepted HARD_fail, ask: "Given this is true, what new possibility opens up that I couldn't see before?"
 > 3. For SOFT_disputed entries, you may DISPUTE — but only if disputing opens a richer path.
 > 4. Emit `path_contract.diff` for each path: `{accepted: [...], disputed: [...], reframed: [...]}`, keyed to Wall's verdict entries by invariant name.
-> 5. If you genuinely have nothing new to add for a path, emit a JSON-compatible sentinel diff with empty lists and the `divergence_marker` field set: `{"path_id": "path_N", "accepted": [], "disputed": [], "reframed": [], "divergence_marker": "NO_NEW_DIVERGENCE"}`. Honesty over performative ideation. (The `divergence_marker` field on `DiffRevision` is the schema-level signal; see RFC §3.1.)
+> 5. If a path has **no HARD_fail verdicts** and you genuinely have nothing new to add, emit a JSON-compatible sentinel diff with empty lists and the `divergence_marker` field set: `{"path_id": "path_N", "accepted": [], "disputed": [], "reframed": [], "divergence_marker": "NO_NEW_DIVERGENCE"}`. Honesty over performative ideation. (The `divergence_marker` field on `DiffRevision` is the schema-level signal; see RFC §3.1.)
+>
+> **REQUIRED CONTENT RULE**: For any path with one or more `HARD_fail` verdicts, `NO_NEW_DIVERGENCE` is INVALID. You MUST produce a real diff — either an `accepted` entry with `terminal_rationale` explaining why the failure is unreframeable, OR a `reframed` entry with `new_possibility` that addresses the failure. The sentinel cannot substitute for constraint-as-catalyst proof on HARD_fail paths.
 
 #### Wind diff output
 


### PR DESCRIPTION
## Summary

Two small doc changes following PR #212 merge:

1. **Ratify RFC-0001** — flip `Status` to `Ratified (2026-05-07)` and add a ratification trail citing PR #212's CE/CRS/SR/TMG approvals at HEAD `3563fc7` (merged as `1dc1c57`). Implementation deferred to tracked issues #196–#205.
2. **Align simulation-harness** — update the Wind consensus prompt block in `docs/rfc-0001-simulation-harness.md` so the harness paste mirrors the live prompt contract:
   - Step 5: `NO_NEW_DIVERGENCE` sentinel now gated on "no HARD_fail verdicts".
   - New REQUIRED CONTENT RULE counterpart: sentinel is INVALID on HARD_fail paths.

This addresses CE's non-blocking follow-up from PR #212 review (https://github.com/elevanaltd/debate-hall-mcp/pull/212#issuecomment-4393241411): "align `docs/rfc-0001-simulation-harness.md` with the no-HARD_fail `NO_NEW_DIVERGENCE` rule before #204 execution."

## Test plan

- [x] `git diff --stat` confirms scope is docs-only (2 files, +6/-4)
- [ ] CI green
- [ ] Reviewer sign-off (TIER_1 self / TIER_2 standard depending on facet detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ratifies RFC-0001 and updates the simulation harness docs to enforce the HARD_fail gate on the `NO_NEW_DIVERGENCE` sentinel. Adds a ratification trail and requires a real diff when any `HARD_fail` verdict exists, aligning docs with the live prompt contract from PR #212.

<sup>Written for commit 865b2082d526c09798302ff4916a68abc422354f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

