### PR TITLE
[RFC-0001] #200 — path_contract validator + VALIDATOR_FAILURE events

### DIFF
--- a/src/debate_hall_mcp/events.py
+++ b/src/debate_hall_mcp/events.py
@@ -47,6 +47,11 @@ class EventType(StrEnum):
     - CONSENSUS_VOTE: Agent voted on consensus
     - ERROR: Error occurred during processing
     - DEBATE_CLOSED: Debate concluded (synthesis, exhaustion, etc.)
+    - VALIDATOR_FAILURE: A path_contract validator rejection (RFC-0001 §6
+      item 3). Failure-type discrimination lives in the event payload
+      (``failure_type`` key) so the A/B harness (#203) can group failures
+      without parsing free text. The discriminator constants are exported
+      from ``debate_hall_mcp.path_contract_validator``.
     """
 
     DEBATE_STARTED = "debate_started"
@@ -54,6 +59,7 @@ class EventType(StrEnum):
     CONSENSUS_VOTE = "consensus_vote"
     ERROR = "error"
     DEBATE_CLOSED = "debate_closed"
+    VALIDATOR_FAILURE = "validator_failure"
 
 
 class DebateEvent(BaseModel):

--- a/src/debate_hall_mcp/path_contract_validator.py
+++ b/src/debate_hall_mcp/path_contract_validator.py
@@ -214,6 +214,48 @@ def _shape_failure(path_id: str, defect: str, details: str) -> ValidatorFailure:
     )
 
 
+# Allowed Literal value sets per RFC §3.1. Centralised here so the shape
+# pre-pass enforces VALUE membership (not just key presence) — addresses
+# Cubic P2 on PR #217: previously ``status="HARD_FAIL"`` (caps) or
+# ``written_by="wind"`` (lowercase) passed shape validation and either
+# silently bypassed semantic checks (false negative on REQUIRED CONTENT
+# RULE) or were mis-categorised as ``OWNERSHIP_VIOLATION``.
+_ALLOWED_STATUS: frozenset[str] = frozenset({"HARD_pass", "HARD_fail", "SOFT_disputed"})
+_ALLOWED_WRITTEN_BY: dict[RevisionKind, frozenset[str]] = {
+    "frame": frozenset({"Wind"}),
+    "verdict": frozenset({"Wall"}),
+    "diff": frozenset({"Wind"}),
+}
+_ALLOWED_DIVERGENCE_MARKER: frozenset[str] = frozenset({"NO_NEW_DIVERGENCE"})
+
+
+def _check_literal_value(
+    value: object,
+    *,
+    allowed: frozenset[str],
+    path_id: str,
+    locator: str,
+) -> ValidatorFailure | None:
+    """Verify ``value`` is one of the ``allowed`` Literal strings.
+
+    Returns ``None`` when ``value`` is a valid member, otherwise a
+    ``SCHEMA_SHAPE_VIOLATION`` with defect ``invalid_literal:<locator>:<repr>``.
+    A ``None`` ``value`` (caller already determined the key is absent and
+    that absence is permitted — e.g. ``NotRequired`` slot) should not be
+    passed here; callers gate on presence first.
+    """
+    if isinstance(value, str) and value in allowed:
+        return None
+    return _shape_failure(
+        path_id,
+        f"invalid_literal:{locator}:{value!r}",
+        (
+            f"{locator} must be one of {sorted(allowed)!r}; "
+            f"got {value!r} (type {type(value).__name__})."
+        ),
+    )
+
+
 def _check_invariant_entries(
     entries: object,
     *,
@@ -306,6 +348,16 @@ def _check_frame_history(history: list[Any], path_id: str) -> list[ValidatorFail
                         f"{locator} missing required key '{key}'.",
                     )
                 )
+        # Literal VALUE membership for ``written_by`` (RFC §3.1).
+        if "written_by" in rev:
+            wb_failure = _check_literal_value(
+                rev["written_by"],
+                allowed=_ALLOWED_WRITTEN_BY["frame"],
+                path_id=path_id,
+                locator=f"{locator}.written_by",
+            )
+            if wb_failure is not None:
+                failures.append(wb_failure)
     return failures
 
 
@@ -332,6 +384,16 @@ def _check_verdict_history(history: list[Any], path_id: str) -> list[ValidatorFa
                         f"{locator} missing required key '{key}'.",
                     )
                 )
+        # Literal VALUE membership for ``written_by`` (RFC §3.1).
+        if "written_by" in rev:
+            wb_failure = _check_literal_value(
+                rev["written_by"],
+                allowed=_ALLOWED_WRITTEN_BY["verdict"],
+                path_id=path_id,
+                locator=f"{locator}.written_by",
+            )
+            if wb_failure is not None:
+                failures.append(wb_failure)
         # value must be a Mapping[str, Mapping] with status/rationale fields.
         if "value" in rev:
             value = rev["value"]
@@ -364,6 +426,16 @@ def _check_verdict_history(history: list[Any], path_id: str) -> list[ValidatorFa
                                 f"{v_loc} missing required key '{key}'.",
                             )
                         )
+                # Literal VALUE membership for ``status`` (RFC §3.1).
+                if "status" in verdict:
+                    status_failure = _check_literal_value(
+                        verdict["status"],
+                        allowed=_ALLOWED_STATUS,
+                        path_id=path_id,
+                        locator=f"{v_loc}.status",
+                    )
+                    if status_failure is not None:
+                        failures.append(status_failure)
     return failures
 
 
@@ -390,6 +462,27 @@ def _check_diff_history(history: list[Any], path_id: str) -> list[ValidatorFailu
                         f"{locator} missing required key '{key}'.",
                     )
                 )
+        # Literal VALUE membership for ``written_by`` (RFC §3.1).
+        if "written_by" in rev:
+            wb_failure = _check_literal_value(
+                rev["written_by"],
+                allowed=_ALLOWED_WRITTEN_BY["diff"],
+                path_id=path_id,
+                locator=f"{locator}.written_by",
+            )
+            if wb_failure is not None:
+                failures.append(wb_failure)
+        # Literal VALUE membership for ``divergence_marker`` (NotRequired —
+        # only checked when present). RFC §3.1: Literal["NO_NEW_DIVERGENCE"].
+        if "divergence_marker" in rev:
+            dm_failure = _check_literal_value(
+                rev["divergence_marker"],
+                allowed=_ALLOWED_DIVERGENCE_MARKER,
+                path_id=path_id,
+                locator=f"{locator}.divergence_marker",
+            )
+            if dm_failure is not None:
+                failures.append(dm_failure)
         if "value" not in rev:
             continue
         value = rev["value"]
@@ -529,6 +622,26 @@ def _validate_diff_shape(diff: object, path_id: str) -> list[ValidatorFailure]:
                     f"diff revision missing required key '{key}'.",
                 )
             )
+    # Literal VALUE membership for ``written_by`` (RFC §3.1: Literal["Wind"]).
+    if "written_by" in diff:
+        wb_failure = _check_literal_value(
+            diff["written_by"],
+            allowed=_ALLOWED_WRITTEN_BY["diff"],
+            path_id=path_id,
+            locator="diff.written_by",
+        )
+        if wb_failure is not None:
+            failures.append(wb_failure)
+    # Literal VALUE membership for ``divergence_marker`` (NotRequired).
+    if "divergence_marker" in diff:
+        dm_failure = _check_literal_value(
+            diff["divergence_marker"],
+            allowed=_ALLOWED_DIVERGENCE_MARKER,
+            path_id=path_id,
+            locator="diff.divergence_marker",
+        )
+        if dm_failure is not None:
+            failures.append(dm_failure)
     if "value" not in diff:
         return failures
     value = diff["value"]
@@ -588,6 +701,21 @@ def validate_revision_shape(
                     f"{kind} revision missing required key '{key}'.",
                 )
             )
+    # Literal VALUE membership for ``written_by`` per ``kind`` (RFC §3.1).
+    # Critical for the two-phase pattern: an invalid Literal here is a
+    # shape defect, not a semantic ``OWNERSHIP_VIOLATION`` — the latter
+    # only applies when ``written_by`` is a STRUCTURALLY valid Literal but
+    # for the wrong revision kind. Without this check, ``written_by="wind"``
+    # (lowercase) would be mis-categorised as OWNERSHIP.
+    if "written_by" in revision:
+        wb_failure = _check_literal_value(
+            revision["written_by"],
+            allowed=_ALLOWED_WRITTEN_BY[kind],
+            path_id=path_id,
+            locator="revision.written_by",
+        )
+        if wb_failure is not None:
+            failures.append(wb_failure)
     return failures
 
 

--- a/src/debate_hall_mcp/path_contract_validator.py
+++ b/src/debate_hall_mcp/path_contract_validator.py
@@ -1,0 +1,419 @@
+"""Path-contract validator (RFC-0001 §3.2 / §3.3 / §6 — issue #200).
+
+This module enforces the policy rules layered on top of the
+``debate_hall_mcp.path_contract`` schema. The schema module (#196) is the
+wire-format boundary; this module is the policy boundary — the split is
+deliberate so the schema module remains stable and the policy can iterate
+independently. See the BOUNDARY docstring on
+``path_contract.path_contract_from_json`` for the matching note.
+
+Scope per RFC-0001 #200:
+
+* Per-invariant REQUIRED CONTENT RULE (§3.2 amended; §3.3 Finding C):
+  every ``HARD_fail`` invariant in the latest ``verdict`` revision MUST
+  have its own qualifying entry in the diff — either in
+  ``accepted`` with a non-empty ``terminal_rationale`` OR in ``reframed``
+  with a non-empty ``new_possibility``. A sibling entry on a different
+  invariant does NOT satisfy the requirement for another invariant on the
+  same path.
+* ``NO_NEW_DIVERGENCE`` sentinel legality (§3.2; §3.3 Finding D): the
+  sentinel is legal ONLY when zero ``HARD_fail`` verdicts exist for the
+  path. The sentinel MAY coexist with a non-empty ``disputed`` list when
+  Wind has legitimate pushback on ``SOFT_disputed`` verdicts.
+* Ownership rule (§3.1): only Wind may append to ``frame_history`` or
+  ``diff_history``; only Wall may append to ``verdict_history``; Door is
+  read-only.
+* Door citation existence (§6 item 2): every invariant Door cites in
+  synthesis MUST appear in the latest ``verdict`` revision; otherwise
+  Door is hallucinating provenance.
+* ``VALIDATOR_FAILURE`` event emission (§6 item 3): every rejection is
+  recorded as a structured event on the I4 append-only ledger with
+  failure-type discrimination in the payload so the A/B harness (#203)
+  can compute invalid-contract-rate by failure type without parsing
+  free text.
+
+Out of scope (deliberately deferred — see PR body):
+
+* Orchestrator call-site wiring into ``_execute_consensus_loop``. Today
+  the loop exchanges only Wind/Wall ``vote.approved`` booleans + free-text
+  feedback; ``PathContract`` objects are not yet threaded through. Wiring
+  depends on #197 (state plumbing) and #198 (prompts producing diff
+  content). The RFC §3 invariant "consensus loop, max_refinement_loops,
+  and Wall re-approval invariant at line 507 are unchanged" is honoured.
+* Prompt edits enforcing the Door synthesis_guidance citation rule
+  (Finding E) — that is prompt/context-compiler territory (#198/#199).
+  This module's responsibility for ``synthesis_guidance`` is bounded to
+  the citation-existence check on the invariants Door names; the
+  *requirement* to cite ``synthesis_guidance`` when present is a Door
+  prompt concern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from debate_hall_mcp.events import DebateEvent, EventType, append_event
+from debate_hall_mcp.path_contract import (
+    DiffRevision,
+    FrameRevision,
+    InvariantEntry,
+    PathContract,
+    VerdictRevision,
+)
+
+# ---------------------------------------------------------------------------
+# Failure-type discriminators (stable identifiers for #203 A/B grouping).
+# ---------------------------------------------------------------------------
+
+MISSING_REQUIRED_ENTRY = "missing_required_entry"
+"""HARD_fail invariant lacks any qualifying entry in the diff."""
+
+EMPTY_TERMINAL_RATIONALE = "empty_terminal_rationale"
+"""``accepted`` entry on a HARD_fail invariant has empty/missing ``terminal_rationale``."""
+
+EMPTY_NEW_POSSIBILITY = "empty_new_possibility"
+"""``reframed`` entry on a HARD_fail invariant has empty/missing ``new_possibility``."""
+
+ILLEGAL_NO_NEW_DIVERGENCE = "illegal_no_new_divergence"
+"""``NO_NEW_DIVERGENCE`` sentinel emitted on a path with at least one HARD_fail verdict."""
+
+OWNERSHIP_VIOLATION = "ownership_violation"
+"""A revision was written by a role other than the legal owner for its kind."""
+
+DOOR_CITATION_NOT_FOUND = "door_citation_not_found"
+"""Door cited an invariant that does not appear in the latest verdict revision."""
+
+
+RevisionKind = Literal["frame", "verdict", "diff"]
+
+
+# ---------------------------------------------------------------------------
+# Structured failure record.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidatorFailure:
+    """A single validator rejection.
+
+    Carries enough discriminated metadata for the A/B harness (#203) to
+    group failures by ``failure_type`` and correlate per ``path_id``,
+    ``invariant``, and ``role`` without parsing free text.
+
+    Attributes:
+        failure_type: One of the module-level discriminator constants
+            (e.g. ``MISSING_REQUIRED_ENTRY``).
+        path_id: The path the failure relates to.
+        invariant: The invariant name when the failure is invariant-scoped;
+            ``None`` otherwise (e.g. ownership violations are not
+            invariant-scoped).
+        role: The acting role when the failure is role-scoped (ownership
+            violations); ``None`` otherwise.
+        details: Human-readable explanation. Not a stable identifier — for
+            grouping use ``failure_type``.
+    """
+
+    failure_type: str
+    path_id: str
+    invariant: str | None
+    role: str | None
+    details: str
+
+
+# ---------------------------------------------------------------------------
+# Per-invariant REQUIRED CONTENT RULE + sentinel legality (§3.2 / §3.3 C+D).
+# ---------------------------------------------------------------------------
+
+
+def _latest_verdict_value(
+    contract: PathContract,
+) -> dict[str, dict[str, str]] | None:
+    """Return the ``value`` dict of the latest ``VerdictRevision`` or ``None``."""
+    history = contract["verdict_history"]
+    if not history:
+        return None
+    # ``value`` is typed as ``dict[Invariant, InvariantVerdict]``; the cast
+    # is for the runtime helper only.
+    return history[-1]["value"]  # type: ignore[return-value]
+
+
+def _hard_fail_invariants(contract: PathContract) -> list[str]:
+    """List the invariant keys whose latest verdict is ``HARD_fail``."""
+    latest = _latest_verdict_value(contract)
+    if latest is None:
+        return []
+    return [name for name, verdict in latest.items() if verdict.get("status") == "HARD_fail"]
+
+
+def _qualifying_accepted(diff: DiffRevision, invariant: str) -> list[InvariantEntry]:
+    """Return ``accepted`` entries matching ``invariant`` (irrespective of content)."""
+    return [e for e in diff["value"]["accepted"] if e.get("invariant") == invariant]
+
+
+def _qualifying_reframed(diff: DiffRevision, invariant: str) -> list[InvariantEntry]:
+    """Return ``reframed`` entries matching ``invariant``."""
+    return [e for e in diff["value"]["reframed"] if e.get("invariant") == invariant]
+
+
+def validate_diff_revision(contract: PathContract, diff: DiffRevision) -> list[ValidatorFailure]:
+    """Validate ``diff`` against the latest verdict for ``contract``.
+
+    Enforces RFC §3.2 / §3.3 Findings C and D:
+
+    * For every ``HARD_fail`` invariant in the latest verdict, the diff
+      MUST contain at least one qualifying entry on the SAME invariant —
+      ``accepted`` with non-empty ``terminal_rationale`` OR ``reframed``
+      with non-empty ``new_possibility``.
+    * ``NO_NEW_DIVERGENCE`` is legal only when zero ``HARD_fail`` verdicts
+      exist for the path; it MAY coexist with a non-empty ``disputed``
+      list (Finding D).
+
+    Returns:
+        A list of ``ValidatorFailure`` records — empty when valid.
+    """
+    failures: list[ValidatorFailure] = []
+    path_id = contract["path_id"]
+    hard_fail = _hard_fail_invariants(contract)
+
+    # Sentinel legality first — Finding D allows sentinel + disputed; the
+    # only thing that makes the sentinel illegal is the presence of any
+    # HARD_fail in the latest verdict.
+    if diff.get("divergence_marker") == "NO_NEW_DIVERGENCE" and hard_fail:
+        failures.append(
+            ValidatorFailure(
+                failure_type=ILLEGAL_NO_NEW_DIVERGENCE,
+                path_id=path_id,
+                invariant=None,
+                role="Wind",
+                details=(
+                    "NO_NEW_DIVERGENCE sentinel emitted on a path whose "
+                    f"latest verdict contains HARD_fail invariants: {hard_fail}"
+                ),
+            )
+        )
+        # Continue checking REQUIRED CONTENT regardless — both failures
+        # are independently audit-worthy and per-invariant grouping in
+        # the A/B harness depends on emitting both.
+
+    # Per-invariant REQUIRED CONTENT RULE.
+    for invariant in hard_fail:
+        accepted_matches = _qualifying_accepted(diff, invariant)
+        reframed_matches = _qualifying_reframed(diff, invariant)
+
+        if not accepted_matches and not reframed_matches:
+            failures.append(
+                ValidatorFailure(
+                    failure_type=MISSING_REQUIRED_ENTRY,
+                    path_id=path_id,
+                    invariant=invariant,
+                    role="Wind",
+                    details=(
+                        f"HARD_fail invariant {invariant!r} has no qualifying "
+                        "entry in diff.accepted or diff.reframed (§3.3 "
+                        "Finding C: per-invariant requirement, sibling entry "
+                        "on a different invariant does not satisfy)."
+                    ),
+                )
+            )
+            continue
+
+        # If accepted entries exist, at least one must carry a non-empty
+        # terminal_rationale. Otherwise, fall through to reframed check.
+        accepted_satisfies = any(
+            isinstance(e.get("terminal_rationale"), str) and e.get("terminal_rationale")
+            for e in accepted_matches
+        )
+        reframed_satisfies = any(
+            isinstance(e.get("new_possibility"), str) and e.get("new_possibility")
+            for e in reframed_matches
+        )
+
+        if accepted_satisfies or reframed_satisfies:
+            continue
+
+        # We have matches but none satisfy content requirements. Emit one
+        # failure per failing match category so the A/B harness can see
+        # exactly which prompt rule was violated.
+        for _ in accepted_matches:
+            failures.append(
+                ValidatorFailure(
+                    failure_type=EMPTY_TERMINAL_RATIONALE,
+                    path_id=path_id,
+                    invariant=invariant,
+                    role="Wind",
+                    details=(
+                        f"accepted entry on HARD_fail invariant {invariant!r} "
+                        "has empty or missing terminal_rationale."
+                    ),
+                )
+            )
+        for _ in reframed_matches:
+            failures.append(
+                ValidatorFailure(
+                    failure_type=EMPTY_NEW_POSSIBILITY,
+                    path_id=path_id,
+                    invariant=invariant,
+                    role="Wind",
+                    details=(
+                        f"reframed entry on HARD_fail invariant {invariant!r} "
+                        "has empty or missing new_possibility."
+                    ),
+                )
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Ownership rule (§3.1).
+# ---------------------------------------------------------------------------
+
+
+_LEGAL_OWNER: dict[RevisionKind, str] = {
+    "frame": "Wind",
+    "verdict": "Wall",
+    "diff": "Wind",
+}
+
+
+def validate_revision_ownership(
+    revision: FrameRevision | VerdictRevision | DiffRevision,
+    *,
+    kind: RevisionKind,
+    path_id: str,
+) -> list[ValidatorFailure]:
+    """Validate that ``revision.written_by`` matches the legal owner for ``kind``.
+
+    RFC §3.1: only Wind may append to ``frame_history`` or ``diff_history``;
+    only Wall may append to ``verdict_history``; Door is read-only and
+    therefore can never legally appear as a writer of any revision.
+
+    Args:
+        revision: The revision wrapper whose owner is being checked.
+        kind: The kind of revision (``frame``, ``verdict``, or ``diff``)
+            — caller knows which history the revision is destined for.
+        path_id: The path-id the revision relates to (for failure
+            correlation; revisions themselves do not carry ``path_id``).
+
+    Returns:
+        A list with at most one ``ValidatorFailure`` of type
+        ``OWNERSHIP_VIOLATION``.
+    """
+    expected = _LEGAL_OWNER[kind]
+    actual = revision["written_by"]
+    if actual == expected:
+        return []
+    return [
+        ValidatorFailure(
+            failure_type=OWNERSHIP_VIOLATION,
+            path_id=path_id,
+            invariant=None,
+            role=actual,
+            details=(
+                f"{kind}_history append by {actual!r} rejected; "
+                f"only {expected!r} may write {kind} revisions (§3.1)."
+            ),
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Door citation existence (§6 item 2).
+# ---------------------------------------------------------------------------
+
+
+def validate_door_citations(
+    contract: PathContract, *, cited_invariants: list[str]
+) -> list[ValidatorFailure]:
+    """Validate that each cited invariant exists in the latest verdict.
+
+    RFC §6 item 2: "when Door's synthesis is produced, validate that every
+    cited entry exists in the contract (no fabricated citations)."
+
+    The caller is responsible for parsing Door's synthesis text and
+    extracting the list of cited invariant names; this function does the
+    membership check against the latest verdict revision.
+
+    Returns:
+        One ``DOOR_CITATION_NOT_FOUND`` failure per cited invariant that
+        does NOT appear in the latest verdict revision. If there is no
+        verdict revision at all, every cited invariant is reported.
+    """
+    latest = _latest_verdict_value(contract)
+    known: set[str] = set(latest.keys()) if latest is not None else set()
+    return [
+        ValidatorFailure(
+            failure_type=DOOR_CITATION_NOT_FOUND,
+            path_id=contract["path_id"],
+            invariant=name,
+            role="Door",
+            details=(
+                f"Door cited invariant {name!r} which does not appear in the "
+                "latest verdict revision (§6 item 2: no fabricated citations)."
+            ),
+        )
+        for name in cited_invariants
+        if name not in known
+    ]
+
+
+# ---------------------------------------------------------------------------
+# VALIDATOR_FAILURE event emission (§6 item 3).
+# ---------------------------------------------------------------------------
+
+
+def _failure_payload(failure: ValidatorFailure) -> dict[str, object]:
+    """Project a ``ValidatorFailure`` into a flat JSON-safe event payload."""
+    return {
+        "failure_type": failure.failure_type,
+        "path_id": failure.path_id,
+        "invariant": failure.invariant,
+        "role": failure.role,
+        "details": failure.details,
+    }
+
+
+def emit_validator_failures(
+    *,
+    thread_id: str,
+    failures: list[ValidatorFailure],
+    state_dir: Path,
+) -> list[DebateEvent]:
+    """Append one ``VALIDATOR_FAILURE`` event per failure to the ledger.
+
+    Failure-type discrimination lives in the ``failure_type`` payload key
+    (NOT in the ``EventType``) so the A/B harness (#203) can group
+    failures without inflating the ``EventType`` enum and breaking
+    consumers iterating its members.
+
+    Returns:
+        The list of created ``DebateEvent`` records (empty when no
+        failures were supplied; no events file is touched in that case).
+    """
+    return [
+        append_event(
+            thread_id=thread_id,
+            event_type=EventType.VALIDATOR_FAILURE,
+            payload=_failure_payload(f),
+            state_dir=state_dir,
+        )
+        for f in failures
+    ]
+
+
+__all__ = [
+    "DOOR_CITATION_NOT_FOUND",
+    "EMPTY_NEW_POSSIBILITY",
+    "EMPTY_TERMINAL_RATIONALE",
+    "ILLEGAL_NO_NEW_DIVERGENCE",
+    "MISSING_REQUIRED_ENTRY",
+    "OWNERSHIP_VIOLATION",
+    "RevisionKind",
+    "ValidatorFailure",
+    "emit_validator_failures",
+    "validate_diff_revision",
+    "validate_door_citations",
+    "validate_revision_ownership",
+]

--- a/src/debate_hall_mcp/path_contract_validator.py
+++ b/src/debate_hall_mcp/path_contract_validator.py
@@ -79,6 +79,21 @@ EMPTY_NEW_POSSIBILITY = "empty_new_possibility"
 ILLEGAL_NO_NEW_DIVERGENCE = "illegal_no_new_divergence"
 """``NO_NEW_DIVERGENCE`` sentinel emitted on a path with at least one HARD_fail verdict."""
 
+ILLEGAL_SENTINEL_WITH_ACCEPTED = "illegal_sentinel_with_accepted"
+"""``NO_NEW_DIVERGENCE`` sentinel emitted alongside a non-empty ``accepted`` list.
+
+Per RFC §3.1 ``divergence_marker`` docstring: when the sentinel is set,
+``value.accepted`` and ``value.reframed`` MUST be empty (``disputed`` MAY
+be non-empty per Finding D).
+"""
+
+ILLEGAL_SENTINEL_WITH_REFRAMED = "illegal_sentinel_with_reframed"
+"""``NO_NEW_DIVERGENCE`` sentinel emitted alongside a non-empty ``reframed`` list.
+
+Per RFC §3.1 ``divergence_marker`` docstring: when the sentinel is set,
+``value.reframed`` MUST be empty.
+"""
+
 OWNERSHIP_VIOLATION = "ownership_violation"
 """A revision was written by a role other than the legal owner for its kind."""
 
@@ -177,32 +192,90 @@ def validate_diff_revision(contract: PathContract, diff: DiffRevision) -> list[V
     path_id = contract["path_id"]
     hard_fail = _hard_fail_invariants(contract)
 
-    # Sentinel legality first — Finding D allows sentinel + disputed; the
-    # only thing that makes the sentinel illegal is the presence of any
-    # HARD_fail in the latest verdict.
-    if diff.get("divergence_marker") == "NO_NEW_DIVERGENCE" and hard_fail:
-        failures.append(
-            ValidatorFailure(
-                failure_type=ILLEGAL_NO_NEW_DIVERGENCE,
-                path_id=path_id,
-                invariant=None,
-                role="Wind",
-                details=(
-                    "NO_NEW_DIVERGENCE sentinel emitted on a path whose "
-                    f"latest verdict contains HARD_fail invariants: {hard_fail}"
-                ),
+    # Sentinel legality — Finding D allows sentinel + disputed; the sentinel
+    # is illegal when (a) any HARD_fail is in the latest verdict, OR (b) the
+    # diff carries a non-empty ``accepted`` or ``reframed`` list (RFC §3.1
+    # ``divergence_marker`` docstring: only ``disputed`` MAY be non-empty).
+    # Each of the three conditions is independently audit-worthy so all
+    # applicable failures are emitted (the A/B harness in #203 groups by
+    # ``failure_type`` and the three discriminators do not occlude each
+    # other).
+    if diff.get("divergence_marker") == "NO_NEW_DIVERGENCE":
+        if hard_fail:
+            failures.append(
+                ValidatorFailure(
+                    failure_type=ILLEGAL_NO_NEW_DIVERGENCE,
+                    path_id=path_id,
+                    invariant=None,
+                    role="Wind",
+                    details=(
+                        "NO_NEW_DIVERGENCE sentinel emitted on a path whose "
+                        f"latest verdict contains HARD_fail invariants: {hard_fail}"
+                    ),
+                )
             )
-        )
-        # Continue checking REQUIRED CONTENT regardless — both failures
-        # are independently audit-worthy and per-invariant grouping in
-        # the A/B harness depends on emitting both.
+        if diff["value"]["accepted"]:
+            failures.append(
+                ValidatorFailure(
+                    failure_type=ILLEGAL_SENTINEL_WITH_ACCEPTED,
+                    path_id=path_id,
+                    invariant=None,
+                    role="Wind",
+                    details=(
+                        "NO_NEW_DIVERGENCE sentinel emitted with a non-empty "
+                        "accepted list; RFC §3.1 requires accepted to be empty "
+                        "when the sentinel is set."
+                    ),
+                )
+            )
+        if diff["value"]["reframed"]:
+            failures.append(
+                ValidatorFailure(
+                    failure_type=ILLEGAL_SENTINEL_WITH_REFRAMED,
+                    path_id=path_id,
+                    invariant=None,
+                    role="Wind",
+                    details=(
+                        "NO_NEW_DIVERGENCE sentinel emitted with a non-empty "
+                        "reframed list; RFC §3.1 requires reframed to be empty "
+                        "when the sentinel is set."
+                    ),
+                )
+            )
+        # Continue checking REQUIRED CONTENT regardless — sentinel-class
+        # failures and per-invariant content failures are independently
+        # audit-worthy.
 
     # Per-invariant REQUIRED CONTENT RULE.
+    #
+    # Two complementary checks per HARD_fail invariant, both emitted:
+    #
+    # 1. Existence (per-invariant, §3.3 Finding C): at least ONE qualifying
+    #    entry must exist (``accepted`` with non-empty ``terminal_rationale``
+    #    OR ``reframed`` with non-empty ``new_possibility``); otherwise
+    #    emit MISSING_REQUIRED_ENTRY.
+    #
+    # 2. Per-entry validity (per-entry, §3.2): EVERY matching ``accepted``
+    #    entry must carry a non-empty ``terminal_rationale``, and EVERY
+    #    matching ``reframed`` entry must carry a non-empty ``new_possibility``;
+    #    each malformed entry emits its own EMPTY_TERMINAL_RATIONALE or
+    #    EMPTY_NEW_POSSIBILITY failure. A sibling entry satisfying the
+    #    existence check does NOT absorb a sibling's per-entry malformation
+    #    — the §3.2 rule is per-entry, not per-invariant.
     for invariant in hard_fail:
         accepted_matches = _qualifying_accepted(diff, invariant)
         reframed_matches = _qualifying_reframed(diff, invariant)
 
-        if not accepted_matches and not reframed_matches:
+        accepted_has_valid = any(
+            isinstance(e.get("terminal_rationale"), str) and e.get("terminal_rationale")
+            for e in accepted_matches
+        )
+        reframed_has_valid = any(
+            isinstance(e.get("new_possibility"), str) and e.get("new_possibility")
+            for e in reframed_matches
+        )
+
+        if not accepted_has_valid and not reframed_has_valid:
             failures.append(
                 ValidatorFailure(
                     failure_type=MISSING_REQUIRED_ENTRY,
@@ -217,51 +290,42 @@ def validate_diff_revision(contract: PathContract, diff: DiffRevision) -> list[V
                     ),
                 )
             )
-            continue
 
-        # If accepted entries exist, at least one must carry a non-empty
-        # terminal_rationale. Otherwise, fall through to reframed check.
-        accepted_satisfies = any(
-            isinstance(e.get("terminal_rationale"), str) and e.get("terminal_rationale")
-            for e in accepted_matches
-        )
-        reframed_satisfies = any(
-            isinstance(e.get("new_possibility"), str) and e.get("new_possibility")
-            for e in reframed_matches
-        )
-
-        if accepted_satisfies or reframed_satisfies:
-            continue
-
-        # We have matches but none satisfy content requirements. Emit one
-        # failure per failing match category so the A/B harness can see
-        # exactly which prompt rule was violated.
-        for _ in accepted_matches:
-            failures.append(
-                ValidatorFailure(
-                    failure_type=EMPTY_TERMINAL_RATIONALE,
-                    path_id=path_id,
-                    invariant=invariant,
-                    role="Wind",
-                    details=(
-                        f"accepted entry on HARD_fail invariant {invariant!r} "
-                        "has empty or missing terminal_rationale."
-                    ),
+        # Per-entry validity — always run, independent of the existence
+        # check above. Each malformed entry emits its own failure so the
+        # A/B harness in #203 can group per-entry violations accurately.
+        for entry in accepted_matches:
+            tr = entry.get("terminal_rationale")
+            if not (isinstance(tr, str) and tr):
+                failures.append(
+                    ValidatorFailure(
+                        failure_type=EMPTY_TERMINAL_RATIONALE,
+                        path_id=path_id,
+                        invariant=invariant,
+                        role="Wind",
+                        details=(
+                            f"accepted entry on HARD_fail invariant {invariant!r} "
+                            "has empty or missing terminal_rationale (§3.2 per-entry "
+                            "rule: each malformed entry is a validator-failure event)."
+                        ),
+                    )
                 )
-            )
-        for _ in reframed_matches:
-            failures.append(
-                ValidatorFailure(
-                    failure_type=EMPTY_NEW_POSSIBILITY,
-                    path_id=path_id,
-                    invariant=invariant,
-                    role="Wind",
-                    details=(
-                        f"reframed entry on HARD_fail invariant {invariant!r} "
-                        "has empty or missing new_possibility."
-                    ),
+        for entry in reframed_matches:
+            np = entry.get("new_possibility")
+            if not (isinstance(np, str) and np):
+                failures.append(
+                    ValidatorFailure(
+                        failure_type=EMPTY_NEW_POSSIBILITY,
+                        path_id=path_id,
+                        invariant=invariant,
+                        role="Wind",
+                        details=(
+                            f"reframed entry on HARD_fail invariant {invariant!r} "
+                            "has empty or missing new_possibility (§3.2 per-entry "
+                            "rule: each malformed entry is a validator-failure event)."
+                        ),
+                    )
                 )
-            )
 
     return failures
 
@@ -408,6 +472,8 @@ __all__ = [
     "EMPTY_NEW_POSSIBILITY",
     "EMPTY_TERMINAL_RATIONALE",
     "ILLEGAL_NO_NEW_DIVERGENCE",
+    "ILLEGAL_SENTINEL_WITH_ACCEPTED",
+    "ILLEGAL_SENTINEL_WITH_REFRAMED",
     "MISSING_REQUIRED_ENTRY",
     "OWNERSHIP_VIOLATION",
     "RevisionKind",

--- a/src/debate_hall_mcp/path_contract_validator.py
+++ b/src/debate_hall_mcp/path_contract_validator.py
@@ -7,6 +7,36 @@ deliberate so the schema module remains stable and the policy can iterate
 independently. See the BOUNDARY docstring on
 ``path_contract.path_contract_from_json`` for the matching note.
 
+Two-phase validation pattern (CE+CRS rework on PR #217):
+-------------------------------------------------------
+
+Per RFC §6 item 3 the validator is the structural-rejection point for
+LLM-emitted payloads. The schema module deliberately does NOT validate
+structure (see the BOUNDARY docstring on ``path_contract_from_json``), so
+this module must defend itself against malformed payloads — an unhandled
+``KeyError`` / ``TypeError`` would crash the orchestrator instead of
+producing an auditable ``VALIDATOR_FAILURE`` event on the I4 ledger.
+
+Validation therefore runs in two phases:
+
+  PHASE 1 — SHAPE pre-pass (``validate_contract_shape`` /
+  ``validate_revision_shape``): checks that the payload is a ``Mapping``
+  with the required keys carrying the required runtime types. Each
+  structural defect emits a ``ValidatorFailure`` with
+  ``failure_type=SCHEMA_SHAPE_VIOLATION`` and a granular ``defect``
+  discriminator on the payload (``missing_key:...`` or ``type_error:...``)
+  so the #203 A/B harness can group by defect class.
+
+  PHASE 2 — SEMANTIC checks (existing functions: REQUIRED CONTENT RULE,
+  sentinel legality, ownership rule, Door citation existence). These run
+  ONLY when the shape pre-pass returned no failures. If the shape is
+  invalid, the public entry points return the shape failures immediately
+  and do NOT attempt semantic interpretation (fail-fast, never crash).
+
+The semantic-check functions therefore assume well-shaped inputs and may
+use direct dict access; the contract is that shape validation passed
+upstream.
+
 Scope per RFC-0001 #200:
 
 * Per-invariant REQUIRED CONTENT RULE (§3.2 amended; §3.3 Finding C):
@@ -50,9 +80,10 @@ Out of scope (deliberately deferred — see PR body):
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from debate_hall_mcp.events import DebateEvent, EventType, append_event
 from debate_hall_mcp.path_contract import (
@@ -100,6 +131,22 @@ OWNERSHIP_VIOLATION = "ownership_violation"
 DOOR_CITATION_NOT_FOUND = "door_citation_not_found"
 """Door cited an invariant that does not appear in the latest verdict revision."""
 
+SCHEMA_SHAPE_VIOLATION = "schema_shape_violation"
+"""Structural pre-pass defect on a contract or revision payload.
+
+Emitted by ``validate_contract_shape`` / ``validate_revision_shape`` for any
+malformed LLM-emitted payload: missing required keys, non-``Mapping`` /
+non-``list`` runtime types where the schema requires them, etc. The granular
+defect identifier (``missing_key:...``, ``type_error:...``) is carried on the
+event payload's ``defect`` field so the #203 A/B harness can group by defect
+class without parsing free text.
+
+This is the structural counterpart to the semantic failure-types above:
+shape defects short-circuit semantic interpretation entirely, preserving
+I4 (auditable ledger) by emitting an event rather than letting a
+``KeyError`` / ``TypeError`` crash the orchestrator.
+"""
+
 
 RevisionKind = Literal["frame", "verdict", "diff"]
 
@@ -128,6 +175,14 @@ class ValidatorFailure:
             violations); ``None`` otherwise.
         details: Human-readable explanation. Not a stable identifier — for
             grouping use ``failure_type``.
+        defect: Granular structural-defect discriminator for
+            ``SCHEMA_SHAPE_VIOLATION`` failures (e.g.
+            ``"missing_key:verdict_history"``,
+            ``"type_error:diff_history[0].value.accepted_not_list"``).
+            ``None`` for non-shape failure-types; preserved as a stable
+            identifier so the #203 harness can group shape defects by
+            class. Defaults to ``None`` for backward compatibility with
+            existing semantic-check call sites.
     """
 
     failure_type: str
@@ -135,6 +190,405 @@ class ValidatorFailure:
     invariant: str | None
     role: str | None
     details: str
+    defect: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# PHASE 1 — Shape pre-pass (CE+CRS rework on PR #217).
+#
+# Defends every public entry point against malformed LLM-emitted payloads.
+# Returns ``SCHEMA_SHAPE_VIOLATION`` failures with a granular ``defect``
+# discriminator instead of letting ``KeyError`` / ``TypeError`` propagate.
+# ---------------------------------------------------------------------------
+
+
+def _shape_failure(path_id: str, defect: str, details: str) -> ValidatorFailure:
+    """Build a ``SCHEMA_SHAPE_VIOLATION`` failure with a granular ``defect``."""
+    return ValidatorFailure(
+        failure_type=SCHEMA_SHAPE_VIOLATION,
+        path_id=path_id,
+        invariant=None,
+        role=None,
+        details=details,
+        defect=defect,
+    )
+
+
+def _check_invariant_entries(
+    entries: object,
+    *,
+    path_id: str,
+    locator_prefix: str,
+) -> list[ValidatorFailure]:
+    """Validate a list of ``InvariantEntry`` dicts.
+
+    Each entry must be a ``Mapping`` carrying at least an ``invariant`` (str)
+    and ``rationale`` (str) field. ``terminal_rationale`` / ``new_possibility``
+    are ``NotRequired`` per the schema and intentionally NOT shape-required —
+    their presence/contents are a semantic concern (handled by
+    ``validate_diff_revision``).
+    """
+    failures: list[ValidatorFailure] = []
+    if not isinstance(entries, list):
+        return [
+            _shape_failure(
+                path_id,
+                f"type_error:{locator_prefix}_not_list",
+                f"{locator_prefix} must be a list (got {type(entries).__name__}).",
+            )
+        ]
+    for index, entry in enumerate(entries):
+        locator = f"{locator_prefix}[{index}]"
+        if not isinstance(entry, Mapping):
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"type_error:{locator}_not_mapping",
+                    f"{locator} must be a Mapping (got {type(entry).__name__}).",
+                )
+            )
+            continue
+        if "invariant" not in entry:
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"missing_key:{locator}.invariant",
+                    f"{locator} missing required key 'invariant'.",
+                )
+            )
+        elif not isinstance(entry["invariant"], str):
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"type_error:{locator}.invariant_not_str",
+                    f"{locator}.invariant must be a string.",
+                )
+            )
+        if "rationale" not in entry:
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"missing_key:{locator}.rationale",
+                    f"{locator} missing required key 'rationale'.",
+                )
+            )
+        elif not isinstance(entry["rationale"], str):
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"type_error:{locator}.rationale_not_str",
+                    f"{locator}.rationale must be a string.",
+                )
+            )
+    return failures
+
+
+def _check_frame_history(history: list[Any], path_id: str) -> list[ValidatorFailure]:
+    """Shape-check each ``FrameRevision`` in ``frame_history``."""
+    failures: list[ValidatorFailure] = []
+    for index, rev in enumerate(history):
+        locator = f"frame_history[{index}]"
+        if not isinstance(rev, Mapping):
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"type_error:{locator}_not_mapping",
+                    f"{locator} must be a Mapping.",
+                )
+            )
+            continue
+        for key in ("rev", "written_at", "written_by", "value"):
+            if key not in rev:
+                failures.append(
+                    _shape_failure(
+                        path_id,
+                        f"missing_key:{locator}.{key}",
+                        f"{locator} missing required key '{key}'.",
+                    )
+                )
+    return failures
+
+
+def _check_verdict_history(history: list[Any], path_id: str) -> list[ValidatorFailure]:
+    """Shape-check each ``VerdictRevision`` in ``verdict_history``."""
+    failures: list[ValidatorFailure] = []
+    for index, rev in enumerate(history):
+        locator = f"verdict_history[{index}]"
+        if not isinstance(rev, Mapping):
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"type_error:{locator}_not_mapping",
+                    f"{locator} must be a Mapping.",
+                )
+            )
+            continue
+        for key in ("rev", "written_at", "written_by", "value"):
+            if key not in rev:
+                failures.append(
+                    _shape_failure(
+                        path_id,
+                        f"missing_key:{locator}.{key}",
+                        f"{locator} missing required key '{key}'.",
+                    )
+                )
+        # value must be a Mapping[str, Mapping] with status/rationale fields.
+        if "value" in rev:
+            value = rev["value"]
+            if not isinstance(value, Mapping):
+                failures.append(
+                    _shape_failure(
+                        path_id,
+                        f"type_error:{locator}.value_not_dict",
+                        f"{locator}.value must be a Mapping[invariant, verdict].",
+                    )
+                )
+                continue
+            for inv_name, verdict in value.items():
+                v_loc = f"{locator}.value[{inv_name!r}]"
+                if not isinstance(verdict, Mapping):
+                    failures.append(
+                        _shape_failure(
+                            path_id,
+                            f"type_error:{v_loc}_not_mapping",
+                            f"{v_loc} must be a Mapping with 'status' and 'rationale'.",
+                        )
+                    )
+                    continue
+                for key in ("status", "rationale"):
+                    if key not in verdict:
+                        failures.append(
+                            _shape_failure(
+                                path_id,
+                                f"missing_key:{v_loc}.{key}",
+                                f"{v_loc} missing required key '{key}'.",
+                            )
+                        )
+    return failures
+
+
+def _check_diff_history(history: list[Any], path_id: str) -> list[ValidatorFailure]:
+    """Shape-check each ``DiffRevision`` in ``diff_history``."""
+    failures: list[ValidatorFailure] = []
+    for index, rev in enumerate(history):
+        locator = f"diff_history[{index}]"
+        if not isinstance(rev, Mapping):
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"type_error:{locator}_not_mapping",
+                    f"{locator} must be a Mapping.",
+                )
+            )
+            continue
+        for key in ("rev", "written_at", "written_by", "value"):
+            if key not in rev:
+                failures.append(
+                    _shape_failure(
+                        path_id,
+                        f"missing_key:{locator}.{key}",
+                        f"{locator} missing required key '{key}'.",
+                    )
+                )
+        if "value" not in rev:
+            continue
+        value = rev["value"]
+        if not isinstance(value, Mapping):
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"type_error:{locator}.value_not_dict",
+                    f"{locator}.value must be a Mapping with accepted/disputed/reframed.",
+                )
+            )
+            continue
+        for bucket in ("accepted", "disputed", "reframed"):
+            if bucket not in value:
+                failures.append(
+                    _shape_failure(
+                        path_id,
+                        f"missing_key:{locator}.value.{bucket}",
+                        f"{locator}.value missing required bucket '{bucket}'.",
+                    )
+                )
+                continue
+            failures.extend(
+                _check_invariant_entries(
+                    value[bucket],
+                    path_id=path_id,
+                    locator_prefix=f"{locator}.value.{bucket}",
+                )
+            )
+    return failures
+
+
+def validate_contract_shape(contract: object) -> list[ValidatorFailure]:
+    """Structural pre-pass — verify ``contract`` matches the ``PathContract`` shape.
+
+    Returns ``SCHEMA_SHAPE_VIOLATION`` failures (with granular ``defect``
+    discriminators) for every structural defect found. An empty return means
+    the payload is well-shaped enough that semantic checks can proceed using
+    direct dict access.
+
+    The function is total: it never raises on a malformed input. Non-``Mapping``
+    inputs produce a single ``defect="not_a_mapping"`` failure (with
+    ``path_id="<unknown>"`` since path_id cannot be read).
+
+    Checks (in order):
+
+    * ``contract`` is a ``Mapping``.
+    * Required top-level keys present: ``path_id`` (str), ``frame_history``
+      (list), ``verdict_history`` (list), ``diff_history`` (list).
+    * For each revision in ``*_history``: a ``Mapping`` carrying ``rev``,
+      ``written_at``, ``written_by``, ``value``.
+    * For ``VerdictRevision.value``: a ``Mapping[str, Mapping]`` where each
+      inner mapping has ``status`` and ``rationale``.
+    * For ``DiffRevision.value``: a ``Mapping`` with ``accepted`` /
+      ``disputed`` / ``reframed`` lists, each containing ``Mapping`` entries
+      with ``invariant`` (str) and ``rationale`` (str).
+
+    ``NotRequired`` schema slots (``terminal_rationale``, ``new_possibility``,
+    ``divergence_marker``, ``synthesis_guidance``) are NOT shape-required —
+    their presence/contents are semantic concerns handled by
+    ``validate_diff_revision`` (per RFC §3.2 per-entry rule).
+    """
+    if not isinstance(contract, Mapping):
+        return [
+            _shape_failure(
+                "<unknown>",
+                "not_a_mapping",
+                f"contract must be a Mapping (got {type(contract).__name__}).",
+            )
+        ]
+
+    # Read path_id defensively for failure correlation.
+    path_id_raw = contract.get("path_id")
+    path_id: str = path_id_raw if isinstance(path_id_raw, str) else "<unknown>"
+
+    failures: list[ValidatorFailure] = []
+
+    if "path_id" not in contract:
+        failures.append(
+            _shape_failure(
+                path_id, "missing_key:path_id", "contract missing required key 'path_id'."
+            )
+        )
+    elif not isinstance(contract["path_id"], str):
+        failures.append(
+            _shape_failure(
+                path_id, "type_error:path_id_not_str", "contract.path_id must be a string."
+            )
+        )
+
+    for history_key in ("frame_history", "verdict_history", "diff_history"):
+        if history_key not in contract:
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"missing_key:{history_key}",
+                    f"contract missing required key '{history_key}'.",
+                )
+            )
+            continue
+        if not isinstance(contract[history_key], list):
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"type_error:{history_key}_not_list",
+                    f"contract.{history_key} must be a list.",
+                )
+            )
+
+    if isinstance(contract.get("frame_history"), list):
+        failures.extend(_check_frame_history(contract["frame_history"], path_id))
+    if isinstance(contract.get("verdict_history"), list):
+        failures.extend(_check_verdict_history(contract["verdict_history"], path_id))
+    if isinstance(contract.get("diff_history"), list):
+        failures.extend(_check_diff_history(contract["diff_history"], path_id))
+
+    return failures
+
+
+def _validate_diff_shape(diff: object, path_id: str) -> list[ValidatorFailure]:
+    """Shape-check a single ``DiffRevision`` payload (the one being appended)."""
+    if not isinstance(diff, Mapping):
+        return [
+            _shape_failure(
+                path_id,
+                "not_a_mapping",
+                f"diff revision must be a Mapping (got {type(diff).__name__}).",
+            )
+        ]
+    failures: list[ValidatorFailure] = []
+    for key in ("rev", "written_at", "written_by", "value"):
+        if key not in diff:
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"missing_key:diff.{key}",
+                    f"diff revision missing required key '{key}'.",
+                )
+            )
+    if "value" not in diff:
+        return failures
+    value = diff["value"]
+    if not isinstance(value, Mapping):
+        failures.append(
+            _shape_failure(
+                path_id,
+                "type_error:diff.value_not_dict",
+                "diff.value must be a Mapping with accepted/disputed/reframed.",
+            )
+        )
+        return failures
+    for bucket in ("accepted", "disputed", "reframed"):
+        if bucket not in value:
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"missing_key:diff.value.{bucket}",
+                    f"diff.value missing required bucket '{bucket}'.",
+                )
+            )
+            continue
+        failures.extend(
+            _check_invariant_entries(
+                value[bucket],
+                path_id=path_id,
+                locator_prefix=f"diff.value.{bucket}",
+            )
+        )
+    return failures
+
+
+def validate_revision_shape(
+    revision: object, *, kind: RevisionKind, path_id: str
+) -> list[ValidatorFailure]:
+    """Structural pre-pass for a single revision (``FrameRevision`` /
+    ``VerdictRevision`` / ``DiffRevision``).
+
+    Used by ``validate_revision_ownership`` to avoid ``KeyError`` on
+    ``revision["written_by"]`` when an LLM emits a malformed revision dict.
+    """
+    if not isinstance(revision, Mapping):
+        return [
+            _shape_failure(
+                path_id,
+                "not_a_mapping",
+                f"{kind} revision must be a Mapping (got {type(revision).__name__}).",
+            )
+        ]
+    failures: list[ValidatorFailure] = []
+    for key in ("rev", "written_at", "written_by", "value"):
+        if key not in revision:
+            failures.append(
+                _shape_failure(
+                    path_id,
+                    f"missing_key:revision.{key}",
+                    f"{kind} revision missing required key '{key}'.",
+                )
+            )
+    return failures
 
 
 # ---------------------------------------------------------------------------
@@ -185,9 +639,23 @@ def validate_diff_revision(contract: PathContract, diff: DiffRevision) -> list[V
       exist for the path; it MAY coexist with a non-empty ``disputed``
       list (Finding D).
 
+    Two-phase pattern: the shape pre-pass runs first; if any structural
+    defects are found the function returns those failures immediately and
+    does NOT proceed to semantic checks (fail-fast, never crash on a
+    malformed LLM payload — see module docstring).
+
     Returns:
         A list of ``ValidatorFailure`` records — empty when valid.
     """
+    # PHASE 1: shape pre-pass — never trust LLM-emitted payloads.
+    path_id_raw = contract.get("path_id") if isinstance(contract, Mapping) else None
+    pid_for_diff: str = path_id_raw if isinstance(path_id_raw, str) else "<unknown>"
+    shape_failures = validate_contract_shape(contract)
+    shape_failures.extend(_validate_diff_shape(diff, pid_for_diff))
+    if shape_failures:
+        return shape_failures
+
+    # PHASE 2: semantic checks (shape is now verified).
     failures: list[ValidatorFailure] = []
     path_id = contract["path_id"]
     hard_fail = _hard_fail_invariants(contract)
@@ -354,6 +822,11 @@ def validate_revision_ownership(
     only Wall may append to ``verdict_history``; Door is read-only and
     therefore can never legally appear as a writer of any revision.
 
+    Two-phase pattern: the per-revision shape pre-pass runs first; if the
+    revision is not a ``Mapping`` or is missing ``written_by``, returns
+    ``SCHEMA_SHAPE_VIOLATION`` failures and does NOT attempt the ownership
+    check (no ``KeyError`` on malformed payloads).
+
     Args:
         revision: The revision wrapper whose owner is being checked.
         kind: The kind of revision (``frame``, ``verdict``, or ``diff``)
@@ -362,9 +835,13 @@ def validate_revision_ownership(
             correlation; revisions themselves do not carry ``path_id``).
 
     Returns:
-        A list with at most one ``ValidatorFailure`` of type
-        ``OWNERSHIP_VIOLATION``.
+        A list with shape failures (if any) OR at most one ``ValidatorFailure``
+        of type ``OWNERSHIP_VIOLATION``.
     """
+    shape_failures = validate_revision_shape(revision, kind=kind, path_id=path_id)
+    if shape_failures:
+        return shape_failures
+
     expected = _LEGAL_OWNER[kind]
     actual = revision["written_by"]
     if actual == expected:
@@ -400,11 +877,20 @@ def validate_door_citations(
     extracting the list of cited invariant names; this function does the
     membership check against the latest verdict revision.
 
+    Two-phase pattern: shape pre-pass runs first; on shape failure the
+    function returns those failures and does NOT attempt citation
+    membership lookup (no ``KeyError`` on malformed payloads).
+
     Returns:
-        One ``DOOR_CITATION_NOT_FOUND`` failure per cited invariant that
-        does NOT appear in the latest verdict revision. If there is no
-        verdict revision at all, every cited invariant is reported.
+        Shape failures (if any) OR one ``DOOR_CITATION_NOT_FOUND`` failure
+        per cited invariant that does NOT appear in the latest verdict
+        revision. If there is no verdict revision at all, every cited
+        invariant is reported.
     """
+    shape_failures = validate_contract_shape(contract)
+    if shape_failures:
+        return shape_failures
+
     latest = _latest_verdict_value(contract)
     known: set[str] = set(latest.keys()) if latest is not None else set()
     return [
@@ -429,13 +915,19 @@ def validate_door_citations(
 
 
 def _failure_payload(failure: ValidatorFailure) -> dict[str, object]:
-    """Project a ``ValidatorFailure`` into a flat JSON-safe event payload."""
+    """Project a ``ValidatorFailure`` into a flat JSON-safe event payload.
+
+    Includes ``defect`` for ``SCHEMA_SHAPE_VIOLATION`` failures so the #203
+    A/B harness can group structural defects by class without parsing the
+    free-text ``details`` field.
+    """
     return {
         "failure_type": failure.failure_type,
         "path_id": failure.path_id,
         "invariant": failure.invariant,
         "role": failure.role,
         "details": failure.details,
+        "defect": failure.defect,
     }
 
 
@@ -476,10 +968,13 @@ __all__ = [
     "ILLEGAL_SENTINEL_WITH_REFRAMED",
     "MISSING_REQUIRED_ENTRY",
     "OWNERSHIP_VIOLATION",
+    "SCHEMA_SHAPE_VIOLATION",
     "RevisionKind",
     "ValidatorFailure",
     "emit_validator_failures",
+    "validate_contract_shape",
     "validate_diff_revision",
     "validate_door_citations",
     "validate_revision_ownership",
+    "validate_revision_shape",
 ]

--- a/tests/unit/test_path_contract_validator.py
+++ b/tests/unit/test_path_contract_validator.py
@@ -514,9 +514,19 @@ def test_no_new_divergence_with_non_empty_disputed_only_is_legal_finding_d_regre
 
 
 def test_ownership_wind_writing_verdict_fails() -> None:
-    """Wind writing a VerdictRevision → OWNERSHIP_VIOLATION."""
+    """Wind writing a VerdictRevision → SCHEMA_SHAPE_VIOLATION.
+
+    Per Cubic P2 rework on PR #217: ``written_by`` is a Literal field; a
+    value outside the kind's Literal set is a STRUCTURAL defect caught at
+    the shape pre-pass, not a semantic OWNERSHIP_VIOLATION. The latter is
+    only reachable when ``written_by`` is a structurally valid string but
+    semantically wrong for the kind — which under the strengthened
+    ``Literal["Wall"]`` rule for verdicts is now unreachable for verdicts
+    (any non-"Wall" value is rejected at shape time).
+    """
     from debate_hall_mcp.path_contract_validator import (
         OWNERSHIP_VIOLATION,
+        SCHEMA_SHAPE_VIOLATION,
         validate_revision_ownership,
     )
 
@@ -527,13 +537,20 @@ def test_ownership_wind_writing_verdict_fails() -> None:
         value={},
     )
     failures = validate_revision_ownership(bad, kind="verdict", path_id="path_1")
-    assert any(f.failure_type == OWNERSHIP_VIOLATION and f.role == "Wind" for f in failures)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:revision.written_by:'Wind'"
+        for f in failures
+    ), failures
+    # Two-phase short-circuit: semantic OWNERSHIP_VIOLATION does NOT also fire.
+    assert not any(f.failure_type == OWNERSHIP_VIOLATION for f in failures)
 
 
 def test_ownership_wall_writing_frame_fails() -> None:
-    """Wall writing a FrameRevision → OWNERSHIP_VIOLATION."""
+    """Wall writing a FrameRevision → SCHEMA_SHAPE_VIOLATION (see verdict test for rationale)."""
     from debate_hall_mcp.path_contract_validator import (
         OWNERSHIP_VIOLATION,
+        SCHEMA_SHAPE_VIOLATION,
         validate_revision_ownership,
     )
 
@@ -549,19 +566,30 @@ def test_ownership_wall_writing_frame_fails() -> None:
         ),
     )
     failures = validate_revision_ownership(bad, kind="frame", path_id="path_1")
-    assert any(f.failure_type == OWNERSHIP_VIOLATION and f.role == "Wall" for f in failures)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:revision.written_by:'Wall'"
+        for f in failures
+    ), failures
+    assert not any(f.failure_type == OWNERSHIP_VIOLATION for f in failures)
 
 
 def test_ownership_door_writing_diff_fails() -> None:
-    """Door writing a DiffRevision → OWNERSHIP_VIOLATION (Door is read-only)."""
+    """Door writing a DiffRevision → SCHEMA_SHAPE_VIOLATION (Door not in Literal["Wind"])."""
     from debate_hall_mcp.path_contract_validator import (
         OWNERSHIP_VIOLATION,
+        SCHEMA_SHAPE_VIOLATION,
         validate_revision_ownership,
     )
 
     bad = _diff_rev(0, written_by="Door")
     failures = validate_revision_ownership(bad, kind="diff", path_id="path_1")
-    assert any(f.failure_type == OWNERSHIP_VIOLATION and f.role == "Door" for f in failures)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:revision.written_by:'Door'"
+        for f in failures
+    ), failures
+    assert not any(f.failure_type == OWNERSHIP_VIOLATION for f in failures)
 
 
 def test_ownership_correct_owners_pass() -> None:
@@ -1056,3 +1084,428 @@ def test_validator_failure_event_payload_includes_defect(tmp_path: Path) -> None
     loaded = load_events(thread_id="t-defect", state_dir=tmp_path)
     assert len(loaded) == 1
     assert loaded[0].payload["defect"] == "missing_key:verdict_history"
+
+
+# ---------------------------------------------------------------------------
+# Shape pre-pass: Literal VALUE membership (Cubic P2 rework on PR #217).
+#
+# The pre-pass previously checked key PRESENCE but not Literal VALUE
+# membership. A malformed status like ``"HARD_FAIL"`` (caps) or
+# ``written_by="wind"`` (lowercase) passed shape validation and then either
+# (a) silently bypassed downstream semantic checks (false negative on the
+# REQUIRED CONTENT RULE) or (b) was mis-categorized as ``OWNERSHIP_VIOLATION``
+# when the real defect is structural.
+#
+# Per RFC §3.1:
+#   * ``InvariantVerdict.status: Literal["HARD_pass", "HARD_fail", "SOFT_disputed"]``
+#   * ``FrameRevision.written_by: Literal["Wind"]``
+#   * ``VerdictRevision.written_by: Literal["Wall"]``
+#   * ``DiffRevision.written_by: Literal["Wind"]``
+#   * ``DiffRevision.divergence_marker: NotRequired[Literal["NO_NEW_DIVERGENCE"]]``
+#
+# Defect identifier format: ``invalid_literal:<locator>:<actual_repr>``.
+# ---------------------------------------------------------------------------
+
+
+def test_shape_rejects_verdict_status_uppercase_literal() -> None:
+    """``status="HARD_FAIL"`` (uppercase) is NOT in the Literal set → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wall",
+                "value": {"inv_a": {"status": "HARD_FAIL", "rationale": "blocked"}},
+            }
+        ],
+        "diff_history": [],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect is not None
+        and f.defect.startswith("invalid_literal:verdict_history[0].value[")
+        and f.defect.endswith("].status:'HARD_FAIL'")
+        for f in failures
+    ), failures
+
+
+def test_shape_rejects_verdict_status_lowercase_failed() -> None:
+    """``status="failed"`` is NOT in the Literal set → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wall",
+                "value": {"inv_a": {"status": "failed", "rationale": "x"}},
+            }
+        ],
+        "diff_history": [],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect is not None
+        and "invalid_literal:" in f.defect
+        and f.defect.endswith(".status:'failed'")
+        for f in failures
+    ), failures
+
+
+def test_shape_rejects_verdict_status_non_string() -> None:
+    """``status=42`` (non-string) → SCHEMA_SHAPE_VIOLATION (invalid_literal defect)."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wall",
+                "value": {"inv_a": {"status": 42, "rationale": "x"}},
+            }
+        ],
+        "diff_history": [],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect is not None
+        and "invalid_literal:" in f.defect
+        and f.defect.endswith(".status:42")
+        for f in failures
+    ), failures
+
+
+def test_shape_rejects_frame_written_by_lowercase_wind() -> None:
+    """Frame ``written_by="wind"`` (lowercase) → SCHEMA_SHAPE_VIOLATION (not OWNERSHIP)."""
+    from debate_hall_mcp.path_contract_validator import (
+        OWNERSHIP_VIOLATION,
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+        validate_revision_ownership,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "wind",  # lowercase — not in Literal set
+                "value": {},
+            }
+        ],
+        "verdict_history": [],
+        "diff_history": [],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:frame_history[0].written_by:'wind'"
+        for f in failures
+    ), failures
+
+    # Per-revision check via validate_revision_shape (called by ownership pre-pass).
+    revision = {"rev": 0, "written_at": _now(), "written_by": "wind", "value": {}}
+    own_failures = validate_revision_ownership(  # type: ignore[arg-type]
+        revision, kind="frame", path_id="p"
+    )
+    assert any(f.failure_type == SCHEMA_SHAPE_VIOLATION for f in own_failures)
+    assert not any(
+        f.failure_type == OWNERSHIP_VIOLATION for f in own_failures
+    ), "Shape violation must short-circuit ownership semantic check"
+
+
+def test_shape_rejects_diff_written_by_door() -> None:
+    """Diff ``written_by="Door"`` is NOT in Literal["Wind"] → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        OWNERSHIP_VIOLATION,
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+        validate_revision_ownership,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [],
+        "diff_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Door",  # not in Literal["Wind"]
+                "value": {"accepted": [], "disputed": [], "reframed": []},
+            }
+        ],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:diff_history[0].written_by:'Door'"
+        for f in failures
+    ), failures
+
+    # Ownership pre-pass short-circuits semantic OWNERSHIP_VIOLATION.
+    revision = {
+        "rev": 0,
+        "written_at": _now(),
+        "written_by": "Door",
+        "value": {"accepted": [], "disputed": [], "reframed": []},
+    }
+    own_failures = validate_revision_ownership(  # type: ignore[arg-type]
+        revision, kind="diff", path_id="p"
+    )
+    assert any(f.failure_type == SCHEMA_SHAPE_VIOLATION for f in own_failures)
+    assert not any(f.failure_type == OWNERSHIP_VIOLATION for f in own_failures)
+
+
+def test_shape_rejects_verdict_written_by_wind_not_wall() -> None:
+    """Verdict ``written_by="Wind"`` is NOT in Literal["Wall"] → SCHEMA_SHAPE_VIOLATION.
+
+    "Wind" is a valid Literal for frame/diff but NOT for verdict; the real
+    defect here is shape (wrong Literal for this revision kind), not
+    semantic ownership.
+    """
+    from debate_hall_mcp.path_contract_validator import (
+        OWNERSHIP_VIOLATION,
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+        validate_revision_ownership,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wind",  # not in Literal["Wall"]
+                "value": {"inv_a": {"status": "HARD_pass", "rationale": "ok"}},
+            }
+        ],
+        "diff_history": [],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:verdict_history[0].written_by:'Wind'"
+        for f in failures
+    ), failures
+
+    revision = {
+        "rev": 0,
+        "written_at": _now(),
+        "written_by": "Wind",
+        "value": {"inv_a": {"status": "HARD_pass", "rationale": "ok"}},
+    }
+    own_failures = validate_revision_ownership(  # type: ignore[arg-type]
+        revision, kind="verdict", path_id="p"
+    )
+    assert any(f.failure_type == SCHEMA_SHAPE_VIOLATION for f in own_failures)
+    assert not any(f.failure_type == OWNERSHIP_VIOLATION for f in own_failures)
+
+
+def test_shape_rejects_divergence_marker_unknown_value() -> None:
+    """``divergence_marker="DIVERGENCE"`` is not in Literal["NO_NEW_DIVERGENCE"] → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [],
+        "diff_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wind",
+                "value": {"accepted": [], "disputed": [], "reframed": []},
+                "divergence_marker": "DIVERGENCE",
+            }
+        ],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:diff_history[0].divergence_marker:'DIVERGENCE'"
+        for f in failures
+    ), failures
+
+
+def test_shape_rejects_divergence_marker_lowercase() -> None:
+    """Lowercase ``divergence_marker="no_new_divergence"`` → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [],
+        "diff_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wind",
+                "value": {"accepted": [], "disputed": [], "reframed": []},
+                "divergence_marker": "no_new_divergence",
+            }
+        ],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:diff_history[0].divergence_marker:'no_new_divergence'"
+        for f in failures
+    ), failures
+
+
+def test_shape_pre_pass_short_circuits_required_content_on_bad_status_literal() -> None:
+    """Malformed status Literal must NOT silently bypass REQUIRED CONTENT RULE.
+
+    Regression guard for the Cubic Bug A false-negative: previously, a verdict
+    with ``status="HARD_FAIL"`` (caps) passed shape validation, then the semantic
+    REQUIRED_CONTENT check compared against the canonical ``"HARD_fail"`` and
+    saw no HARD_fail invariants — so a diff missing required rationale was
+    silently accepted. The fix: shape pre-pass rejects the bad Literal first;
+    semantic checks never run on shape-invalid input.
+    """
+    from debate_hall_mcp.path_contract_validator import (
+        MISSING_REQUIRED_ENTRY,
+        SCHEMA_SHAPE_VIOLATION,
+        validate_diff_revision,
+    )
+
+    bad_contract: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wall",
+                "value": {"inv_a": {"status": "HARD_FAIL", "rationale": "blocked"}},
+            }
+        ],
+        "diff_history": [],
+    }
+    # Diff with NO qualifying entry for inv_a — would be a MISSING_REQUIRED_ENTRY
+    # if the status Literal were valid; instead we must see only shape failures.
+    diff = _diff_rev(0)
+
+    failures = validate_diff_revision(bad_contract, diff)  # type: ignore[arg-type]
+
+    # Shape failure on the status Literal must be present.
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect is not None
+        and "invalid_literal:" in f.defect
+        and ".status:'HARD_FAIL'" in f.defect
+        for f in failures
+    ), failures
+    # Two-phase short-circuit: no semantic failures emitted.
+    assert not any(
+        f.failure_type == MISSING_REQUIRED_ENTRY for f in failures
+    ), "Shape pre-pass must short-circuit semantic checks on shape-invalid input"
+
+
+def test_shape_pre_pass_allows_all_three_valid_status_literals() -> None:
+    """Regression guard: each of the 3 valid status Literals passes shape pre-pass."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    for status in ("HARD_pass", "HARD_fail", "SOFT_disputed"):
+        contract: dict[str, object] = {
+            "path_id": "p",
+            "frame_history": [],
+            "verdict_history": [
+                {
+                    "rev": 0,
+                    "written_at": _now(),
+                    "written_by": "Wall",
+                    "value": {"inv_a": {"status": status, "rationale": "x"}},
+                }
+            ],
+            "diff_history": [],
+        }
+        failures = validate_contract_shape(contract)
+        assert not any(
+            f.failure_type == SCHEMA_SHAPE_VIOLATION for f in failures
+        ), f"Valid status Literal {status!r} must not produce shape failures; got {failures}"
+
+
+def test_shape_pre_pass_allows_valid_divergence_marker() -> None:
+    """Regression guard: ``divergence_marker="NO_NEW_DIVERGENCE"`` passes shape pre-pass."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    contract: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [],
+        "diff_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wind",
+                "value": {"accepted": [], "disputed": [], "reframed": []},
+                "divergence_marker": "NO_NEW_DIVERGENCE",
+            }
+        ],
+    }
+    failures = validate_contract_shape(contract)
+    assert not any(f.failure_type == SCHEMA_SHAPE_VIOLATION for f in failures), failures
+
+
+def test_shape_pre_pass_diff_shape_helper_rejects_invalid_written_by() -> None:
+    """``validate_diff_revision`` (which calls ``_validate_diff_shape``) rejects diff with bad written_by Literal."""
+    from debate_hall_mcp.path_contract_validator import (
+        OWNERSHIP_VIOLATION,
+        SCHEMA_SHAPE_VIOLATION,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    bad_diff: dict[str, object] = {
+        "rev": 0,
+        "written_at": _now(),
+        "written_by": "Door",  # not in Literal["Wind"]
+        "value": {"accepted": [], "disputed": [], "reframed": []},
+    }
+    failures = validate_diff_revision(contract, bad_diff)  # type: ignore[arg-type]
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "invalid_literal:diff.written_by:'Door'"
+        for f in failures
+    ), failures
+    # Two-phase: ownership/semantic checks short-circuit on shape failure.
+    assert not any(f.failure_type == OWNERSHIP_VIOLATION for f in failures)

--- a/tests/unit/test_path_contract_validator.py
+++ b/tests/unit/test_path_contract_validator.py
@@ -1,0 +1,569 @@
+"""RED-stage unit tests for ``debate_hall_mcp.path_contract_validator`` (RFC-0001 #200).
+
+Acceptance bound to the AMENDED RFC at
+``docs/rfc-0001-path-contract-wind-learning-loop.md``:
+
+* §3.1 — Ownership rule (Wind→frame/diff, Wall→verdict, Door read-only).
+* §3.2 — REQUIRED CONTENT RULE for ``diff`` revisions, **per HARD_fail invariant**
+  (each HARD_fail needs its own qualifying ``accepted``-with-``terminal_rationale``
+  OR ``reframed``-with-``new_possibility`` entry); ``NO_NEW_DIVERGENCE`` legal only
+  when zero HARD_fail verdicts; sentinel MAY coexist with a non-empty ``disputed``
+  list (Finding D).
+* §3.3 — Findings C (per-invariant tightening), D (sentinel+disputed coexistence),
+  E (``synthesis_guidance`` slot — Door-citation enforcement is the validator's
+  ``validate_door_citations`` responsibility for *existence* of cited invariants;
+  the *requirement* to cite ``synthesis_guidance`` when present is downstream
+  prompt-level (#198) and Door-side context (#199), out of scope here).
+* §6 item 2 — citation existence check for Door.
+* §6 item 3 — ``VALIDATOR_FAILURE`` events with failure-type metadata.
+
+Out of scope here (downstream issues): orchestrator call-site wiring (depends on
+#197/#198 to thread ``PathContract`` objects through ``_execute_consensus_loop``);
+prompt edits (#198); state serialization (#197); feature flag wiring (#201/#205).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from debate_hall_mcp.path_contract import (
+    DiffRevision,
+    FrameRevision,
+    InvariantEntry,
+    InvariantVerdict,
+    PathContract,
+    PathDiff,
+    PathFrame,
+    VerdictRevision,
+    new_path_contract,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — minimal contract builders used across the RED matrix.
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _frame_rev(rev: int = 0, invariants: list[str] | None = None) -> FrameRevision:
+    return FrameRevision(
+        rev=rev,
+        written_at=_now(),
+        written_by="Wind",
+        value=PathFrame(
+            assumed_problem="x",
+            success_criterion="y",
+            accepted_failure_mode="z",
+            invariants_touched=invariants or ["inv_a"],
+        ),
+    )
+
+
+def _verdict_rev(
+    rev: int,
+    verdicts: dict[str, tuple[str, str]],
+) -> VerdictRevision:
+    return VerdictRevision(
+        rev=rev,
+        written_at=_now(),
+        written_by="Wall",
+        value={
+            name: InvariantVerdict(status=status, rationale=rationale)  # type: ignore[typeddict-item]
+            for name, (status, rationale) in verdicts.items()
+        },
+    )
+
+
+def _entry(invariant: str, **extra: str) -> InvariantEntry:
+    base: InvariantEntry = InvariantEntry(invariant=invariant, rationale="r")
+    for k, v in extra.items():
+        base[k] = v  # type: ignore[literal-required]
+    return base
+
+
+def _diff_rev(
+    rev: int,
+    *,
+    accepted: list[InvariantEntry] | None = None,
+    disputed: list[InvariantEntry] | None = None,
+    reframed: list[InvariantEntry] | None = None,
+    divergence_marker: str | None = None,
+    synthesis_guidance: str | None = None,
+    written_by: str = "Wind",
+) -> DiffRevision:
+    diff: DiffRevision = DiffRevision(
+        rev=rev,
+        written_at=_now(),
+        written_by=written_by,  # type: ignore[typeddict-item]
+        value=PathDiff(
+            accepted=accepted or [],
+            disputed=disputed or [],
+            reframed=reframed or [],
+        ),
+    )
+    if divergence_marker is not None:
+        diff["divergence_marker"] = divergence_marker  # type: ignore[typeddict-item]
+    if synthesis_guidance is not None:
+        diff["synthesis_guidance"] = synthesis_guidance
+    return diff
+
+
+def _contract_with_verdicts(
+    verdicts: dict[str, tuple[str, str]],
+    *,
+    path_id: str = "path_1",
+) -> PathContract:
+    contract = new_path_contract(path_id)
+    contract["frame_history"].append(
+        _frame_rev(invariants=list(verdicts.keys()))
+    )
+    contract["verdict_history"].append(_verdict_rev(0, verdicts))
+    return contract
+
+
+# ---------------------------------------------------------------------------
+# Module importability.
+# ---------------------------------------------------------------------------
+
+
+def test_module_importable() -> None:
+    """The validator module must be importable from the package root."""
+    import debate_hall_mcp.path_contract_validator  # noqa: F401
+
+
+def test_validator_failure_dataclass_shape() -> None:
+    """``ValidatorFailure`` exposes failure_type, path_id, invariant, role, details."""
+    from debate_hall_mcp.path_contract_validator import ValidatorFailure
+
+    failure = ValidatorFailure(
+        failure_type="missing_required_entry",
+        path_id="path_1",
+        invariant="inv_a",
+        role="Wind",
+        details="explanation",
+    )
+    assert failure.failure_type == "missing_required_entry"
+    assert failure.path_id == "path_1"
+    assert failure.invariant == "inv_a"
+    assert failure.role == "Wind"
+    assert failure.details == "explanation"
+
+
+def test_failure_type_constants_present() -> None:
+    """Failure-type discriminators are exposed as module constants for #203 A/B grouping."""
+    from debate_hall_mcp.path_contract_validator import (
+        DOOR_CITATION_NOT_FOUND,
+        EMPTY_NEW_POSSIBILITY,
+        EMPTY_TERMINAL_RATIONALE,
+        ILLEGAL_NO_NEW_DIVERGENCE,
+        MISSING_REQUIRED_ENTRY,
+        OWNERSHIP_VIOLATION,
+    )
+
+    # All constants are non-empty strings; values are stable identifiers.
+    for c in (
+        MISSING_REQUIRED_ENTRY,
+        EMPTY_TERMINAL_RATIONALE,
+        EMPTY_NEW_POSSIBILITY,
+        ILLEGAL_NO_NEW_DIVERGENCE,
+        OWNERSHIP_VIOLATION,
+        DOOR_CITATION_NOT_FOUND,
+    ):
+        assert isinstance(c, str) and c
+
+
+# ---------------------------------------------------------------------------
+# REQUIRED CONTENT RULE — per-invariant (RFC §3.2 / §3.3 Finding C).
+# ---------------------------------------------------------------------------
+
+
+def test_diff_satisfies_when_accepted_has_terminal_rationale() -> None:
+    """HARD_fail invariant with matching ``accepted`` + non-empty ``terminal_rationale`` PASSES."""
+    from debate_hall_mcp.path_contract_validator import validate_diff_revision
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(
+        0,
+        accepted=[_entry("inv_a", terminal_rationale="no creative reframe exists")],
+    )
+    failures = validate_diff_revision(contract, diff)
+    assert failures == []
+
+
+def test_diff_satisfies_when_reframed_has_new_possibility() -> None:
+    """HARD_fail invariant with matching ``reframed`` + non-empty ``new_possibility`` PASSES."""
+    from debate_hall_mcp.path_contract_validator import validate_diff_revision
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(
+        0,
+        reframed=[_entry("inv_a", new_possibility="catalyst-opened path b")],
+    )
+    failures = validate_diff_revision(contract, diff)
+    assert failures == []
+
+
+def test_diff_fails_when_hard_fail_invariant_silently_omitted() -> None:
+    """HARD_fail with NO matching entry anywhere → MISSING_REQUIRED_ENTRY."""
+    from debate_hall_mcp.path_contract_validator import (
+        MISSING_REQUIRED_ENTRY,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(0)  # all buckets empty
+    failures = validate_diff_revision(contract, diff)
+    assert any(
+        f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_a"
+        for f in failures
+    )
+
+
+def test_diff_fails_when_accepted_entry_has_empty_terminal_rationale() -> None:
+    """``accepted`` on HARD_fail with empty ``terminal_rationale`` → EMPTY_TERMINAL_RATIONALE."""
+    from debate_hall_mcp.path_contract_validator import (
+        EMPTY_TERMINAL_RATIONALE,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(0, accepted=[_entry("inv_a", terminal_rationale="")])
+    failures = validate_diff_revision(contract, diff)
+    assert any(
+        f.failure_type == EMPTY_TERMINAL_RATIONALE and f.invariant == "inv_a"
+        for f in failures
+    )
+
+
+def test_diff_fails_when_accepted_entry_missing_terminal_rationale() -> None:
+    """``accepted`` on HARD_fail with NO ``terminal_rationale`` key → EMPTY_TERMINAL_RATIONALE."""
+    from debate_hall_mcp.path_contract_validator import (
+        EMPTY_TERMINAL_RATIONALE,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(0, accepted=[_entry("inv_a")])  # no terminal_rationale at all
+    failures = validate_diff_revision(contract, diff)
+    assert any(
+        f.failure_type == EMPTY_TERMINAL_RATIONALE and f.invariant == "inv_a"
+        for f in failures
+    )
+
+
+def test_diff_fails_when_reframed_entry_has_empty_new_possibility() -> None:
+    """``reframed`` on HARD_fail with empty ``new_possibility`` → EMPTY_NEW_POSSIBILITY."""
+    from debate_hall_mcp.path_contract_validator import (
+        EMPTY_NEW_POSSIBILITY,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(0, reframed=[_entry("inv_a", new_possibility="")])
+    failures = validate_diff_revision(contract, diff)
+    assert any(
+        f.failure_type == EMPTY_NEW_POSSIBILITY and f.invariant == "inv_a"
+        for f in failures
+    )
+
+
+def test_diff_fails_when_reframed_entry_missing_new_possibility() -> None:
+    """``reframed`` on HARD_fail with NO ``new_possibility`` key → EMPTY_NEW_POSSIBILITY."""
+    from debate_hall_mcp.path_contract_validator import (
+        EMPTY_NEW_POSSIBILITY,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(0, reframed=[_entry("inv_a")])  # no new_possibility at all
+    failures = validate_diff_revision(contract, diff)
+    assert any(
+        f.failure_type == EMPTY_NEW_POSSIBILITY and f.invariant == "inv_a"
+        for f in failures
+    )
+
+
+def test_diff_fails_per_invariant_not_per_path_finding_c() -> None:
+    """RFC §3.3 Finding C: sibling entry on different invariant does NOT satisfy.
+
+    Two HARD_fail invariants (inv_a, inv_b); a reframed entry on inv_b does NOT
+    cover the requirement on inv_a. Validator must emit MISSING_REQUIRED_ENTRY
+    for inv_a specifically.
+    """
+    from debate_hall_mcp.path_contract_validator import (
+        MISSING_REQUIRED_ENTRY,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts(
+        {"inv_a": ("HARD_fail", "blocked"), "inv_b": ("HARD_fail", "blocked")}
+    )
+    diff = _diff_rev(
+        0, reframed=[_entry("inv_b", new_possibility="covers inv_b only")]
+    )
+    failures = validate_diff_revision(contract, diff)
+    inv_a_misses = [
+        f for f in failures
+        if f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_a"
+    ]
+    inv_b_misses = [
+        f for f in failures
+        if f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_b"
+    ]
+    assert inv_a_misses, "inv_a HARD_fail must be flagged as missing"
+    assert not inv_b_misses, "inv_b is satisfied by reframed entry"
+
+
+def test_diff_clean_when_no_hard_fail_verdicts() -> None:
+    """All-pass-or-disputed verdicts impose no REQUIRED CONTENT requirement."""
+    from debate_hall_mcp.path_contract_validator import validate_diff_revision
+
+    contract = _contract_with_verdicts(
+        {"inv_a": ("HARD_pass", "ok"), "inv_b": ("SOFT_disputed", "discuss")}
+    )
+    diff = _diff_rev(0)  # empty buckets allowed
+    failures = validate_diff_revision(contract, diff)
+    assert failures == []
+
+
+# ---------------------------------------------------------------------------
+# NO_NEW_DIVERGENCE sentinel rules (RFC §3.2 / §3.3 Finding D).
+# ---------------------------------------------------------------------------
+
+
+def test_no_new_divergence_legal_when_zero_hard_fail() -> None:
+    """Sentinel legal when every verdict is HARD_pass or SOFT_disputed."""
+    from debate_hall_mcp.path_contract_validator import validate_diff_revision
+
+    contract = _contract_with_verdicts(
+        {"inv_a": ("HARD_pass", "ok"), "inv_b": ("SOFT_disputed", "discuss")}
+    )
+    diff = _diff_rev(0, divergence_marker="NO_NEW_DIVERGENCE")
+    failures = validate_diff_revision(contract, diff)
+    assert failures == []
+
+
+def test_no_new_divergence_finding_d_may_coexist_with_disputed() -> None:
+    """Finding D: sentinel + non-empty ``disputed`` list is LEGAL."""
+    from debate_hall_mcp.path_contract_validator import validate_diff_revision
+
+    contract = _contract_with_verdicts(
+        {"inv_soft": ("SOFT_disputed", "discuss")}
+    )
+    diff = _diff_rev(
+        0,
+        divergence_marker="NO_NEW_DIVERGENCE",
+        disputed=[_entry("inv_soft")],
+    )
+    failures = validate_diff_revision(contract, diff)
+    assert failures == [], (
+        "RFC §3.3 Finding D: sentinel may coexist with non-empty disputed"
+    )
+
+
+def test_no_new_divergence_fails_on_any_hard_fail_verdict() -> None:
+    """Sentinel on a path whose verdict contains any HARD_fail → ILLEGAL_NO_NEW_DIVERGENCE."""
+    from debate_hall_mcp.path_contract_validator import (
+        ILLEGAL_NO_NEW_DIVERGENCE,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts(
+        {"inv_a": ("HARD_pass", "ok"), "inv_b": ("HARD_fail", "blocked")}
+    )
+    diff = _diff_rev(0, divergence_marker="NO_NEW_DIVERGENCE")
+    failures = validate_diff_revision(contract, diff)
+    assert any(
+        f.failure_type == ILLEGAL_NO_NEW_DIVERGENCE for f in failures
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ownership rule (RFC §3.1).
+# ---------------------------------------------------------------------------
+
+
+def test_ownership_wind_writing_verdict_fails() -> None:
+    """Wind writing a VerdictRevision → OWNERSHIP_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        OWNERSHIP_VIOLATION,
+        validate_revision_ownership,
+    )
+
+    bad: VerdictRevision = VerdictRevision(
+        rev=0,
+        written_at=_now(),
+        written_by="Wind",  # type: ignore[typeddict-item]
+        value={},
+    )
+    failures = validate_revision_ownership(bad, kind="verdict", path_id="path_1")
+    assert any(f.failure_type == OWNERSHIP_VIOLATION and f.role == "Wind" for f in failures)
+
+
+def test_ownership_wall_writing_frame_fails() -> None:
+    """Wall writing a FrameRevision → OWNERSHIP_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        OWNERSHIP_VIOLATION,
+        validate_revision_ownership,
+    )
+
+    bad: FrameRevision = FrameRevision(
+        rev=0,
+        written_at=_now(),
+        written_by="Wall",  # type: ignore[typeddict-item]
+        value=PathFrame(
+            assumed_problem="x",
+            success_criterion="y",
+            accepted_failure_mode="z",
+            invariants_touched=[],
+        ),
+    )
+    failures = validate_revision_ownership(bad, kind="frame", path_id="path_1")
+    assert any(f.failure_type == OWNERSHIP_VIOLATION and f.role == "Wall" for f in failures)
+
+
+def test_ownership_door_writing_diff_fails() -> None:
+    """Door writing a DiffRevision → OWNERSHIP_VIOLATION (Door is read-only)."""
+    from debate_hall_mcp.path_contract_validator import (
+        OWNERSHIP_VIOLATION,
+        validate_revision_ownership,
+    )
+
+    bad = _diff_rev(0, written_by="Door")
+    failures = validate_revision_ownership(bad, kind="diff", path_id="path_1")
+    assert any(f.failure_type == OWNERSHIP_VIOLATION and f.role == "Door" for f in failures)
+
+
+def test_ownership_correct_owners_pass() -> None:
+    """Correct owners (Wind→frame/diff, Wall→verdict) produce no failures."""
+    from debate_hall_mcp.path_contract_validator import validate_revision_ownership
+
+    assert validate_revision_ownership(_frame_rev(), kind="frame", path_id="p") == []
+    assert (
+        validate_revision_ownership(
+            _verdict_rev(0, {"x": ("HARD_pass", "ok")}), kind="verdict", path_id="p"
+        )
+        == []
+    )
+    assert validate_revision_ownership(_diff_rev(0), kind="diff", path_id="p") == []
+
+
+# ---------------------------------------------------------------------------
+# Door citation existence (RFC §6 item 2).
+# ---------------------------------------------------------------------------
+
+
+def test_door_citation_of_existing_invariant_passes() -> None:
+    """Door citing an invariant present in latest verdict → no failure."""
+    from debate_hall_mcp.path_contract_validator import validate_door_citations
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    failures = validate_door_citations(contract, cited_invariants=["inv_a"])
+    assert failures == []
+
+
+def test_door_citation_of_nonexistent_invariant_fails() -> None:
+    """Door citing an invariant NOT in latest verdict → DOOR_CITATION_NOT_FOUND."""
+    from debate_hall_mcp.path_contract_validator import (
+        DOOR_CITATION_NOT_FOUND,
+        validate_door_citations,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    failures = validate_door_citations(contract, cited_invariants=["ghost_invariant"])
+    assert any(
+        f.failure_type == DOOR_CITATION_NOT_FOUND and f.invariant == "ghost_invariant"
+        for f in failures
+    )
+
+
+def test_door_citation_with_no_verdict_history_fails_all_citations() -> None:
+    """If no verdict revision exists, every cited invariant is a not-found failure."""
+    from debate_hall_mcp.path_contract_validator import (
+        DOOR_CITATION_NOT_FOUND,
+        validate_door_citations,
+    )
+
+    contract = new_path_contract("path_1")  # no verdict history
+    failures = validate_door_citations(contract, cited_invariants=["any_inv"])
+    assert any(f.failure_type == DOOR_CITATION_NOT_FOUND for f in failures)
+
+
+# ---------------------------------------------------------------------------
+# VALIDATOR_FAILURE event emission (RFC §6 item 3).
+# ---------------------------------------------------------------------------
+
+
+def test_event_type_validator_failure_exists() -> None:
+    """``EventType.VALIDATOR_FAILURE`` must exist with the exact RFC-§6 string."""
+    from debate_hall_mcp.events import EventType
+
+    assert EventType.VALIDATOR_FAILURE.value == "validator_failure"
+
+
+def test_emit_validator_failures_writes_one_event_per_failure(tmp_path: Path) -> None:
+    """``emit_validator_failures`` appends one VALIDATOR_FAILURE event per failure."""
+    from debate_hall_mcp.events import EventType, load_events
+    from debate_hall_mcp.path_contract_validator import (
+        ValidatorFailure,
+        emit_validator_failures,
+    )
+
+    failures = [
+        ValidatorFailure(
+            failure_type="missing_required_entry",
+            path_id="path_1",
+            invariant="inv_a",
+            role=None,
+            details="HARD_fail on inv_a has no qualifying diff entry",
+        ),
+        ValidatorFailure(
+            failure_type="ownership_violation",
+            path_id="path_1",
+            invariant=None,
+            role="Wind",
+            details="Wind attempted verdict write",
+        ),
+    ]
+
+    events = emit_validator_failures(
+        thread_id="t-1", failures=failures, state_dir=tmp_path
+    )
+    assert len(events) == 2
+    assert all(e.event_type == EventType.VALIDATOR_FAILURE for e in events)
+
+    loaded = load_events(thread_id="t-1", state_dir=tmp_path)
+    assert len(loaded) == 2
+
+    # Discrimination metadata is in the payload, not the event_type, so #203 can group.
+    payloads = [e.payload for e in loaded]
+    assert {p["failure_type"] for p in payloads} == {
+        "missing_required_entry",
+        "ownership_violation",
+    }
+    # Per-failure correlatable fields preserved.
+    missing = next(p for p in payloads if p["failure_type"] == "missing_required_entry")
+    assert missing["path_id"] == "path_1"
+    assert missing["invariant"] == "inv_a"
+    assert missing["details"].startswith("HARD_fail")
+    ownership = next(p for p in payloads if p["failure_type"] == "ownership_violation")
+    assert ownership["role"] == "Wind"
+
+
+def test_emit_validator_failures_empty_list_is_noop(tmp_path: Path) -> None:
+    """No failures → no events written, no exceptions."""
+    from debate_hall_mcp.path_contract_validator import emit_validator_failures
+
+    events = emit_validator_failures(
+        thread_id="t-empty", failures=[], state_dir=tmp_path
+    )
+    assert events == []
+    # No events file written for an empty failure list.
+    events_file = tmp_path / "t-empty.events.jsonl"
+    assert not events_file.exists()

--- a/tests/unit/test_path_contract_validator.py
+++ b/tests/unit/test_path_contract_validator.py
@@ -361,6 +361,154 @@ def test_no_new_divergence_fails_on_any_hard_fail_verdict() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Per-entry rationale checks — Cubic bot-resolution P1 (RFC §3.2 per-entry rule).
+# ---------------------------------------------------------------------------
+
+
+def test_diff_fails_per_entry_when_sibling_accepted_entry_empty_terminal_rationale() -> None:
+    """RFC §3.2 per-entry rule: even when ONE ``accepted`` entry on a HARD_fail invariant
+    has a valid ``terminal_rationale``, a SIBLING ``accepted`` entry on the SAME invariant
+    with an empty/missing ``terminal_rationale`` MUST emit EMPTY_TERMINAL_RATIONALE.
+
+    The per-invariant existence check is satisfied by the valid entry (no
+    MISSING_REQUIRED_ENTRY), but the malformed sibling is still a per-entry
+    violation and must surface to the A/B harness.
+    """
+    from debate_hall_mcp.path_contract_validator import (
+        EMPTY_TERMINAL_RATIONALE,
+        MISSING_REQUIRED_ENTRY,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(
+        0,
+        accepted=[
+            _entry("inv_a", terminal_rationale="valid reason — no creative reframe"),
+            _entry("inv_a", terminal_rationale=""),  # malformed sibling
+        ],
+    )
+    failures = validate_diff_revision(contract, diff)
+    # The valid entry satisfies the per-invariant existence check.
+    assert not any(
+        f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_a" for f in failures
+    )
+    # But the malformed sibling must still emit a per-entry failure.
+    empty_tr = [
+        f for f in failures if f.failure_type == EMPTY_TERMINAL_RATIONALE and f.invariant == "inv_a"
+    ]
+    assert len(empty_tr) == 1, (
+        "RFC §3.2 per-entry: each malformed accepted entry must emit its own "
+        "EMPTY_TERMINAL_RATIONALE; the per-invariant existence check does not absorb it."
+    )
+
+
+def test_diff_fails_per_entry_when_sibling_reframed_entry_empty_new_possibility() -> None:
+    """RFC §3.2 per-entry rule: even when ONE ``reframed`` entry on a HARD_fail invariant
+    has a valid ``new_possibility``, a SIBLING ``reframed`` entry on the SAME invariant
+    with an empty/missing ``new_possibility`` MUST emit EMPTY_NEW_POSSIBILITY.
+    """
+    from debate_hall_mcp.path_contract_validator import (
+        EMPTY_NEW_POSSIBILITY,
+        MISSING_REQUIRED_ENTRY,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(
+        0,
+        reframed=[
+            _entry("inv_a", new_possibility="catalyst-opened path b"),
+            _entry("inv_a", new_possibility=""),  # malformed sibling
+        ],
+    )
+    failures = validate_diff_revision(contract, diff)
+    assert not any(
+        f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_a" for f in failures
+    )
+    empty_np = [
+        f for f in failures if f.failure_type == EMPTY_NEW_POSSIBILITY and f.invariant == "inv_a"
+    ]
+    assert len(empty_np) == 1, (
+        "RFC §3.2 per-entry: each malformed reframed entry must emit its own "
+        "EMPTY_NEW_POSSIBILITY; the per-invariant existence check does not absorb it."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sentinel-with-accepted/reframed rejection — Cubic bot-resolution P2 (§3.1 docstring).
+# ---------------------------------------------------------------------------
+
+
+def test_no_new_divergence_with_non_empty_accepted_is_illegal() -> None:
+    """RFC §3.1 ``divergence_marker`` docstring: when sentinel is set, ``accepted`` MUST be
+    empty. Sentinel + non-empty ``accepted`` → ILLEGAL_SENTINEL_WITH_ACCEPTED.
+    """
+    from debate_hall_mcp.path_contract_validator import (
+        ILLEGAL_SENTINEL_WITH_ACCEPTED,
+        validate_diff_revision,
+    )
+
+    # No HARD_fail verdicts so the existing sentinel-vs-HARD_fail check does NOT
+    # fire — we are isolating the new sentinel-vs-accepted rule.
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    diff = _diff_rev(
+        0,
+        divergence_marker="NO_NEW_DIVERGENCE",
+        accepted=[_entry("inv_a", terminal_rationale="anything")],
+    )
+    failures = validate_diff_revision(contract, diff)
+    assert any(
+        f.failure_type == ILLEGAL_SENTINEL_WITH_ACCEPTED for f in failures
+    ), "RFC §3.1: NO_NEW_DIVERGENCE sentinel + non-empty accepted is illegal"
+
+
+def test_no_new_divergence_with_non_empty_reframed_is_illegal() -> None:
+    """RFC §3.1 ``divergence_marker`` docstring: when sentinel is set, ``reframed`` MUST be
+    empty. Sentinel + non-empty ``reframed`` → ILLEGAL_SENTINEL_WITH_REFRAMED.
+    """
+    from debate_hall_mcp.path_contract_validator import (
+        ILLEGAL_SENTINEL_WITH_REFRAMED,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    diff = _diff_rev(
+        0,
+        divergence_marker="NO_NEW_DIVERGENCE",
+        reframed=[_entry("inv_a", new_possibility="anything")],
+    )
+    failures = validate_diff_revision(contract, diff)
+    assert any(
+        f.failure_type == ILLEGAL_SENTINEL_WITH_REFRAMED for f in failures
+    ), "RFC §3.1: NO_NEW_DIVERGENCE sentinel + non-empty reframed is illegal"
+
+
+def test_no_new_divergence_with_non_empty_disputed_only_is_legal_finding_d_regression_guard() -> (
+    None
+):
+    """RFC §3.3 Finding D regression guard: sentinel + non-empty ``disputed`` only
+    (with empty ``accepted`` and ``reframed``) remains LEGAL.
+
+    Duplicates the spirit of ``test_no_new_divergence_finding_d_may_coexist_with_disputed``
+    but explicitly guards against the P2 fix over-rejecting the disputed bucket.
+    """
+    from debate_hall_mcp.path_contract_validator import validate_diff_revision
+
+    contract = _contract_with_verdicts({"inv_soft": ("SOFT_disputed", "discuss")})
+    diff = _diff_rev(
+        0,
+        divergence_marker="NO_NEW_DIVERGENCE",
+        disputed=[_entry("inv_soft")],
+    )
+    failures = validate_diff_revision(contract, diff)
+    assert failures == [], (
+        "RFC §3.3 Finding D: sentinel + non-empty disputed (only) must remain legal "
+        "after the sentinel-with-accepted/reframed rejection is added"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Ownership rule (RFC §3.1).
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_path_contract_validator.py
+++ b/tests/unit/test_path_contract_validator.py
@@ -687,3 +687,372 @@ def test_emit_validator_failures_empty_list_is_noop(tmp_path: Path) -> None:
     # No events file written for an empty failure list.
     events_file = tmp_path / "t-empty.events.jsonl"
     assert not events_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# SCHEMA_SHAPE_VIOLATION pre-pass — CE+CRS rework on PR #217.
+#
+# These tests cover the structural pre-pass that must run BEFORE any semantic
+# check on a contract/revision payload originating from an LLM. Malformed
+# payloads MUST yield ValidatorFailure events with failure_type
+# SCHEMA_SHAPE_VIOLATION and a granular ``defect`` discriminator on the
+# payload (for #203 grouping) — NOT raise KeyError or TypeError.
+# ---------------------------------------------------------------------------
+
+
+def test_schema_shape_violation_constant_present() -> None:
+    """``SCHEMA_SHAPE_VIOLATION`` is exported as a module constant."""
+    from debate_hall_mcp.path_contract_validator import SCHEMA_SHAPE_VIOLATION
+
+    assert SCHEMA_SHAPE_VIOLATION == "schema_shape_violation"
+
+
+def test_validator_failure_carries_defect_discriminator() -> None:
+    """``ValidatorFailure`` exposes a ``defect`` field; default is ``None``."""
+    from debate_hall_mcp.path_contract_validator import ValidatorFailure
+
+    f = ValidatorFailure(
+        failure_type="schema_shape_violation",
+        path_id="path_1",
+        invariant=None,
+        role=None,
+        details="missing required top-level key",
+        defect="missing_key:verdict_history",
+    )
+    assert f.defect == "missing_key:verdict_history"
+
+    # Backwards compatible: defect defaults to None for existing call sites.
+    g = ValidatorFailure(
+        failure_type="missing_required_entry",
+        path_id="path_1",
+        invariant="inv_a",
+        role="Wind",
+        details="x",
+    )
+    assert g.defect is None
+
+
+def test_validate_contract_shape_accepts_well_formed_contract() -> None:
+    """A semantically-valid, well-shaped contract emits zero shape failures."""
+    from debate_hall_mcp.path_contract_validator import validate_contract_shape
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    contract["diff_history"].append(_diff_rev(0))
+    assert validate_contract_shape(contract) == []
+
+
+def test_validate_contract_shape_rejects_non_dict_input() -> None:
+    """A non-Mapping input → SCHEMA_SHAPE_VIOLATION (defect: not_a_mapping)."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    failures = validate_contract_shape("not a dict")  # type: ignore[arg-type]
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION and f.defect == "not_a_mapping" for f in failures
+    )
+
+
+def test_validate_contract_shape_rejects_missing_path_id() -> None:
+    """Contract missing ``path_id`` → SCHEMA_SHAPE_VIOLATION (defect: missing_key:path_id)."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad = {
+        "frame_history": [],
+        "verdict_history": [],
+        "diff_history": [],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION and f.defect == "missing_key:path_id"
+        for f in failures
+    )
+
+
+def test_validate_contract_shape_rejects_missing_verdict_history() -> None:
+    """Contract missing ``verdict_history`` → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad = {"path_id": "p", "frame_history": [], "diff_history": []}
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION and f.defect == "missing_key:verdict_history"
+        for f in failures
+    )
+
+
+def test_validate_contract_shape_rejects_history_not_a_list() -> None:
+    """``verdict_history`` is a dict instead of list → SCHEMA_SHAPE_VIOLATION (type_error)."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": {"not": "a list"},
+        "diff_history": [],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "type_error:verdict_history_not_list"
+        for f in failures
+    )
+
+
+def test_validate_contract_shape_rejects_diff_entry_missing_value() -> None:
+    """``diff_history[0]`` missing ``value`` → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    contract["diff_history"].append(
+        {  # type: ignore[arg-type]
+            "rev": 0,
+            "written_at": _now(),
+            "written_by": "Wind",
+            # value: deliberately missing
+        }
+    )
+    failures = validate_contract_shape(contract)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION and f.defect == "missing_key:diff_history[0].value"
+        for f in failures
+    )
+
+
+def test_validate_contract_shape_rejects_diff_value_accepted_not_list() -> None:
+    """``diff_history[0].value.accepted`` is a dict instead of list → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    contract["diff_history"].append(
+        {  # type: ignore[arg-type]
+            "rev": 0,
+            "written_at": _now(),
+            "written_by": "Wind",
+            "value": {
+                "accepted": {"oops": "dict not list"},
+                "disputed": [],
+                "reframed": [],
+            },
+        }
+    )
+    failures = validate_contract_shape(contract)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "type_error:diff_history[0].value.accepted_not_list"
+        for f in failures
+    )
+
+
+def test_validate_contract_shape_rejects_verdict_value_not_dict() -> None:
+    """``verdict_history[0].value`` is a list instead of dict → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    bad: dict[str, object] = {
+        "path_id": "p",
+        "frame_history": [],
+        "verdict_history": [
+            {
+                "rev": 0,
+                "written_at": _now(),
+                "written_by": "Wall",
+                "value": ["not", "a", "dict"],
+            }
+        ],
+        "diff_history": [],
+    }
+    failures = validate_contract_shape(bad)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "type_error:verdict_history[0].value_not_dict"
+        for f in failures
+    )
+
+
+def test_validate_contract_shape_rejects_invariant_entry_missing_invariant() -> None:
+    """``InvariantEntry`` missing ``invariant`` key → SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_contract_shape,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_pass", "ok")})
+    contract["diff_history"].append(
+        {  # type: ignore[arg-type]
+            "rev": 0,
+            "written_at": _now(),
+            "written_by": "Wind",
+            "value": {
+                "accepted": [{"rationale": "r"}],  # invariant missing
+                "disputed": [],
+                "reframed": [],
+            },
+        }
+    )
+    failures = validate_contract_shape(contract)
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION
+        and f.defect == "missing_key:diff_history[0].value.accepted[0].invariant"
+        for f in failures
+    )
+
+
+def test_validate_diff_revision_returns_shape_failures_instead_of_keyerror() -> None:
+    """``validate_diff_revision`` on a malformed contract must NOT raise — returns failures."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_diff_revision,
+    )
+
+    # Contract is missing verdict_history entirely; previous code would
+    # KeyError on the first access in _hard_fail_invariants.
+    malformed = {"path_id": "p"}  # missing all three histories
+    diff = _diff_rev(0)
+
+    try:
+        failures = validate_diff_revision(malformed, diff)  # type: ignore[arg-type]
+    except (KeyError, TypeError) as exc:  # pragma: no cover - failure path
+        raise AssertionError(
+            f"validate_diff_revision must not raise on malformed payload: {exc!r}"
+        ) from exc
+
+    assert any(f.failure_type == SCHEMA_SHAPE_VIOLATION for f in failures)
+
+
+def test_validate_diff_revision_short_circuits_on_shape_failure() -> None:
+    """When shape is invalid, semantic checks MUST NOT run — only shape failures returned."""
+    from debate_hall_mcp.path_contract_validator import (
+        ILLEGAL_NO_NEW_DIVERGENCE,
+        MISSING_REQUIRED_ENTRY,
+        SCHEMA_SHAPE_VIOLATION,
+        validate_diff_revision,
+    )
+
+    malformed = {"path_id": "p"}  # missing histories
+    diff = _diff_rev(0, divergence_marker="NO_NEW_DIVERGENCE")
+    failures = validate_diff_revision(malformed, diff)  # type: ignore[arg-type]
+
+    # Only shape failures; no semantic failures from short-circuit.
+    assert all(f.failure_type == SCHEMA_SHAPE_VIOLATION for f in failures)
+    assert not any(
+        f.failure_type in (MISSING_REQUIRED_ENTRY, ILLEGAL_NO_NEW_DIVERGENCE) for f in failures
+    )
+
+
+def test_validate_door_citations_returns_shape_failures_instead_of_keyerror() -> None:
+    """``validate_door_citations`` on a malformed contract must NOT raise — returns failures."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_door_citations,
+    )
+
+    malformed = {"frame_history": []}  # missing path_id + verdict_history + diff_history
+
+    try:
+        failures = validate_door_citations(malformed, cited_invariants=["x"])  # type: ignore[arg-type]
+    except (KeyError, TypeError) as exc:  # pragma: no cover - failure path
+        raise AssertionError(
+            f"validate_door_citations must not raise on malformed payload: {exc!r}"
+        ) from exc
+
+    assert any(f.failure_type == SCHEMA_SHAPE_VIOLATION for f in failures)
+
+
+def test_validate_revision_ownership_returns_shape_failure_when_written_by_missing() -> None:
+    """Revision missing ``written_by`` must NOT raise — returns SCHEMA_SHAPE_VIOLATION."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_revision_ownership,
+    )
+
+    bad = {"rev": 0, "written_at": _now(), "value": {}}  # no written_by
+
+    try:
+        failures = validate_revision_ownership(  # type: ignore[arg-type]
+            bad, kind="verdict", path_id="path_1"
+        )
+    except (KeyError, TypeError) as exc:  # pragma: no cover - failure path
+        raise AssertionError(
+            f"validate_revision_ownership must not raise on malformed revision: {exc!r}"
+        ) from exc
+
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION and f.defect == "missing_key:revision.written_by"
+        for f in failures
+    )
+
+
+def test_validate_revision_ownership_returns_shape_failure_when_not_a_mapping() -> None:
+    """Revision that is not a Mapping → SCHEMA_SHAPE_VIOLATION (defect: not_a_mapping)."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_revision_ownership,
+    )
+
+    failures = validate_revision_ownership(  # type: ignore[arg-type]
+        "not a dict", kind="verdict", path_id="path_1"
+    )
+    assert any(
+        f.failure_type == SCHEMA_SHAPE_VIOLATION and f.defect == "not_a_mapping" for f in failures
+    )
+
+
+def test_valid_contract_passes_pre_pass_regression_guard() -> None:
+    """Semantically-correct contract still passes; pre-pass produces no false positives."""
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        validate_diff_revision,
+    )
+
+    contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
+    diff = _diff_rev(
+        0, accepted=[_entry("inv_a", terminal_rationale="terminal — no creative reframe")]
+    )
+    failures = validate_diff_revision(contract, diff)
+    # No shape failures; semantic check also passes.
+    assert not any(f.failure_type == SCHEMA_SHAPE_VIOLATION for f in failures)
+    assert failures == []
+
+
+def test_validator_failure_event_payload_includes_defect(tmp_path: Path) -> None:
+    """``emit_validator_failures`` surfaces ``defect`` in the event payload for #203 grouping."""
+    from debate_hall_mcp.events import load_events
+    from debate_hall_mcp.path_contract_validator import (
+        SCHEMA_SHAPE_VIOLATION,
+        ValidatorFailure,
+        emit_validator_failures,
+    )
+
+    failures = [
+        ValidatorFailure(
+            failure_type=SCHEMA_SHAPE_VIOLATION,
+            path_id="path_1",
+            invariant=None,
+            role=None,
+            details="missing required top-level key",
+            defect="missing_key:verdict_history",
+        )
+    ]
+    emit_validator_failures(thread_id="t-defect", failures=failures, state_dir=tmp_path)
+    loaded = load_events(thread_id="t-defect", state_dir=tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0].payload["defect"] == "missing_key:verdict_history"

--- a/tests/unit/test_path_contract_validator.py
+++ b/tests/unit/test_path_contract_validator.py
@@ -27,8 +27,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 
-import pytest
-
 from debate_hall_mcp.path_contract import (
     DiffRevision,
     FrameRevision,
@@ -40,7 +38,6 @@ from debate_hall_mcp.path_contract import (
     VerdictRevision,
     new_path_contract,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixture helpers — minimal contract builders used across the RED matrix.
@@ -120,9 +117,7 @@ def _contract_with_verdicts(
     path_id: str = "path_1",
 ) -> PathContract:
     contract = new_path_contract(path_id)
-    contract["frame_history"].append(
-        _frame_rev(invariants=list(verdicts.keys()))
-    )
+    contract["frame_history"].append(_frame_rev(invariants=list(verdicts.keys())))
     contract["verdict_history"].append(_verdict_rev(0, verdicts))
     return contract
 
@@ -220,8 +215,7 @@ def test_diff_fails_when_hard_fail_invariant_silently_omitted() -> None:
     diff = _diff_rev(0)  # all buckets empty
     failures = validate_diff_revision(contract, diff)
     assert any(
-        f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_a"
-        for f in failures
+        f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_a" for f in failures
     )
 
 
@@ -236,8 +230,7 @@ def test_diff_fails_when_accepted_entry_has_empty_terminal_rationale() -> None:
     diff = _diff_rev(0, accepted=[_entry("inv_a", terminal_rationale="")])
     failures = validate_diff_revision(contract, diff)
     assert any(
-        f.failure_type == EMPTY_TERMINAL_RATIONALE and f.invariant == "inv_a"
-        for f in failures
+        f.failure_type == EMPTY_TERMINAL_RATIONALE and f.invariant == "inv_a" for f in failures
     )
 
 
@@ -252,8 +245,7 @@ def test_diff_fails_when_accepted_entry_missing_terminal_rationale() -> None:
     diff = _diff_rev(0, accepted=[_entry("inv_a")])  # no terminal_rationale at all
     failures = validate_diff_revision(contract, diff)
     assert any(
-        f.failure_type == EMPTY_TERMINAL_RATIONALE and f.invariant == "inv_a"
-        for f in failures
+        f.failure_type == EMPTY_TERMINAL_RATIONALE and f.invariant == "inv_a" for f in failures
     )
 
 
@@ -267,10 +259,7 @@ def test_diff_fails_when_reframed_entry_has_empty_new_possibility() -> None:
     contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
     diff = _diff_rev(0, reframed=[_entry("inv_a", new_possibility="")])
     failures = validate_diff_revision(contract, diff)
-    assert any(
-        f.failure_type == EMPTY_NEW_POSSIBILITY and f.invariant == "inv_a"
-        for f in failures
-    )
+    assert any(f.failure_type == EMPTY_NEW_POSSIBILITY and f.invariant == "inv_a" for f in failures)
 
 
 def test_diff_fails_when_reframed_entry_missing_new_possibility() -> None:
@@ -283,10 +272,7 @@ def test_diff_fails_when_reframed_entry_missing_new_possibility() -> None:
     contract = _contract_with_verdicts({"inv_a": ("HARD_fail", "blocked")})
     diff = _diff_rev(0, reframed=[_entry("inv_a")])  # no new_possibility at all
     failures = validate_diff_revision(contract, diff)
-    assert any(
-        f.failure_type == EMPTY_NEW_POSSIBILITY and f.invariant == "inv_a"
-        for f in failures
-    )
+    assert any(f.failure_type == EMPTY_NEW_POSSIBILITY and f.invariant == "inv_a" for f in failures)
 
 
 def test_diff_fails_per_invariant_not_per_path_finding_c() -> None:
@@ -304,17 +290,13 @@ def test_diff_fails_per_invariant_not_per_path_finding_c() -> None:
     contract = _contract_with_verdicts(
         {"inv_a": ("HARD_fail", "blocked"), "inv_b": ("HARD_fail", "blocked")}
     )
-    diff = _diff_rev(
-        0, reframed=[_entry("inv_b", new_possibility="covers inv_b only")]
-    )
+    diff = _diff_rev(0, reframed=[_entry("inv_b", new_possibility="covers inv_b only")])
     failures = validate_diff_revision(contract, diff)
     inv_a_misses = [
-        f for f in failures
-        if f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_a"
+        f for f in failures if f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_a"
     ]
     inv_b_misses = [
-        f for f in failures
-        if f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_b"
+        f for f in failures if f.failure_type == MISSING_REQUIRED_ENTRY and f.invariant == "inv_b"
     ]
     assert inv_a_misses, "inv_a HARD_fail must be flagged as missing"
     assert not inv_b_misses, "inv_b is satisfied by reframed entry"
@@ -353,18 +335,14 @@ def test_no_new_divergence_finding_d_may_coexist_with_disputed() -> None:
     """Finding D: sentinel + non-empty ``disputed`` list is LEGAL."""
     from debate_hall_mcp.path_contract_validator import validate_diff_revision
 
-    contract = _contract_with_verdicts(
-        {"inv_soft": ("SOFT_disputed", "discuss")}
-    )
+    contract = _contract_with_verdicts({"inv_soft": ("SOFT_disputed", "discuss")})
     diff = _diff_rev(
         0,
         divergence_marker="NO_NEW_DIVERGENCE",
         disputed=[_entry("inv_soft")],
     )
     failures = validate_diff_revision(contract, diff)
-    assert failures == [], (
-        "RFC §3.3 Finding D: sentinel may coexist with non-empty disputed"
-    )
+    assert failures == [], "RFC §3.3 Finding D: sentinel may coexist with non-empty disputed"
 
 
 def test_no_new_divergence_fails_on_any_hard_fail_verdict() -> None:
@@ -379,9 +357,7 @@ def test_no_new_divergence_fails_on_any_hard_fail_verdict() -> None:
     )
     diff = _diff_rev(0, divergence_marker="NO_NEW_DIVERGENCE")
     failures = validate_diff_revision(contract, diff)
-    assert any(
-        f.failure_type == ILLEGAL_NO_NEW_DIVERGENCE for f in failures
-    )
+    assert any(f.failure_type == ILLEGAL_NO_NEW_DIVERGENCE for f in failures)
 
 
 # ---------------------------------------------------------------------------
@@ -532,9 +508,7 @@ def test_emit_validator_failures_writes_one_event_per_failure(tmp_path: Path) ->
         ),
     ]
 
-    events = emit_validator_failures(
-        thread_id="t-1", failures=failures, state_dir=tmp_path
-    )
+    events = emit_validator_failures(thread_id="t-1", failures=failures, state_dir=tmp_path)
     assert len(events) == 2
     assert all(e.event_type == EventType.VALIDATOR_FAILURE for e in events)
 
@@ -560,9 +534,7 @@ def test_emit_validator_failures_empty_list_is_noop(tmp_path: Path) -> None:
     """No failures → no events written, no exceptions."""
     from debate_hall_mcp.path_contract_validator import emit_validator_failures
 
-    events = emit_validator_failures(
-        thread_id="t-empty", failures=[], state_dir=tmp_path
-    )
+    events = emit_validator_failures(thread_id="t-empty", failures=[], state_dir=tmp_path)
     assert events == []
     # No events file written for an empty failure list.
     events_file = tmp_path / "t-empty.events.jsonl"


### PR DESCRIPTION
Closes #200
Part of #195

## Summary

Implements the validator policy layer for the `path_contract` schema delivered by #196. Acceptance bound to the **AMENDED RFC** at `docs/rfc-0001-path-contract-wind-learning-loop.md` — specifically §3.1 (ownership), §3.2 (REQUIRED CONTENT RULE + sentinel rules), §3.3 Findings C+D+E, and §6 items 2-3.

Schema (#196) is the wire-format boundary; this PR adds the policy boundary as a sibling module so the schema remains stable and the policy can iterate independently — matching the BOUNDARY docstring on `path_contract.path_contract_from_json` (lines 252-282).

## Validator behaviours covered

- **REQUIRED CONTENT RULE per-invariant** (§3.2, §3.3 Finding C): each `HARD_fail` invariant needs its own qualifying entry — `accepted` with non-empty `terminal_rationale` OR `reframed` with non-empty `new_possibility`. A sibling entry on a different invariant does NOT satisfy.
- **Empty/missing `terminal_rationale`** on an `accepted` entry covering a `HARD_fail` invariant = failure.
- **Empty/missing `new_possibility`** on a `reframed` entry covering a `HARD_fail` invariant = failure.
- **`NO_NEW_DIVERGENCE` sentinel** on a path with any `HARD_fail` verdict = failure (§3.2).
- **`NO_NEW_DIVERGENCE` with non-empty `disputed`** = OK (§3.3 Finding D — sentinel may coexist with SOFT_disputed pushback).
- **Ownership rule** (§3.1): Wind→frame/diff, Wall→verdict, Door read-only. Wrong-role write = failure.
- **Door citation existence** (§6 item 2): every cited invariant must appear in the latest verdict revision; fabricated citations = failure.
- **`VALIDATOR_FAILURE` events** (§6 item 3): one event per failure, with `failure_type` discrimination in the payload (NOT in `EventType`) so the #203 A/B harness can group invalid-contract-rate by failure type without parsing free text.

## Failure-type discriminators (exported from `path_contract_validator`)

- `MISSING_REQUIRED_ENTRY`
- `EMPTY_TERMINAL_RATIONALE`
- `EMPTY_NEW_POSSIBILITY`
- `ILLEGAL_NO_NEW_DIVERGENCE`
- `OWNERSHIP_VIOLATION`
- `DOOR_CITATION_NOT_FOUND`

## Orchestrator integration scope (DEFERRED — explicit note)

RFC §6 item 2 specifies wiring into `_execute_consensus_loop` at `orchestrator.py:482-560`. That wiring is **deferred** from this PR because:

1. Today the loop exchanges only Wind/Wall `vote.approved` booleans plus free-text feedback; `PathContract` objects are not yet threaded through the call frame.
2. Threading those objects requires #197 (state plumbing for `PathContract` serialization) and #198 (prompts that actually produce `diff` content) to land first.
3. The RFC §3 invariant "consensus loop, `max_refinement_loops`, and Wall re-approval invariant at line 507 are unchanged" is honoured by NOT modifying loop control flow here.

The validator API is shaped so #197/#198 can wire it in trivially when contract objects become available: `validate_diff_revision(contract, diff)` → `emit_validator_failures(thread_id=..., failures=..., state_dir=...)`. This split honours the "small bundled PRs" preference recorded in prior CE/CRS reviews on #196.

## Test plan

- [x] RED commit (`b55bdf8`): 25 failing tests covering every validator behaviour above — fail with `ModuleNotFoundError` for the right reason.
- [x] GREEN commit (`609b101`): module + EventType extension; all 25 validator tests pass.
- [x] Full pytest suite: **1486 passed** (no regressions).
- [x] `uv run ruff check` on touched files: clean.
- [x] `uv run black --check` on touched files: clean.
- [x] `uv run mypy --strict src/debate_hall_mcp/path_contract_validator.py`: clean.
- [x] `uv run mypy src/`: clean (42 files).

## Acceptance vs RFC

If reviewers find any drift between this PR and the AMENDED RFC §3.1/§3.2/§3.3/§6, the RFC is authoritative — flag and I will iterate. Issue #200's body (if present) is treated as advisory per the established convention (#196's issue body was stale; treat issue bodies as advisory unless they cite a section newer than 2026-05-16).

## Out of scope (per task spec — not touched)

- `src/debate_hall_mcp/prompts/__init__.py` (downstream — #198)
- `src/debate_hall_mcp/context_compiler.py` and `<PATH_CONTRACTS>` injection (downstream — #199)
- `src/debate_hall_mcp/state.py` PathContract serialization (downstream — #197)
- Feature flag wiring (#201/#205)
- The schema module `path_contract.py` (#196 boundary — read-only)
- Orchestrator `_execute_consensus_loop` (deferred as documented above)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `path_contract` validator per RFC-0001 that defends against malformed payloads with a shape pre-pass (now including Literal value checks) and emits structured `VALIDATOR_FAILURE` events; tightens per-entry rationale rules and sentinel legality (per #200).

- **New Features**
  - New `debate_hall_mcp.path_contract_validator` with a two-phase approach:
    - Shape pre-pass (`validate_contract_shape`, `validate_revision_shape`): mapping/required-key/type checks plus Literal value membership for `status`, `written_by`, and `divergence_marker`. Emits `SCHEMA_SHAPE_VIOLATION` with `defect` like `missing_key:...`, `type_error:...`, `invalid_literal:<locator>:<value>`. Semantic checks short-circuit on shape failures.
    - `validate_diff_revision`: per-invariant REQUIRED CONTENT; per-entry failures for empty `terminal_rationale`/`new_possibility`; `NO_NEW_DIVERGENCE` legality (reject with any `HARD_fail`, and when paired with non-empty `accepted`/`reframed`; allow with non-empty `disputed`).
    - `validate_revision_ownership` and `validate_door_citations`: Wind→frame/diff, Wall→verdict; all cited invariants must exist in the latest verdict.
  - Emits one `EventType.VALIDATOR_FAILURE` per failure via `emit_validator_failures`; payload includes `failure_type` and optional `defect`. Exports constants including `SCHEMA_SHAPE_VIOLATION`, `ILLEGAL_SENTINEL_WITH_ACCEPTED`, and `ILLEGAL_SENTINEL_WITH_REFRAMED`.

- **Migration**
  - No wiring yet; call `validate_diff_revision(contract, diff)` then `emit_validator_failures(...)` when `PathContract` objects are threaded through the orchestrator.

<sup>Written for commit bc4f79144af30ab24bd6ae036f674ece7e08154f. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/217?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

