### PR TITLE
[RFC-0001] #196 — path_contract schema + types (per amended RFC §3.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "octave-mcp>=1.9.2",  # v1.9.2: latest version with improvements
     "python-ulid>=3.0.0",  # ULID for event ordering (ADR-0002)
     "PyYAML>=6.0",  # Tier configuration loading (ADR-0002)
+    "typing_extensions>=4.12",  # Required directly: path_contract uses typing_extensions.TypedDict for Pydantic 2 runtime introspection on Python < 3.12 (PR #216)
 ]
 
 [project.optional-dependencies]

--- a/src/debate_hall_mcp/path_contract.py
+++ b/src/debate_hall_mcp/path_contract.py
@@ -1,0 +1,305 @@
+"""Path-contract schema and append-only typed wrappers (RFC-0001 §3.1).
+
+This module is intentionally type-only: it defines the data shapes Wind, Wall,
+and Door exchange via a path's contract, plus minimal JSON (de)serialisation
+helpers and a prompt-context view helper used by #198/#199/#200.
+
+Scope per RFC-0001 #196:
+
+* Schema (§3.1): ``Invariant = str`` (open set; Wall-discipline naming convention
+  per Finding A), TypedDicts for ``PathFrame`` / ``InvariantVerdict`` /
+  ``PathDiff`` / ``InvariantEntry``, and append-only ``FrameRevision`` /
+  ``VerdictRevision`` / ``DiffRevision`` wrappers carrying Wind/Wall ownership
+  ``Literal``s. Door is read-only and has no revision wrapper.
+* Findings (§3.3): ``DiffRevision.divergence_marker`` (Finding D) and
+  ``DiffRevision.synthesis_guidance`` (Finding E) as ``NotRequired`` slots.
+  ``NO_NEW_DIVERGENCE`` may coexist with a non-empty ``disputed`` list.
+* Helpers: ``new_path_contract``, ``path_contract_to_json`` /
+  ``path_contract_from_json``, and ``prompt_context_view``.
+
+Out of scope (deliberately not implemented here):
+
+* Validator behaviour — REQUIRED CONTENT RULE, ownership enforcement, sentinel
+  legality — belongs to #200.
+* State persistence integration belongs to #197.
+* Prompt edits belong to #198.
+* Feature flag wiring belongs to #201 / #205.
+
+Wall-discipline naming convention for ``Invariant``: lowercase ``snake_case``,
+semantically distinct per orthogonal concern (e.g. ``spec_grammar_coherence``,
+``sync_api_contract``). The type system does *not* enumerate them — Wall is
+responsible for assigning distinct names per orthogonal verdict so that
+``dict[Invariant, InvariantVerdict]`` keying preserves verdict nuance.
+"""
+
+import json
+from datetime import datetime
+from typing import Any, Literal, NotRequired, TypedDict
+
+# NOTE: ``from __future__ import annotations`` is intentionally NOT used.
+# Under PEP 563 stringification, the runtime ``TypedDict`` machinery in
+# CPython 3.11 fails to detect ``NotRequired[...]`` wrappers and folds the
+# fields into ``__required_keys__``. The schema's ``NotRequired`` slots
+# (``terminal_rationale``, ``new_possibility``, ``divergence_marker``,
+# ``synthesis_guidance``) are load-bearing for the validator in #200, so we
+# evaluate annotations eagerly here.
+
+# ---------------------------------------------------------------------------
+# Open-set invariant name (RFC §3.1 / §3.3 Finding A).
+# ---------------------------------------------------------------------------
+
+Invariant = str
+"""Free-text invariant identifier (Wall-discipline naming convention).
+
+Closed-enum ``HardInvariant`` was superseded by the amended RFC (Finding A) —
+real Wall verdicts are topic-shaped, not protocol-shaped, so the type is an
+open set. Wall is responsible for assigning distinct ``snake_case`` names per
+orthogonal concern so the ``dict[Invariant, InvariantVerdict]`` keying in
+``VerdictRevision.value`` preserves verdict nuance.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Per-path frame, verdict, and diff payloads (RFC §3.1).
+# ---------------------------------------------------------------------------
+
+
+class PathFrame(TypedDict):
+    """Wind's framing of a single path (rev 0 written turn 1)."""
+
+    assumed_problem: str
+    success_criterion: str
+    accepted_failure_mode: str
+    invariants_touched: list[Invariant]
+
+
+class InvariantVerdict(TypedDict):
+    """Wall's verdict on one invariant.
+
+    ``HARD_pass`` / ``HARD_fail`` are non-negotiable; ``SOFT_disputed`` is
+    tradeable and Wind may push back on it in a subsequent diff.
+    """
+
+    status: Literal["HARD_pass", "HARD_fail", "SOFT_disputed"]
+    rationale: str
+
+
+class InvariantEntry(TypedDict):
+    """Wind's per-invariant entry inside a ``PathDiff`` bucket.
+
+    ``terminal_rationale`` is required on ``accepted`` items where the verdict
+    was ``HARD_fail`` and no creative reframe is possible (validator-enforced
+    in #200; here it is ``NotRequired`` because the same dict-shape is reused
+    for ``disputed`` and ``reframed`` buckets that do not need it).
+
+    ``new_possibility`` is required on ``reframed`` items — the
+    catalyst-opened possibility this constraint reveals.
+    """
+
+    invariant: Invariant
+    rationale: str
+    terminal_rationale: NotRequired[str]
+    new_possibility: NotRequired[str]
+
+
+class PathDiff(TypedDict):
+    """Wind's consensus-turn diff against Wall's latest verdict revision."""
+
+    accepted: list[InvariantEntry]
+    disputed: list[InvariantEntry]
+    reframed: list[InvariantEntry]
+
+
+# ---------------------------------------------------------------------------
+# Append-only revision wrappers (RFC §3.1).
+#
+# Ownership ``Literal``s carry the role discipline at the type level so the
+# runtime validator in #200 can reject a write from a non-owning role.
+# Door is read-only — there is intentionally no ``DoorRevision``.
+# ---------------------------------------------------------------------------
+
+
+class FrameRevision(TypedDict):
+    """Append-only frame revision; only Wind may write."""
+
+    rev: int
+    written_at: datetime
+    written_by: Literal["Wind"]
+    value: PathFrame
+
+
+class VerdictRevision(TypedDict):
+    """Append-only verdict revision; only Wall may write."""
+
+    rev: int
+    written_at: datetime
+    written_by: Literal["Wall"]
+    value: dict[Invariant, InvariantVerdict]
+
+
+class DiffRevision(TypedDict):
+    """Append-only consensus-phase diff; only Wind may write.
+
+    ``divergence_marker`` (Finding D) is a sentinel for paths where Wind has
+    no new catalyst content to add. It is legal only when every invariant
+    verdict for the path is ``HARD_pass`` or ``SOFT_disputed``; the sentinel
+    *may* coexist with a non-empty ``value.disputed`` list when Wind has
+    legitimate pushback on ``SOFT_disputed`` verdicts.
+
+    ``synthesis_guidance`` (Finding E) is free-text cross-path / synthesis-level
+    insight that does not fit any per-path entry. Door's citation rule (§5.4)
+    requires explicit citation when present. Both fields are validator-checked
+    in #200; here they are merely typed.
+    """
+
+    rev: int
+    written_at: datetime
+    written_by: Literal["Wind"]
+    value: PathDiff
+    divergence_marker: NotRequired[Literal["NO_NEW_DIVERGENCE"]]
+    synthesis_guidance: NotRequired[str]
+
+
+# ---------------------------------------------------------------------------
+# Top-level container (RFC §3.1).
+# ---------------------------------------------------------------------------
+
+
+class PathContract(TypedDict):
+    """Per-path append-only contract: identity plus three revision histories."""
+
+    path_id: str
+    frame_history: list[FrameRevision]
+    verdict_history: list[VerdictRevision]
+    diff_history: list[DiffRevision]
+
+
+# ---------------------------------------------------------------------------
+# Constructor / factory helper.
+# ---------------------------------------------------------------------------
+
+
+def new_path_contract(path_id: str) -> PathContract:
+    """Return an empty, valid ``PathContract`` for ``path_id``.
+
+    Histories default to empty lists so existing call sites that read the
+    contract before Wind writes rev 0 do not crash.
+    """
+    return PathContract(
+        path_id=path_id,
+        frame_history=[],
+        verdict_history=[],
+        diff_history=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON (de)serialisation helpers.
+#
+# Storage layer (#197) needs a stable wire format; the round-trip must
+# preserve absence of ``NotRequired`` keys (do not coerce missing keys to
+# ``None``). ``datetime`` objects are serialised as ISO-8601 strings and
+# restored on read.
+# ---------------------------------------------------------------------------
+
+
+def _encode(obj: Any) -> Any:
+    """Recursively convert ``datetime`` instances to ISO-8601 strings."""
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, dict):
+        return {k: _encode(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_encode(item) for item in obj]
+    return obj
+
+
+def _decode_revision(rev: dict[str, Any]) -> dict[str, Any]:
+    """Restore the ``written_at`` ISO string on a revision dict to a datetime."""
+    if "written_at" in rev and isinstance(rev["written_at"], str):
+        rev["written_at"] = datetime.fromisoformat(rev["written_at"])
+    return rev
+
+
+def path_contract_to_json(contract: PathContract) -> str:
+    """Serialise a ``PathContract`` to a JSON string.
+
+    ``datetime`` objects are encoded as ISO-8601. ``NotRequired`` keys that
+    are absent on the input remain absent in the output.
+    """
+    return json.dumps(_encode(contract))
+
+
+def path_contract_from_json(payload: str) -> PathContract:
+    """Deserialise the JSON produced by :func:`path_contract_to_json`.
+
+    Restores ``datetime`` instances on every revision in every history. Keys
+    that were absent on the source object remain absent on the result.
+    """
+    raw: dict[str, Any] = json.loads(payload)
+    for key in ("frame_history", "verdict_history", "diff_history"):
+        history = raw.get(key, [])
+        for rev in history:
+            _decode_revision(rev)
+    return raw  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Prompt-context view helper.
+#
+# Per RFC §3.1: each role sees the *latest* revision per field plus the
+# revision count (so the agent knows "this is Wall's Nth verdict, after
+# Wind's reframe"). Full history is stored but not blasted into every prompt
+# (token discipline). #199 owns the integration into the orchestrator's
+# prompt context block; this helper provides the contract's view-shape.
+# ---------------------------------------------------------------------------
+
+
+class PromptContextView(TypedDict):
+    """Latest-revision-only view of a ``PathContract`` for prompt context."""
+
+    path_id: str
+    latest_frame: FrameRevision | None
+    latest_verdict: VerdictRevision | None
+    latest_diff: DiffRevision | None
+    frame_count: int
+    verdict_count: int
+    diff_count: int
+
+
+def prompt_context_view(contract: PathContract) -> PromptContextView:
+    """Project a ``PathContract`` to its prompt-context view.
+
+    Empty histories are handled safely: ``latest_*`` are ``None`` and the
+    corresponding ``*_count`` is ``0``.
+    """
+    frame_history = contract["frame_history"]
+    verdict_history = contract["verdict_history"]
+    diff_history = contract["diff_history"]
+    return PromptContextView(
+        path_id=contract["path_id"],
+        latest_frame=frame_history[-1] if frame_history else None,
+        latest_verdict=verdict_history[-1] if verdict_history else None,
+        latest_diff=diff_history[-1] if diff_history else None,
+        frame_count=len(frame_history),
+        verdict_count=len(verdict_history),
+        diff_count=len(diff_history),
+    )
+
+
+__all__ = [
+    "DiffRevision",
+    "FrameRevision",
+    "Invariant",
+    "InvariantEntry",
+    "InvariantVerdict",
+    "PathContract",
+    "PathDiff",
+    "PathFrame",
+    "PromptContextView",
+    "VerdictRevision",
+    "new_path_contract",
+    "path_contract_from_json",
+    "path_contract_to_json",
+    "prompt_context_view",
+]

--- a/src/debate_hall_mcp/path_contract.py
+++ b/src/debate_hall_mcp/path_contract.py
@@ -34,7 +34,13 @@ responsible for assigning distinct names per orthogonal verdict so that
 
 import json
 from datetime import datetime
-from typing import Any, Literal, NotRequired, TypedDict
+from typing import Any, Literal
+
+# NOTE: ``TypedDict`` / ``NotRequired`` are imported from ``typing_extensions``
+# (not ``typing``) because Pydantic 2 on Python < 3.12 requires the
+# ``typing_extensions`` variant for runtime introspection — see the longer
+# comment block below for the full rationale.
+from typing_extensions import NotRequired, TypedDict  # noqa: UP035
 
 # NOTE: ``from __future__ import annotations`` is intentionally NOT used.
 # Under PEP 563 stringification, the runtime ``TypedDict`` machinery in
@@ -43,6 +49,13 @@ from typing import Any, Literal, NotRequired, TypedDict
 # (``terminal_rationale``, ``new_possibility``, ``divergence_marker``,
 # ``synthesis_guidance``) are load-bearing for the validator in #200, so we
 # evaluate annotations eagerly here.
+#
+# NOTE: ``TypedDict`` and ``NotRequired`` are imported from ``typing_extensions``
+# (not ``typing``) because Pydantic 2 on Python < 3.12 requires the
+# ``typing_extensions`` variant for runtime introspection — ``TypeAdapter(...)``
+# raises ``PydanticUserError`` (see https://errors.pydantic.dev/2.12/u/typed-dict-version)
+# when given a ``typing.TypedDict``. This module's TypedDicts are consumed by
+# #197 state serialisation via Pydantic, so the source must be ``typing_extensions``.
 
 # ---------------------------------------------------------------------------
 # Open-set invariant name (RFC §3.1 / §3.3 Finding A).
@@ -235,6 +248,37 @@ def path_contract_from_json(payload: str) -> PathContract:
 
     Restores ``datetime`` instances on every revision in every history. Keys
     that were absent on the source object remain absent on the result.
+
+    BOUNDARY (deliberate non-validation):
+
+    This function performs JSON deserialisation and ``datetime`` conversion
+    ONLY. It does NOT validate the structural correctness of the resulting
+    ``PathContract``. Specifically, it does NOT check that:
+
+    * ``frame_history`` / ``verdict_history`` / ``diff_history`` are lists,
+    * revisions are monotonically ordered by ``rev``,
+    * ``written_by`` respects the ownership ``Literal`` for the revision kind
+      (``Wind`` for frame/diff, ``Wall`` for verdict),
+    * ``status`` values inside ``InvariantVerdict`` are members of the closed
+      ``Literal["HARD_pass", "HARD_fail", "SOFT_disputed"]``,
+    * the ``NO_NEW_DIVERGENCE`` sentinel co-occurs only with legal verdict
+      states (see RFC-0001 §3.3 Finding D), or
+    * ``terminal_rationale`` / ``new_possibility`` are present where
+      ``InvariantEntry`` semantics require them.
+
+    Per RFC-0001 §6, all such schema-shape violations are enforced as
+    ``VALIDATOR_FAILURE`` events by the orchestrator validator (#200), not
+    here. The same separation-of-concerns rationale that keeps
+    ``from __future__ import annotations`` out of this module (see the
+    module-level note above) keeps validation logic out as well: this module
+    is the wire-format I/O boundary; #200 is the policy boundary.
+
+    Callers MUST NOT treat the return value as a validated contract — it is
+    structurally typed for the type checker but is not runtime-checked. Pass
+    the result through the #200 validator before relying on any invariant
+    that is not encoded in the JSON wire format itself (i.e. anything beyond
+    "this parsed as JSON and any ``written_at`` strings decoded as ISO-8601
+    datetimes").
     """
     raw: dict[str, Any] = json.loads(payload)
     for key in ("frame_history", "verdict_history", "diff_history"):

--- a/tests/unit/test_path_contract_schema.py
+++ b/tests/unit/test_path_contract_schema.py
@@ -1,0 +1,388 @@
+"""Unit tests for ``debate_hall_mcp.path_contract`` (RFC-0001 #196).
+
+Acceptance derived from the AMENDED RFC (2026-05-16) — specifically:
+
+- §3.1 Schema: ``Invariant = str`` (open-set, Wall-discipline naming), TypedDicts
+  ``PathFrame``, ``InvariantVerdict``, ``PathDiff``, ``InvariantEntry``.
+- §3.1 Append-only wrappers: ``FrameRevision`` / ``VerdictRevision`` / ``DiffRevision``
+  with ownership ``Literal``s (Wind / Wall / Wind respectively); Door is read-only.
+- §3.1 ``DiffRevision`` carries ``divergence_marker`` (Finding D) **and**
+  ``synthesis_guidance`` (Finding E) as ``NotRequired`` slots.
+- §3.1 ``InvariantEntry`` carries ``terminal_rationale`` and ``new_possibility`` as
+  ``NotRequired`` slots (semantic enforcement is #200's job; #196 defines the types
+  that *enable* it).
+- §3.1 ``PathContract`` exposes ``path_id`` plus three append-only history lists.
+- Briefing: helper exposing the prompt-context view (latest revision + revision
+  count per field, NOT full history) — signature must be present even if the
+  implementation is minimal.
+
+This PR explicitly does **not** implement validator behaviour (#200), prompt edits
+(#198), state serialization (#197), feature flags (#201), or the features wrapper
+(#205). Tests here cover *only* the type-level guarantees and JSON round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import get_args, get_type_hints
+
+import pytest
+
+# -- Module presence ---------------------------------------------------------
+
+
+def test_module_importable() -> None:
+    """The new module must be importable from the package root."""
+    import debate_hall_mcp.path_contract  # noqa: F401
+
+
+# -- Open-set Invariant alias (Finding A) ------------------------------------
+
+
+def test_invariant_is_open_set_str_alias() -> None:
+    """RFC §3.1 / §3.3 Finding A: ``Invariant`` MUST be ``str`` (open set).
+
+    The previous closed-enum decision (RFC §8 row 1) was superseded
+    2026-05-16. Wall is responsible for distinct snake_case names per
+    orthogonal concern; the type system does not enumerate them.
+    """
+    from debate_hall_mcp.path_contract import Invariant
+
+    # The alias resolves to the built-in ``str`` type (or is `str` itself).
+    assert Invariant is str
+
+
+# -- TypedDict required keys -------------------------------------------------
+
+
+def test_path_frame_required_keys() -> None:
+    """RFC §3.1: PathFrame required keys."""
+    from debate_hall_mcp.path_contract import PathFrame
+
+    required = set(PathFrame.__required_keys__)
+    assert required == {
+        "assumed_problem",
+        "success_criterion",
+        "accepted_failure_mode",
+        "invariants_touched",
+    }
+    assert PathFrame.__optional_keys__ == frozenset()
+
+
+def test_invariant_verdict_shape() -> None:
+    """RFC §3.1: InvariantVerdict status Literal + rationale."""
+    from debate_hall_mcp.path_contract import InvariantVerdict
+
+    required = set(InvariantVerdict.__required_keys__)
+    assert required == {"status", "rationale"}
+
+    hints = get_type_hints(InvariantVerdict)
+    status_args = set(get_args(hints["status"]))
+    assert status_args == {"HARD_pass", "HARD_fail", "SOFT_disputed"}
+
+
+def test_invariant_entry_required_and_optional_slots() -> None:
+    """RFC §3.1: InvariantEntry has invariant+rationale required; terminal_rationale
+    and new_possibility as NotRequired (semantic enforcement deferred to #200)."""
+    from debate_hall_mcp.path_contract import InvariantEntry
+
+    required = set(InvariantEntry.__required_keys__)
+    optional = set(InvariantEntry.__optional_keys__)
+    assert required == {"invariant", "rationale"}
+    assert optional == {"terminal_rationale", "new_possibility"}
+
+
+def test_path_diff_required_buckets() -> None:
+    """RFC §3.1: PathDiff has three required bucket lists."""
+    from debate_hall_mcp.path_contract import PathDiff
+
+    required = set(PathDiff.__required_keys__)
+    assert required == {"accepted", "disputed", "reframed"}
+
+
+# -- Revision wrappers & ownership Literals ----------------------------------
+
+
+def test_frame_revision_ownership_literal_wind() -> None:
+    """RFC §3.1 ownership rule: FrameRevision.written_by MUST be Literal['Wind']."""
+    from debate_hall_mcp.path_contract import FrameRevision
+
+    required = set(FrameRevision.__required_keys__)
+    assert required == {"rev", "written_at", "written_by", "value"}
+
+    hints = get_type_hints(FrameRevision)
+    assert get_args(hints["written_by"]) == ("Wind",)
+
+
+def test_verdict_revision_ownership_literal_wall() -> None:
+    """RFC §3.1 ownership rule: VerdictRevision.written_by MUST be Literal['Wall']."""
+    from debate_hall_mcp.path_contract import VerdictRevision
+
+    required = set(VerdictRevision.__required_keys__)
+    assert required == {"rev", "written_at", "written_by", "value"}
+
+    hints = get_type_hints(VerdictRevision)
+    assert get_args(hints["written_by"]) == ("Wall",)
+
+
+def test_diff_revision_ownership_literal_wind_and_optional_slots() -> None:
+    """RFC §3.1: DiffRevision is Wind-owned (consensus phase). Optional slots:
+
+    - ``divergence_marker`` (Finding D) — Literal[``NO_NEW_DIVERGENCE``].
+    - ``synthesis_guidance`` (Finding E) — free-text cross-path insight.
+    """
+    from debate_hall_mcp.path_contract import DiffRevision
+
+    required = set(DiffRevision.__required_keys__)
+    optional = set(DiffRevision.__optional_keys__)
+    assert required == {"rev", "written_at", "written_by", "value"}
+    assert optional == {"divergence_marker", "synthesis_guidance"}
+
+    hints = get_type_hints(DiffRevision)
+    assert get_args(hints["written_by"]) == ("Wind",)
+    assert get_args(hints["divergence_marker"]) == ("NO_NEW_DIVERGENCE",)
+
+
+def test_door_has_no_revision_wrapper() -> None:
+    """RFC §3.1: Door is read-only. There must be no DoorRevision class."""
+    import debate_hall_mcp.path_contract as mod
+
+    assert not hasattr(mod, "DoorRevision")
+
+
+# -- PathContract container --------------------------------------------------
+
+
+def test_path_contract_shape() -> None:
+    """RFC §3.1: PathContract has path_id + three append-only history lists."""
+    from debate_hall_mcp.path_contract import PathContract
+
+    required = set(PathContract.__required_keys__)
+    assert required == {
+        "path_id",
+        "frame_history",
+        "verdict_history",
+        "diff_history",
+    }
+
+
+def test_new_path_contract_defaults_to_empty_histories() -> None:
+    """Briefing: 'Defaults are empty lists (don't crash existing code).'
+
+    A constructor / factory helper must be exposed that returns an empty,
+    valid PathContract for a given ``path_id``.
+    """
+    from debate_hall_mcp.path_contract import new_path_contract
+
+    pc = new_path_contract("path_1")
+    assert pc["path_id"] == "path_1"
+    assert pc["frame_history"] == []
+    assert pc["verdict_history"] == []
+    assert pc["diff_history"] == []
+
+
+# -- JSON round-trip ---------------------------------------------------------
+
+
+def _make_populated_contract() -> dict[str, object]:
+    """Build a richly-populated contract exercising every optional slot."""
+    from debate_hall_mcp.path_contract import (
+        DiffRevision,
+        FrameRevision,
+        PathContract,
+        VerdictRevision,
+    )
+
+    ts = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+
+    frame_rev: FrameRevision = {
+        "rev": 0,
+        "written_at": ts,
+        "written_by": "Wind",
+        "value": {
+            "assumed_problem": "Wind cannot react to Wall's critique",
+            "success_criterion": "Wind produces a diff that cites Wall verdicts",
+            "accepted_failure_mode": "Token cost rises by <40%",
+            "invariants_touched": ["spec_grammar_coherence", "sync_api_contract"],
+        },
+    }
+
+    verdict_rev: VerdictRevision = {
+        "rev": 0,
+        "written_at": ts,
+        "written_by": "Wall",
+        "value": {
+            "spec_grammar_coherence": {
+                "status": "HARD_fail",
+                "rationale": "Grammar violates §3.1 ownership rule.",
+            },
+            "sync_api_contract": {
+                "status": "SOFT_disputed",
+                "rationale": "Contract is debatable but tradeable.",
+            },
+        },
+    }
+
+    diff_rev: DiffRevision = {
+        "rev": 0,
+        "written_at": ts,
+        "written_by": "Wind",
+        "value": {
+            "accepted": [],
+            "disputed": [
+                {
+                    "invariant": "sync_api_contract",
+                    "rationale": "Still pushing back on the SOFT verdict.",
+                }
+            ],
+            "reframed": [
+                {
+                    "invariant": "spec_grammar_coherence",
+                    "rationale": "Reframed via append-only wrappers.",
+                    "new_possibility": "Ownership Literals make violation a type error.",
+                }
+            ],
+        },
+        # Finding D: sentinel coexists with non-empty disputed list.
+        "divergence_marker": "NO_NEW_DIVERGENCE",
+        # Finding E: cross-path emergent insight.
+        "synthesis_guidance": "Path-1's reframe only works when merged with path-2.",
+    }
+
+    contract: PathContract = {
+        "path_id": "path_1",
+        "frame_history": [frame_rev],
+        "verdict_history": [verdict_rev],
+        "diff_history": [diff_rev],
+    }
+    return dict(contract)
+
+
+def test_round_trip_json_serialization() -> None:
+    """Briefing: 'All types JSON-serializable; include a round-trip test.'"""
+    from debate_hall_mcp.path_contract import (
+        path_contract_from_json,
+        path_contract_to_json,
+    )
+
+    original = _make_populated_contract()
+    encoded = path_contract_to_json(original)  # type: ignore[arg-type]
+
+    # Must be a JSON string (not bytes/dict).
+    assert isinstance(encoded, str)
+
+    # Decode independently to confirm valid JSON.
+    decoded_raw = json.loads(encoded)
+    assert decoded_raw["path_id"] == "path_1"
+    # datetimes serialized as ISO strings.
+    assert isinstance(decoded_raw["frame_history"][0]["written_at"], str)
+
+    # Round-trip via the helper restores Python-native datetimes.
+    restored = path_contract_from_json(encoded)
+    assert restored["path_id"] == original["path_id"]
+    assert restored["frame_history"][0]["written_at"] == datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    assert (
+        restored["diff_history"][0]["divergence_marker"]  # type: ignore[typeddict-item]
+        == "NO_NEW_DIVERGENCE"
+    )
+    assert (
+        restored["diff_history"][0]["synthesis_guidance"]  # type: ignore[typeddict-item]
+        == "Path-1's reframe only works when merged with path-2."
+    )
+
+
+def test_round_trip_preserves_optional_absence() -> None:
+    """Optional NotRequired slots must remain absent (not coerced to None)."""
+    from debate_hall_mcp.path_contract import (
+        path_contract_from_json,
+        path_contract_to_json,
+    )
+
+    pc = _make_populated_contract()
+    # Strip the optional slots from the lone diff revision.
+    diff = pc["diff_history"][0]  # type: ignore[index]
+    diff.pop("divergence_marker", None)  # type: ignore[union-attr]
+    diff.pop("synthesis_guidance", None)  # type: ignore[union-attr]
+
+    restored = path_contract_from_json(path_contract_to_json(pc))  # type: ignore[arg-type]
+    restored_diff = restored["diff_history"][0]
+    assert "divergence_marker" not in restored_diff
+    assert "synthesis_guidance" not in restored_diff
+
+
+# -- Max-token-budget prompt-context view helper -----------------------------
+
+
+def test_prompt_context_view_helper_signature() -> None:
+    """Briefing: max-token-budget helper exposing latest revision + count per field.
+
+    Spec the helper signature even if the implementation is minimal. #199 owns
+    the integration into the orchestrator's prompt context block.
+    """
+    from debate_hall_mcp.path_contract import prompt_context_view
+
+    pc = _make_populated_contract()
+    view = prompt_context_view(pc)  # type: ignore[arg-type]
+
+    # Latest revision per field, NOT full history.
+    assert view["path_id"] == "path_1"
+    assert view["latest_frame"] == pc["frame_history"][-1]  # type: ignore[index]
+    assert view["latest_verdict"] == pc["verdict_history"][-1]  # type: ignore[index]
+    assert view["latest_diff"] == pc["diff_history"][-1]  # type: ignore[index]
+
+    # Revision counts so the agent knows "this is Wall's Nth verdict, after Wind's reframe".
+    assert view["frame_count"] == 1
+    assert view["verdict_count"] == 1
+    assert view["diff_count"] == 1
+
+
+def test_prompt_context_view_handles_empty_histories() -> None:
+    """Empty contracts MUST NOT crash the view helper; latest_* are None."""
+    from debate_hall_mcp.path_contract import new_path_contract, prompt_context_view
+
+    pc = new_path_contract("path_2")
+    view = prompt_context_view(pc)
+
+    assert view["latest_frame"] is None
+    assert view["latest_verdict"] is None
+    assert view["latest_diff"] is None
+    assert view["frame_count"] == 0
+    assert view["verdict_count"] == 0
+    assert view["diff_count"] == 0
+
+
+# -- Sanity: out-of-scope guards --------------------------------------------
+
+
+def test_no_closed_hard_invariant_enum_exported() -> None:
+    """Finding A explicitly supersedes the closed enum. Guard against re-introduction."""
+    import debate_hall_mcp.path_contract as mod
+
+    # Common shapes the superseded design could resurrect under:
+    for forbidden in ("HardInvariant", "HARD_INVARIANTS", "HardInvariantEnum"):
+        assert not hasattr(
+            mod, forbidden
+        ), f"{forbidden} contradicts RFC §3.3 Finding A (open-set Invariant=str)."
+
+
+def test_module_does_not_smuggle_validator_logic() -> None:
+    """#196 defines types only; validator behaviour belongs to #200.
+
+    The module must not expose anything that *executes* the per-invariant
+    REQUIRED CONTENT RULE or the ownership rule — those are #200's job.
+    """
+    import debate_hall_mcp.path_contract as mod
+
+    for forbidden in (
+        "validate_required_content",
+        "validate_ownership",
+        "enforce_diff_required_content",
+    ):
+        assert not hasattr(
+            mod, forbidden
+        ), f"{forbidden} would conflate #196 with #200 (validator scope)."
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_path_contract_schema.py
+++ b/tests/unit/test_path_contract_schema.py
@@ -282,12 +282,9 @@ def test_round_trip_json_serialization() -> None:
     restored = path_contract_from_json(encoded)
     assert restored["path_id"] == original["path_id"]
     assert restored["frame_history"][0]["written_at"] == datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC)
+    assert restored["diff_history"][0]["divergence_marker"] == "NO_NEW_DIVERGENCE"
     assert (
-        restored["diff_history"][0]["divergence_marker"]  # type: ignore[typeddict-item]
-        == "NO_NEW_DIVERGENCE"
-    )
-    assert (
-        restored["diff_history"][0]["synthesis_guidance"]  # type: ignore[typeddict-item]
+        restored["diff_history"][0]["synthesis_guidance"]
         == "Path-1's reframe only works when merged with path-2."
     )
 
@@ -302,8 +299,8 @@ def test_round_trip_preserves_optional_absence() -> None:
     pc = _make_populated_contract()
     # Strip the optional slots from the lone diff revision.
     diff = pc["diff_history"][0]  # type: ignore[index]
-    diff.pop("divergence_marker", None)  # type: ignore[union-attr]
-    diff.pop("synthesis_guidance", None)  # type: ignore[union-attr]
+    diff.pop("divergence_marker", None)
+    diff.pop("synthesis_guidance", None)
 
     restored = path_contract_from_json(path_contract_to_json(pc))  # type: ignore[arg-type]
     restored_diff = restored["diff_history"][0]
@@ -382,6 +379,32 @@ def test_module_does_not_smuggle_validator_logic() -> None:
         assert not hasattr(
             mod, forbidden
         ), f"{forbidden} would conflate #196 with #200 (validator scope)."
+
+
+# -- Pydantic runtime compatibility (CE finding on PR #216) ------------------
+
+
+def test_path_contract_is_pydantic_compatible() -> None:
+    """``TypeAdapter(PathContract)`` must succeed on Python 3.11.
+
+    Pydantic 2 on Python < 3.12 requires ``typing_extensions.TypedDict``; the
+    ``typing.TypedDict`` variant raises ``PydanticUserError`` at TypeAdapter
+    construction (see https://errors.pydantic.dev/2.12/u/typed-dict-version).
+    #197 (state serialisation) round-trips ``PathContract`` through Pydantic,
+    so this smoke test guards the load-bearing import source in
+    ``path_contract.py`` to prevent silent regression.
+    """
+    from pydantic import TypeAdapter
+
+    from debate_hall_mcp.path_contract import PathContract, new_path_contract
+
+    adapter = TypeAdapter(PathContract)
+    # Minimal valid contract (empty histories) must validate without error.
+    validated = adapter.validate_python(new_path_contract("path_1"))
+    assert validated["path_id"] == "path_1"
+    assert validated["frame_history"] == []
+    assert validated["verdict_history"] == []
+    assert validated["diff_history"] == []
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -347,6 +347,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-ulid" },
     { name = "pyyaml" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -380,6 +381,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "typing-extensions", specifier = ">=4.12" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary

Implements the load-bearing `path_contract` schema and append-only typed
wrappers for RFC-0001 (Wind learning loop). This is the foundation for
downstream sub-issues #197 (state persistence), #198 (prompt edits),
#199 (context compiler), #200 (validator), and #202 (feature wiring).

**Acceptance is bound to the AMENDED RFC**
(`docs/rfc-0001-path-contract-wind-learning-loop.md` §3.1 / §3.2 / §3.3),
**NOT** to the stale issue body on #196. In particular:

- §3.1 schema with **`Invariant = str`** open-set alias (Finding A
  supersedes the previously-closed `HardInvariant` enum; §8 row 1 is
  strikethrough-superseded in the RFC and intentionally **not** bound).
- §3.3 Finding D: `divergence_marker = NO_NEW_DIVERGENCE` may coexist
  with a non-empty `disputed` list.
- §3.3 Finding E: `synthesis_guidance: NotRequired[str]` slot on
  `DiffRevision` for cross-path emergent insight.

## Types delivered

In `src/debate_hall_mcp/path_contract.py`:

- `Invariant` (`= str`, open-set; Wall-discipline `snake_case` naming
  documented in module docstring).
- `PathFrame`, `InvariantVerdict`, `InvariantEntry`, `PathDiff` —
  per-path payload TypedDicts.
- `FrameRevision`, `VerdictRevision`, `DiffRevision` — append-only
  wrappers with `Literal["Wind"]` / `Literal["Wall"]` ownership tags
  (Door is read-only; no `DoorRevision` exists).
- `PathContract` — top-level container with `path_id` + three
  append-only history lists.
- `PromptContextView` TypedDict for the helper return type.

Helpers:

- `new_path_contract(path_id)` — empty-defaults factory.
- `path_contract_to_json` / `path_contract_from_json` — JSON round-trip
  that preserves absence of `NotRequired` keys and restores `datetime`
  on revisions.
- `prompt_context_view(contract)` — latest-revision + count-per-field
  projection for token-bounded prompt context (#199 will integrate).

## Out of scope (per orchestrator brief)

- Validator behaviour (REQUIRED CONTENT RULE, ownership enforcement,
  sentinel legality) — **#200**.
- State persistence integration — **#197**.
- Prompt edits — **#198**.
- Feature flag / wrapper wiring — **#201 / #205**.

Type-level enforceability (the `Literal["Wind"]` / `Literal["Wall"]`
ownership tags) is in scope here because the runtime validator in #200
relies on those annotations to enforce ownership.

## Deviations from the existing RED test file

One deviation, documented for transparency:

- The pre-existing RED test file shipped with two ruff violations
  (`I001` unsorted imports; `F401` unused `Literal` import) and one
  black formatting delta. The orchestrator brief instructed
  preservation, but the project's BLOCKING quality gates require all
  files to pass ruff/black/mypy. I applied `ruff --fix` + `black`
  (purely mechanical, zero assertion changes) and amended the RED
  commit so the two-commit TDD evidence trail remains intact. All 18
  test assertions are preserved verbatim.

One implementation note worth flagging for downstream consumers:

- The module deliberately does **not** use `from __future__ import
  annotations`. Under PEP 563 stringification, the CPython 3.11
  `TypedDict` machinery fails to detect `NotRequired[...]` wrappers
  and folds those fields into `__required_keys__`, which would
  silently break the validator in #200. Eager annotation evaluation
  is required for correctness. Downstream consumers importing these
  types are unaffected — only this module needs the eager evaluation.

## Test plan

- [x] `uv run pytest tests/unit/test_path_contract_schema.py` — 18/18
      passed, 0 skipped.
- [x] `uv run ruff check .` — clean.
- [x] `uv run black --check .` — 118 files unchanged.
- [x] `uv run mypy src/` — 0 issues in 41 source files.
- [x] Pre-push hook (mypy + ruff) — passed on `git push`.

Closes #196.
Part of #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the `debate_hall_mcp.path_contract` schema and append-only typed wrappers for RFC‑0001, plus JSON round‑trip and a prompt context view. Adds Pydantic 2 compatibility on Python <3.12 and clarifies the JSON/validation boundary; fulfills #196 per amended RFC §3.1–§3.3 and sets up #197–#200, #202.

- **Bug Fixes**
  - Use `typing_extensions.TypedDict` and `NotRequired` to satisfy Pydantic 2 `TypeAdapter(...)` on Python <3.12; keep eager annotations (no `from __future__ import annotations`) for `NotRequired` detection.
  - Clarify `path_contract_from_json` docs: deserializes and restores `datetime` only; validation lives in #200.
  - Add a smoke test ensuring `TypeAdapter(PathContract)` validates a minimal contract.

- **Dependencies**
  - Add `typing_extensions>=4.12` as a direct dependency.

<sup>Written for commit 36e8e6004d7221755d7834241151f624595494f8. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/216?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

