### PR TITLE
[RFC-0001] #199 — Context compiler: <PATH_CONTRACTS> injection + Findings F+I

### DIFF
--- a/src/debate_hall_mcp/context_compiler.py
+++ b/src/debate_hall_mcp/context_compiler.py
@@ -1,25 +1,37 @@
-"""Context Compiler - Export decisions to .hestai/state/context/decisions/.
+"""Context Compiler - Export decisions and render in-prompt context blocks.
 
-Issue #138: Layer 3 Query Enhancements - Decision Indexing
+This module hosts two related concerns:
 
-This module implements the "Context Compiler" feature that exports debate
-decisions as compiled OCTAVE files. These files can be read by future agents
-as part of their binding context, achieving 98% token savings vs re-debating.
+1. **Decision export (issue #138)** — :func:`export_decision_to_context` writes
+   a :class:`DecisionRecord` to ``.hestai/state/context/decisions/`` as a
+   compiled OCTAVE file that future agents can read as binding context (≈98%
+   token savings vs re-debating).
 
-Exports to: .hestai/state/context/decisions/{YYYY-MM-DD}-{topic-slug}-{short_id}.oct.md
-
-Note: The short_id suffix (extracted from thread_id) prevents filename
-collisions when multiple debates on the same topic occur on the same day.
+2. **In-prompt ``<PATH_CONTRACTS>`` rendering (RFC-0001 #199)** —
+   :func:`render_path_contracts_block` projects the latest revision of each
+   :class:`PathContract` field plus revision counts into a sub-block that the
+   orchestrator injects inside ``<DEBATE_STATE>``. This satisfies RFC §6 item 1
+   ("the ``<DEBATE_STATE>`` block in prompts includes a ``<PATH_CONTRACTS>``
+   sub-block with the latest revision per field plus revision counts; full
+   history available in storage but not pushed into prompts on every turn")
+   while keeping the token-budget ceiling of RFC §8 Q3.
 
 Compliance:
-- I4 (Verifiable Event Ledger): Exported decisions preserve integrity via hashes
-- I2 (Universal OCTAVE Binding): Uses validated OCTAVE format
+
+- I4 (Verifiable Event Ledger): Exported decisions preserve integrity via hashes;
+  ``render_path_contracts_block`` projects history without mutating it.
+- I2 (Universal OCTAVE Binding): All emitted blocks use OCTAVE structural form.
+- I1 (Cognitive State Isolation): The renderer is a pure function over its
+  inputs; it performs no disk reads (the orchestrator-side fix for Finding I).
 """
 
+import json
 import re
 from pathlib import Path
+from typing import Any
 
 from debate_hall_mcp.decision import DecisionRecord
+from debate_hall_mcp.path_contract import PathContract, prompt_context_view
 
 # Maximum length for slugified topic in filename
 MAX_SLUG_LENGTH = 60
@@ -319,3 +331,119 @@ def get_context_dir() -> Path:
 
     # Priority 3: Current working directory fallback
     return Path.cwd() / ".hestai" / "state" / "context"
+
+
+# ---------------------------------------------------------------------------
+# RFC-0001 #199 — <PATH_CONTRACTS> sub-block renderer
+#
+# Pure projection of a list of PathContract objects into the in-prompt
+# <PATH_CONTRACTS> sub-block. Consumed by Orchestrator._format_debate_state.
+#
+# Design choices:
+#
+# * Latest-revision-only per field, plus revision counts (RFC §6 item 1).
+#   Earlier revisions stay in storage (I4 append-only) and are never rendered.
+#
+# * Empty input list ⇒ empty string output. The caller is responsible for
+#   suppressing the surrounding envelope structure. This preserves byte-identity
+#   with the legacy envelope when the feature is off or no contracts exist.
+#
+# * Frame/verdict/diff values are emitted as compact one-line JSON. OCTAVE
+#   tolerates JSON-as-value, and per-line JSON keeps the projection trivially
+#   diff-able. Token budget tests (see test_context_compiler_path_contracts.py)
+#   gate the worst case against RFC §8 Q3.
+#
+# * datetime objects are ISO-8601-stringified (re-using the storage helper's
+#   convention) so the rendered block is JSON-safe and stable across runs.
+# ---------------------------------------------------------------------------
+
+
+def _isoformat_datetimes(obj: Any) -> Any:
+    """Recursively convert datetime values to ISO-8601 strings for JSON safety."""
+    from datetime import datetime
+
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, dict):
+        return {k: _isoformat_datetimes(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_isoformat_datetimes(item) for item in obj]
+    return obj
+
+
+def render_path_contracts_block(contracts: list[PathContract]) -> str:
+    """Render the in-prompt ``<PATH_CONTRACTS>`` sub-block (RFC-0001 #199).
+
+    Per RFC §6 item 1, only the latest revision of each field is rendered,
+    accompanied by revision counts. Full revision history stays in storage
+    (RFC §3.1, I4 append-only ledger) and is never blasted into prompts.
+
+    Args:
+        contracts: Per-path append-only contracts. ``[]`` yields ``""`` so the
+            caller can omit the surrounding envelope structure entirely (the
+            feature-off byte-identity guarantee).
+
+    Returns:
+        OCTAVE sub-block bracketed by ``<PATH_CONTRACTS>`` / ``</PATH_CONTRACTS>``
+        when ``contracts`` is non-empty; the empty string otherwise.
+    """
+    if not contracts:
+        return ""
+
+    lines: list[str] = ["<PATH_CONTRACTS>"]
+    for contract in contracts:
+        view = prompt_context_view(contract)
+        lines.append(f"  PATH::{view['path_id']}")
+        lines.append(f"    frame_rev_count::{view['frame_count']}")
+        if view["latest_frame"] is not None:
+            frame_value = _isoformat_datetimes(view["latest_frame"]["value"])
+            lines.append(f"    FRAME::{json.dumps(frame_value, separators=(',', ':'))}")
+        lines.append(f"    verdict_rev_count::{view['verdict_count']}")
+        if view["latest_verdict"] is not None:
+            verdict_value = _isoformat_datetimes(view["latest_verdict"]["value"])
+            lines.append(f"    VERDICT::{json.dumps(verdict_value, separators=(',', ':'))}")
+        lines.append(f"    diff_rev_count::{view['diff_count']}")
+        if view["latest_diff"] is not None:
+            diff_payload: dict[str, Any] = {"value": view["latest_diff"]["value"]}
+            # Carry optional fields when present so downstream consumers
+            # (Door's citation rule, validator) can see them without a second lookup.
+            if "divergence_marker" in view["latest_diff"]:
+                diff_payload["divergence_marker"] = view["latest_diff"]["divergence_marker"]
+            if "synthesis_guidance" in view["latest_diff"]:
+                diff_payload["synthesis_guidance"] = view["latest_diff"]["synthesis_guidance"]
+            diff_payload = _isoformat_datetimes(diff_payload)
+            lines.append(f"    DIFF::{json.dumps(diff_payload, separators=(',', ':'))}")
+    lines.append("</PATH_CONTRACTS>")
+    return "\n".join(lines)
+
+
+def derive_synthesis_status(*, synthesis: str | None, turn_count: int) -> str:
+    """Derive the ``<SYNTHESIS_STATUS>`` value for the envelope (Finding F).
+
+    Three values disambiguate the APPROVE/REJECT-vs-no-synthesis conflation
+    reported in RFC-0001 §3.3 Finding F:
+
+    * ``PRESENT`` — Door has produced (or refined) a synthesis that is
+      currently the active candidate; ``synthesis`` is set.
+    * ``PENDING_INITIAL`` — No synthesis exists yet for the current round and
+      Door has not run; fewer than 3 turns have completed.
+    * ``PENDING_REFINEMENT`` — A prior synthesis was withdrawn (e.g. rejected)
+      and a Door refinement turn is expected; ``synthesis`` is unset but at
+      least 3 turns have completed (Wind/Wall/Door have all spoken).
+
+    The orchestrator emits this value as ``SYNTHESIS_STATUS::<value>`` inside
+    ``<DEBATE_STATE>``. Wind's #198 prompt branches on it deterministically so
+    APPROVE/REJECT can never be conflated with "there is nothing to vote on".
+
+    Args:
+        synthesis: ``debate_state["synthesis"]`` (may be ``None`` or empty).
+        turn_count: ``debate_state["turn_count"]``.
+
+    Returns:
+        One of ``"PRESENT"``, ``"PENDING_INITIAL"``, or ``"PENDING_REFINEMENT"``.
+    """
+    if synthesis:
+        return "PRESENT"
+    if turn_count < 3:
+        return "PENDING_INITIAL"
+    return "PENDING_REFINEMENT"

--- a/src/debate_hall_mcp/orchestrator.py
+++ b/src/debate_hall_mcp/orchestrator.py
@@ -216,11 +216,25 @@ class DebateOrchestrator:
         Returns:
             Formatted string with DEBATE_STATE tags
         """
+        from debate_hall_mcp.context_compiler import (
+            derive_synthesis_status,
+            render_path_contracts_block,
+        )
+
         lines = ["<DEBATE_STATE>"]
         lines.append(f"THREAD_ID::{debate_state['thread_id']}")
         lines.append(f"TOPIC::{debate_state['topic']}")
         lines.append(f"STATUS::{debate_state['status']}")
         lines.append(f"TURN_COUNT::{debate_state['turn_count']}")
+
+        # RFC-0001 #199 Finding F: explicit synthesis-status flag so Wind/Wall/Door
+        # prompts (#198) can branch unambiguously. Always emitted; the value
+        # distinguishes "no synthesis yet" from "synthesis withdrawn for refinement".
+        synthesis_status = derive_synthesis_status(
+            synthesis=debate_state.get("synthesis"),
+            turn_count=int(debate_state.get("turn_count", 0)),
+        )
+        lines.append(f"SYNTHESIS_STATUS::{synthesis_status}")
 
         if debate_state.get("synthesis"):
             lines.append(f"SYNTHESIS::{debate_state['synthesis']}")
@@ -242,6 +256,14 @@ class DebateOrchestrator:
                     lines.append(f"  {role_label} ({token_output} tokens):: {content}")
                 else:
                     lines.append(f"  {role_label}:: {content}")
+
+        # RFC-0001 #199: inject <PATH_CONTRACTS> sub-block (RFC §6 item 1)
+        # when path_contracts are present in the in-memory state. Absent/empty
+        # input renders nothing — preserves envelope byte-identity for the
+        # feature-off path (gated by #201/#205).
+        path_contracts_block = render_path_contracts_block(debate_state.get("path_contracts") or [])
+        if path_contracts_block:
+            lines.append(path_contracts_block)
 
         lines.append("</DEBATE_STATE>")
         return "\n".join(lines)

--- a/src/debate_hall_mcp/orchestrator.py
+++ b/src/debate_hall_mcp/orchestrator.py
@@ -227,15 +227,6 @@ class DebateOrchestrator:
         lines.append(f"STATUS::{debate_state['status']}")
         lines.append(f"TURN_COUNT::{debate_state['turn_count']}")
 
-        # RFC-0001 #199 Finding F: explicit synthesis-status flag so Wind/Wall/Door
-        # prompts (#198) can branch unambiguously. Always emitted; the value
-        # distinguishes "no synthesis yet" from "synthesis withdrawn for refinement".
-        synthesis_status = derive_synthesis_status(
-            synthesis=debate_state.get("synthesis"),
-            turn_count=int(debate_state.get("turn_count", 0)),
-        )
-        lines.append(f"SYNTHESIS_STATUS::{synthesis_status}")
-
         if debate_state.get("synthesis"):
             lines.append(f"SYNTHESIS::{debate_state['synthesis']}")
 
@@ -261,8 +252,23 @@ class DebateOrchestrator:
         # when path_contracts are present in the in-memory state. Absent/empty
         # input renders nothing — preserves envelope byte-identity for the
         # feature-off path (gated by #201/#205).
+        #
+        # PR #218 rework — joint emission contract (CE finding 1):
+        # ``SYNTHESIS_STATUS::<value>`` and ``<PATH_CONTRACTS>`` are emitted
+        # IFF path_contracts is non-empty. When the feature is off, the
+        # envelope is byte-identical to the pre-#199 shape. #198's prompt
+        # branches depend on this joint emission contract — SYNTHESIS_STATUS
+        # only matters when contracts are being tracked.
         path_contracts_block = render_path_contracts_block(debate_state.get("path_contracts") or [])
         if path_contracts_block:
+            # Insert SYNTHESIS_STATUS just before the </DEBATE_STATE> closer,
+            # alongside the contracts block, so both appear jointly inside the
+            # envelope without disturbing the pre-PR header line ordering.
+            synthesis_status = derive_synthesis_status(
+                synthesis=debate_state.get("synthesis"),
+                turn_count=int(debate_state.get("turn_count", 0)),
+            )
+            lines.append(f"SYNTHESIS_STATUS::{synthesis_status}")
             lines.append(path_contracts_block)
 
         lines.append("</DEBATE_STATE>")

--- a/tests/unit/test_context_compiler_path_contracts.py
+++ b/tests/unit/test_context_compiler_path_contracts.py
@@ -210,7 +210,12 @@ class TestRenderPathContractsBlock:
         assert "users cannot reset their password" not in block
 
     def test_token_budget_three_paths_under_3600(self) -> None:
-        """RFC §8 Q3: worst-case ≤ ~3.6k tokens for 3 paths × 3 fields.
+        """RFC §8 Q3 (happy-path): ≤ ~3.6k tokens for 3 paths × 3 fields.
+
+        Assumes reasonably-short agent outputs typical of debate transcripts
+        (single-sentence rationales, succinct synthesis_guidance). The
+        worst-case upper bound under long-form prose is bounded separately
+        by :meth:`test_token_budget_three_paths_with_long_content`.
 
         Uses character-count / 4 as a portable token approximation (tiktoken-free).
         """
@@ -225,6 +230,96 @@ class TestRenderPathContractsBlock:
         assert approx_tokens <= 3600, (
             f"PATH_CONTRACTS rendering exceeded RFC §8 Q3 ceiling: "
             f"{approx_tokens} tokens for 3 paths × 3 fields"
+        )
+
+    def test_token_budget_three_paths_with_long_content(self) -> None:
+        """Stress-test worst-case: long-form prose in every text field (RFC §8 Q3 envelope).
+
+        Schema text fields (assumed_problem, success_criterion, accepted_failure_mode,
+        rationale × N, synthesis_guidance, divergence_marker, new_possibility) are
+        unbounded in the schema; this test pushes ~200-token prose into each free-text
+        field across 3 paths × 3 revision categories (frame/verdict/diff) and asserts
+        the rendered block stays under a documented ceiling.
+
+        This bounds the realistic worst-case empirically. If the measured value
+        approaches the assertion ceiling, escalate to #196 (schema input-bounding).
+        """
+        from debate_hall_mcp.context_compiler import render_path_contracts_block
+
+        # ~200-token prose blob (~800 chars). Multi-sentence to match real worst case.
+        long_text = (
+            "This rationale captures the full structural argument with caveats, "
+            "edge cases, and operational considerations that emerged during the "
+            "deliberation. The agent enumerates failure modes, recovery paths, "
+            "and the cost of deferred remediation. It cross-references prior "
+            "synthesis attempts, notes which invariants are load-bearing, and "
+            "explains why the chosen reframing is preferred over the alternatives "
+            "considered. Includes references to relevant ADRs and prior debates "
+            "so downstream readers can reconstruct provenance without leaving "
+            "the prompt. "
+        ) * 2  # ~1600 chars, ~400 token-equivalent budget per field — intentionally over
+
+        def _stress_contract(path_id: str) -> PathContract:
+            contract = new_path_contract(path_id)
+            contract["frame_history"].append(
+                FrameRevision(
+                    rev=0,
+                    written_at=_ts(),
+                    written_by="Wind",
+                    value={
+                        "assumed_problem": long_text,
+                        "success_criterion": long_text,
+                        "accepted_failure_mode": long_text,
+                        "invariants_touched": ["halting", "single_wall_coherence"],
+                    },
+                )
+            )
+            contract["verdict_history"].append(
+                VerdictRevision(
+                    rev=0,
+                    written_at=_ts(1),
+                    written_by="Wall",
+                    value={
+                        "halting": {"status": "HARD_pass", "rationale": long_text},
+                        "single_wall_coherence": {
+                            "status": "SOFT_disputed",
+                            "rationale": long_text,
+                        },
+                    },
+                )
+            )
+            contract["diff_history"].append(
+                DiffRevision(
+                    rev=0,
+                    written_at=_ts(2),
+                    written_by="Wind",
+                    value={
+                        "accepted": [
+                            {"invariant": "halting", "rationale": long_text},
+                        ],
+                        "disputed": [
+                            {"invariant": "single_wall_coherence", "rationale": long_text},
+                        ],
+                        "reframed": [],
+                    },
+                    divergence_marker=long_text,
+                    synthesis_guidance=long_text,
+                )
+            )
+            return contract
+
+        contracts = [_stress_contract(f"path_{i}") for i in (1, 2, 3)]
+        block = render_path_contracts_block(contracts)
+
+        approx_tokens = len(block) // 4
+        # Documented stress-test ceiling. If this is breached, the renderer is
+        # not at fault — long-form rationales must be bounded upstream (#196).
+        # Empirical measurement at the time of authoring informs this ceiling.
+        WORST_CASE_TOKEN_CEILING = 9000
+        assert approx_tokens <= WORST_CASE_TOKEN_CEILING, (
+            f"PATH_CONTRACTS long-form stress test exceeded documented ceiling: "
+            f"{approx_tokens} tokens (ceiling {WORST_CASE_TOKEN_CEILING}). "
+            f"Escalate to #196 for schema input-bounding rather than renderer fix."
         )
 
 
@@ -248,24 +343,39 @@ class TestOrchestratorEnvelopeIntegration:
         return state
 
     # ---- Finding F: SYNTHESIS_STATUS ----
+    #
+    # PR #218 rework: SYNTHESIS_STATUS is emitted IFF <PATH_CONTRACTS> is
+    # emitted (joint emission contract — see CE finding 1). All Finding F
+    # status-derivation tests therefore feed a non-empty ``path_contracts``
+    # list so the gated branch is exercised. The Finding F semantics
+    # (PRESENT / PENDING_INITIAL / PENDING_REFINEMENT derivation) are
+    # unchanged; only the emission gate has been tightened.
 
     def test_synthesis_status_pending_initial_before_any_turns(self, tmp_path: Path) -> None:
-        """No synthesis + zero turns ⇒ SYNTHESIS_STATUS::PENDING_INITIAL."""
+        """No synthesis + zero turns ⇒ SYNTHESIS_STATUS::PENDING_INITIAL (with contracts)."""
         orch = _make_orchestrator(tmp_path)
-        block = orch._format_debate_state(self._base_state(turn_count=0))
+        block = orch._format_debate_state(
+            self._base_state(turn_count=0, path_contracts=[_contract_frame_only()])
+        )
         assert "SYNTHESIS_STATUS::PENDING_INITIAL" in block
 
     def test_synthesis_status_pending_initial_before_door_speaks(self, tmp_path: Path) -> None:
         """No synthesis + Wind/Wall spoken but no Door yet ⇒ still PENDING_INITIAL."""
         orch = _make_orchestrator(tmp_path)
-        block = orch._format_debate_state(self._base_state(turn_count=2))
+        block = orch._format_debate_state(
+            self._base_state(turn_count=2, path_contracts=[_contract_frame_only()])
+        )
         assert "SYNTHESIS_STATUS::PENDING_INITIAL" in block
 
     def test_synthesis_status_present_when_synthesis_set(self, tmp_path: Path) -> None:
         """Door has synthesised ⇒ SYNTHESIS_STATUS::PRESENT."""
         orch = _make_orchestrator(tmp_path)
         block = orch._format_debate_state(
-            self._base_state(turn_count=3, synthesis="Door's initial synthesis text")
+            self._base_state(
+                turn_count=3,
+                synthesis="Door's initial synthesis text",
+                path_contracts=[_contract_full()],
+            )
         )
         assert "SYNTHESIS_STATUS::PRESENT" in block
 
@@ -279,7 +389,9 @@ class TestOrchestratorEnvelopeIntegration:
         "synthesis withdrawn for refinement".
         """
         orch = _make_orchestrator(tmp_path)
-        block = orch._format_debate_state(self._base_state(turn_count=4, synthesis=None))
+        block = orch._format_debate_state(
+            self._base_state(turn_count=4, synthesis=None, path_contracts=[_contract_full()])
+        )
         assert "SYNTHESIS_STATUS::PENDING_REFINEMENT" in block
 
     # ---- PATH_CONTRACTS injection ----
@@ -299,6 +411,92 @@ class TestOrchestratorEnvelopeIntegration:
         orch = _make_orchestrator(tmp_path)
         block = orch._format_debate_state(self._base_state(path_contracts=[]))
         assert "<PATH_CONTRACTS>" not in block
+
+    # ---- Byte-identity snapshot (PR #218 rework: CE finding 1) ----
+
+    def _pre_pr_reference_envelope(
+        self, debate_state: dict[str, Any], *, show_token_counts: bool = False
+    ) -> str:
+        """Reproduce the pre-#199 _format_debate_state output verbatim.
+
+        This is the canonical reference for the "feature-off byte-identity"
+        guarantee. Any line emitted by the current renderer that does NOT also
+        appear here when ``path_contracts`` is absent/empty constitutes envelope
+        drift and must be gated on the feature being active.
+
+        Source: orchestrator.py @ commit 354cb9e (immediate parent of #199 merge).
+        """
+        lines = ["<DEBATE_STATE>"]
+        lines.append(f"THREAD_ID::{debate_state['thread_id']}")
+        lines.append(f"TOPIC::{debate_state['topic']}")
+        lines.append(f"STATUS::{debate_state['status']}")
+        lines.append(f"TURN_COUNT::{debate_state['turn_count']}")
+        if debate_state.get("synthesis"):
+            lines.append(f"SYNTHESIS::{debate_state['synthesis']}")
+        if debate_state.get("transcript"):
+            lines.append("\nTRANSCRIPT::")
+            for turn in debate_state["transcript"]:
+                role = turn.get("role", "Unknown")
+                cognition = turn.get("cognition")
+                content = turn.get("content", "")
+                token_output = turn.get("token_output")
+                role_label = f"[{role}/{cognition}]" if cognition else f"[{role}]"
+                if show_token_counts and token_output:
+                    lines.append(f"  {role_label} ({token_output} tokens):: {content}")
+                else:
+                    lines.append(f"  {role_label}:: {content}")
+        lines.append("</DEBATE_STATE>")
+        return "\n".join(lines)
+
+    def test_feature_off_envelope_is_byte_identical_to_pre_pr(self, tmp_path: Path) -> None:
+        """Feature-off (no path_contracts) ⇒ envelope is byte-identical to pre-#199 output.
+
+        Catches any future unconditional addition to ``_format_debate_state``
+        (the original PR #218 CE finding 1 symptom was an unconditional
+        ``SYNTHESIS_STATUS::<value>`` line). The contract: any new envelope
+        line MUST be gated on ``path_contracts`` being non-empty so the
+        legacy callers continue to see exactly the pre-#199 shape.
+
+        Joint emission contract (documented in PR #218 for #198 prompt PR):
+        ``SYNTHESIS_STATUS`` is emitted IFF ``<PATH_CONTRACTS>`` is emitted.
+        """
+        orch = _make_orchestrator(tmp_path)
+        state = self._base_state(
+            turn_count=2,
+            transcript=[
+                {"role": "Wind", "cognition": "PATHOS", "content": "hello"},
+                {"role": "Wall", "cognition": "ETHOS", "content": "constraint"},
+            ],
+        )
+        actual = orch._format_debate_state(state)
+        expected = self._pre_pr_reference_envelope(state)
+        assert actual == expected, (
+            "Feature-off envelope drifted from pre-#199 byte-identical reference.\n"
+            f"--- expected (pre-PR) ---\n{expected}\n"
+            f"--- actual (current)   ---\n{actual}"
+        )
+
+    def test_feature_off_envelope_byte_identical_minimal_state(self, tmp_path: Path) -> None:
+        """Minimal state (no transcript, no synthesis) also byte-identical."""
+        orch = _make_orchestrator(tmp_path)
+        state = self._base_state()
+        actual = orch._format_debate_state(state)
+        expected = self._pre_pr_reference_envelope(state)
+        assert actual == expected
+
+    def test_feature_on_envelope_emits_synthesis_status_jointly(self, tmp_path: Path) -> None:
+        """Joint emission contract: SYNTHESIS_STATUS is emitted IFF <PATH_CONTRACTS> is.
+
+        When ``path_contracts`` is non-empty, both ``SYNTHESIS_STATUS::<value>``
+        and the ``<PATH_CONTRACTS>`` sub-block must appear. This is the
+        downstream contract #198's Wind prompt branches depend on.
+        """
+        orch = _make_orchestrator(tmp_path)
+        block = orch._format_debate_state(
+            self._base_state(path_contracts=[_contract_full("path_1")])
+        )
+        assert "SYNTHESIS_STATUS::" in block
+        assert "<PATH_CONTRACTS>" in block
 
     def test_path_contracts_present_block_injected(self, tmp_path: Path) -> None:
         """Non-empty path_contracts ⇒ block injected inside <DEBATE_STATE>."""
@@ -338,27 +536,72 @@ class TestFindingIDoorPromptNoDiskRead:
     ) -> None:
         """Door's consensus-phase refinement prompt is assembled entirely in-memory.
 
-        Patches ``builtins.open`` to raise on any call that mentions the thread id,
-        proving the orchestrator never falls back to a filesystem read.
+        Patches every reasonable disk-read entry point to record any call that
+        mentions the thread id, proving the orchestrator never falls back to a
+        filesystem read via ANY of these paths.
+
+        Guard surface (PR #218 CE + TMG concur — Finding I widening):
+
+        * ``builtins.open`` (original guard)
+        * ``pathlib.Path.open``
+        * ``pathlib.Path.read_text``
+        * ``pathlib.Path.read_bytes`` (symmetry)
+        * ``io.open``
+
+        Note: ``aiofiles`` is NOT in this project's dependency tree (verified
+        against ``pyproject.toml`` at the time of PR #218 rework). If it is
+        ever added, extend this guard with an ``aiofiles.open`` patch.
         """
         import builtins
+        import contextlib
+        import io
+        import pathlib
 
         orch = _make_orchestrator(tmp_path)
         thread_id = "2026-05-19-finding-i-test"
 
-        real_open = builtins.open
         offending_opens: list[str] = []
 
-        def guarded_open(path: Any, *args: Any, **kwargs: Any) -> Any:
-            try:
-                spath = str(path)
-            except Exception:
-                spath = ""
+        def _record(spath: str) -> None:
             if thread_id in spath:
                 offending_opens.append(spath)
-            return real_open(path, *args, **kwargs)
 
-        monkeypatch.setattr(builtins, "open", guarded_open)
+        real_builtin_open = builtins.open
+        real_io_open = io.open
+        real_path_open = pathlib.Path.open
+        real_path_read_text = pathlib.Path.read_text
+        real_path_read_bytes = pathlib.Path.read_bytes
+
+        def guarded_builtin_open(path: Any, *args: Any, **kwargs: Any) -> Any:
+            with contextlib.suppress(Exception):
+                _record(str(path))
+            return real_builtin_open(path, *args, **kwargs)
+
+        def guarded_io_open(path: Any, *args: Any, **kwargs: Any) -> Any:
+            with contextlib.suppress(Exception):
+                _record(str(path))
+            return real_io_open(path, *args, **kwargs)
+
+        def guarded_path_open(self: pathlib.Path, *args: Any, **kwargs: Any) -> Any:
+            with contextlib.suppress(Exception):
+                _record(str(self))
+            return real_path_open(self, *args, **kwargs)
+
+        def guarded_path_read_text(self: pathlib.Path, *args: Any, **kwargs: Any) -> str:
+            with contextlib.suppress(Exception):
+                _record(str(self))
+            return real_path_read_text(self, *args, **kwargs)
+
+        def guarded_path_read_bytes(self: pathlib.Path) -> bytes:
+            with contextlib.suppress(Exception):
+                _record(str(self))
+            return real_path_read_bytes(self)
+
+        monkeypatch.setattr(builtins, "open", guarded_builtin_open)
+        monkeypatch.setattr(io, "open", guarded_io_open)
+        monkeypatch.setattr(pathlib.Path, "open", guarded_path_open)
+        monkeypatch.setattr(pathlib.Path, "read_text", guarded_path_read_text)
+        monkeypatch.setattr(pathlib.Path, "read_bytes", guarded_path_read_bytes)
 
         # Build a consensus refinement prompt for Door — this is the construction
         # site Finding I flagged. The orchestrator helper is pure string assembly.
@@ -371,9 +614,11 @@ class TestFindingIDoorPromptNoDiskRead:
 
         assert isinstance(prompt, str)
         assert thread_id in prompt
-        assert (
-            offending_opens == []
-        ), f"Door prompt construction performed disk reads for thread paths: {offending_opens}"
+        assert offending_opens == [], (
+            "Door prompt construction performed disk reads for thread paths via one "
+            f"of builtins.open / io.open / pathlib.Path.{{open,read_text,read_bytes}}: "
+            f"{offending_opens}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_context_compiler_path_contracts.py
+++ b/tests/unit/test_context_compiler_path_contracts.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -32,8 +31,6 @@ from debate_hall_mcp.path_contract import (
     VerdictRevision,
     new_path_contract,
 )
-from debate_hall_mcp.providers import ProviderResponse
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -374,9 +371,9 @@ class TestFindingIDoorPromptNoDiskRead:
 
         assert isinstance(prompt, str)
         assert thread_id in prompt
-        assert offending_opens == [], (
-            f"Door prompt construction performed disk reads for thread paths: {offending_opens}"
-        )
+        assert (
+            offending_opens == []
+        ), f"Door prompt construction performed disk reads for thread paths: {offending_opens}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_context_compiler_path_contracts.py
+++ b/tests/unit/test_context_compiler_path_contracts.py
@@ -1,0 +1,402 @@
+"""Tests for <PATH_CONTRACTS> rendering and <SYNTHESIS_STATUS> signaling (RFC-0001 #199).
+
+Covers:
+
+* RFC §6 item 1 — latest-revision-per-field + revision-count rendering
+* Feature-off byte-identity: empty contracts list ⇒ no <PATH_CONTRACTS> block emitted
+* Finding F — explicit <SYNTHESIS_STATUS> flag (PENDING_INITIAL | PRESENT |
+  PENDING_REFINEMENT) so Wind/Wall/Door prompts can branch unambiguously without
+  the APPROVE/REJECT-vs-no-synthesis conflation reported in #204
+* RFC §8 Q3 — token-budget worst-case ≤ ~3.6k tokens for 3 paths × 3 fields
+* Finding I — orchestrator's Door prompt construction never reads from disk;
+  the in-memory debate_state envelope is the sole source of truth
+
+TDD Discipline: RED → GREEN → REFACTOR.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from debate_hall_mcp.config import RoleConfig, TierConfig, TierSettings
+from debate_hall_mcp.orchestrator import DebateOrchestrator
+from debate_hall_mcp.path_contract import (
+    DiffRevision,
+    FrameRevision,
+    PathContract,
+    VerdictRevision,
+    new_path_contract,
+)
+from debate_hall_mcp.providers import ProviderResponse
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _ts(minute: int = 0) -> datetime:
+    return datetime(2026, 5, 19, 12, minute, 0, tzinfo=UTC)
+
+
+def _contract_frame_only(path_id: str = "path_1") -> PathContract:
+    contract = new_path_contract(path_id)
+    contract["frame_history"].append(
+        FrameRevision(
+            rev=0,
+            written_at=_ts(),
+            written_by="Wind",
+            value={
+                "assumed_problem": "users cannot reset their password without contacting support",
+                "success_criterion": "password reset completes in under 60 seconds end-to-end",
+                "accepted_failure_mode": "email delivery latency may exceed 60s in adverse network conditions",
+                "invariants_touched": ["halting", "single_wall_coherence"],
+            },
+        )
+    )
+    return contract
+
+
+def _contract_frame_and_verdict(path_id: str = "path_1") -> PathContract:
+    contract = _contract_frame_only(path_id)
+    contract["verdict_history"].append(
+        VerdictRevision(
+            rev=0,
+            written_at=_ts(1),
+            written_by="Wall",
+            value={
+                "halting": {"status": "HARD_pass", "rationale": "reset loop has a 3-attempt cap"},
+                "single_wall_coherence": {
+                    "status": "SOFT_disputed",
+                    "rationale": "second factor may be missing on legacy accounts",
+                },
+            },
+        )
+    )
+    return contract
+
+
+def _contract_full(path_id: str = "path_1") -> PathContract:
+    contract = _contract_frame_and_verdict(path_id)
+    contract["diff_history"].append(
+        DiffRevision(
+            rev=0,
+            written_at=_ts(2),
+            written_by="Wind",
+            value={
+                "accepted": [
+                    {
+                        "invariant": "halting",
+                        "rationale": "the 3-attempt cap is correct and not negotiable",
+                    }
+                ],
+                "disputed": [
+                    {
+                        "invariant": "single_wall_coherence",
+                        "rationale": "legacy accounts can be migrated as a precondition rather than blocked",
+                    }
+                ],
+                "reframed": [],
+            },
+        )
+    )
+    return contract
+
+
+def _make_orchestrator(tmp_path: Path) -> DebateOrchestrator:
+    tier_config = TierConfig(
+        wind=RoleConfig(provider="cli", cli="claude"),
+        wall=RoleConfig(provider="cli", cli="codex"),
+        door=RoleConfig(provider="cli", cli="gemini"),
+        settings=TierSettings(),
+    )
+    return DebateOrchestrator(tier_config, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Pure renderer tests (context_compiler.render_path_contracts_block)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPathContractsBlock:
+    """Pure-function tests for the <PATH_CONTRACTS> sub-block renderer."""
+
+    def test_empty_contracts_returns_empty_string(self) -> None:
+        """Feature-off: an empty contracts list renders no <PATH_CONTRACTS> block.
+
+        This guarantees byte-identity with the legacy envelope when path contracts
+        are not yet plumbed by the orchestrator (e.g. before #197 persistence lands
+        or when the feature flag is off in #201/#205).
+        """
+        from debate_hall_mcp.context_compiler import render_path_contracts_block
+
+        assert render_path_contracts_block([]) == ""
+
+    def test_frame_only_emits_frame_and_revcount(self) -> None:
+        """Single path with frame only (Wind initial) shows frame + rev count, no verdict/diff."""
+        from debate_hall_mcp.context_compiler import render_path_contracts_block
+
+        block = render_path_contracts_block([_contract_frame_only("path_1")])
+
+        assert "<PATH_CONTRACTS>" in block
+        assert "</PATH_CONTRACTS>" in block
+        assert "path_1" in block
+        # Frame rendered
+        assert "FRAME" in block
+        assert "frame_rev_count::1" in block
+        assert "assumed_problem" in block
+        # Verdict and diff absent (no rev yet)
+        assert "verdict_rev_count::0" in block
+        assert "diff_rev_count::0" in block
+
+    def test_frame_and_verdict_shows_both_no_diff(self) -> None:
+        """Single path with frame + verdict (Wind→Wall done) shows both, no diff."""
+        from debate_hall_mcp.context_compiler import render_path_contracts_block
+
+        block = render_path_contracts_block([_contract_frame_and_verdict("path_1")])
+
+        assert "frame_rev_count::1" in block
+        assert "verdict_rev_count::1" in block
+        assert "diff_rev_count::0" in block
+        assert "HARD_pass" in block
+        assert "SOFT_disputed" in block
+
+    def test_full_lifecycle_shows_all_three(self) -> None:
+        """Single path with frame + verdict + diff shows all three (latest rev only)."""
+        from debate_hall_mcp.context_compiler import render_path_contracts_block
+
+        block = render_path_contracts_block([_contract_full("path_1")])
+
+        assert "frame_rev_count::1" in block
+        assert "verdict_rev_count::1" in block
+        assert "diff_rev_count::1" in block
+        # Diff content rendered
+        assert "accepted" in block
+        assert "disputed" in block
+
+    def test_latest_revision_only_full_history_not_rendered(self) -> None:
+        """RFC §6 item 1: only the latest revision per field is rendered in-prompt.
+
+        Earlier revisions stay in storage (I4 append-only) but must NOT appear in
+        the prompt context.
+        """
+        from debate_hall_mcp.context_compiler import render_path_contracts_block
+
+        contract = _contract_full("path_1")
+        # Append a second (latest) frame revision with a distinct marker
+        contract["frame_history"].append(
+            FrameRevision(
+                rev=1,
+                written_at=_ts(3),
+                written_by="Wind",
+                value={
+                    "assumed_problem": "REVISED_PROBLEM_MARKER",
+                    "success_criterion": "REVISED_SUCCESS",
+                    "accepted_failure_mode": "REVISED_FAILURE",
+                    "invariants_touched": ["halting"],
+                },
+            )
+        )
+
+        block = render_path_contracts_block([contract])
+
+        # Latest is shown
+        assert "REVISED_PROBLEM_MARKER" in block
+        # Revision count reflects both revisions
+        assert "frame_rev_count::2" in block
+        # The earlier frame's distinctive substring MUST NOT appear
+        assert "users cannot reset their password" not in block
+
+    def test_token_budget_three_paths_under_3600(self) -> None:
+        """RFC §8 Q3: worst-case ≤ ~3.6k tokens for 3 paths × 3 fields.
+
+        Uses character-count / 4 as a portable token approximation (tiktoken-free).
+        """
+        from debate_hall_mcp.context_compiler import render_path_contracts_block
+
+        contracts = [_contract_full(f"path_{i}") for i in (1, 2, 3)]
+        block = render_path_contracts_block(contracts)
+
+        approx_tokens = len(block) // 4
+        # Per RFC §8 Q3, the ceiling is ~3.6k tokens worst-case for 3 paths × 3 fields.
+        # Real-world content is shorter than the simulation worst case; assert headroom.
+        assert approx_tokens <= 3600, (
+            f"PATH_CONTRACTS rendering exceeded RFC §8 Q3 ceiling: "
+            f"{approx_tokens} tokens for 3 paths × 3 fields"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator integration tests (_format_debate_state)
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorEnvelopeIntegration:
+    """End-to-end envelope assembly via DebateOrchestrator._format_debate_state."""
+
+    def _base_state(self, **overrides: Any) -> dict[str, Any]:
+        state: dict[str, Any] = {
+            "thread_id": "2026-05-19-rfc0001-test",
+            "topic": "Test topic",
+            "status": "in_progress",
+            "turn_count": 0,
+            "transcript": [],
+        }
+        state.update(overrides)
+        return state
+
+    # ---- Finding F: SYNTHESIS_STATUS ----
+
+    def test_synthesis_status_pending_initial_before_any_turns(self, tmp_path: Path) -> None:
+        """No synthesis + zero turns ⇒ SYNTHESIS_STATUS::PENDING_INITIAL."""
+        orch = _make_orchestrator(tmp_path)
+        block = orch._format_debate_state(self._base_state(turn_count=0))
+        assert "SYNTHESIS_STATUS::PENDING_INITIAL" in block
+
+    def test_synthesis_status_pending_initial_before_door_speaks(self, tmp_path: Path) -> None:
+        """No synthesis + Wind/Wall spoken but no Door yet ⇒ still PENDING_INITIAL."""
+        orch = _make_orchestrator(tmp_path)
+        block = orch._format_debate_state(self._base_state(turn_count=2))
+        assert "SYNTHESIS_STATUS::PENDING_INITIAL" in block
+
+    def test_synthesis_status_present_when_synthesis_set(self, tmp_path: Path) -> None:
+        """Door has synthesised ⇒ SYNTHESIS_STATUS::PRESENT."""
+        orch = _make_orchestrator(tmp_path)
+        block = orch._format_debate_state(
+            self._base_state(turn_count=3, synthesis="Door's initial synthesis text")
+        )
+        assert "SYNTHESIS_STATUS::PRESENT" in block
+
+    def test_synthesis_status_pending_refinement_after_door_but_no_synthesis_field(
+        self, tmp_path: Path
+    ) -> None:
+        """Door's synthesis was rejected and cleared pending refinement ⇒ PENDING_REFINEMENT.
+
+        The orchestrator clears ``synthesis`` while keeping turn_count ≥ 3 when a
+        refinement loop is in flight; this distinguishes "never synthesised" from
+        "synthesis withdrawn for refinement".
+        """
+        orch = _make_orchestrator(tmp_path)
+        block = orch._format_debate_state(self._base_state(turn_count=4, synthesis=None))
+        assert "SYNTHESIS_STATUS::PENDING_REFINEMENT" in block
+
+    # ---- PATH_CONTRACTS injection ----
+
+    def test_no_path_contracts_no_block(self, tmp_path: Path) -> None:
+        """When debate_state has no path_contracts key, no <PATH_CONTRACTS> block is emitted.
+
+        Byte-identity guarantee for the feature-off path.
+        """
+        orch = _make_orchestrator(tmp_path)
+        block = orch._format_debate_state(self._base_state())
+        assert "<PATH_CONTRACTS>" not in block
+        assert "</PATH_CONTRACTS>" not in block
+
+    def test_empty_path_contracts_list_no_block(self, tmp_path: Path) -> None:
+        """Empty list also yields no <PATH_CONTRACTS> block."""
+        orch = _make_orchestrator(tmp_path)
+        block = orch._format_debate_state(self._base_state(path_contracts=[]))
+        assert "<PATH_CONTRACTS>" not in block
+
+    def test_path_contracts_present_block_injected(self, tmp_path: Path) -> None:
+        """Non-empty path_contracts ⇒ block injected inside <DEBATE_STATE>."""
+        orch = _make_orchestrator(tmp_path)
+        block = orch._format_debate_state(
+            self._base_state(path_contracts=[_contract_full("path_1")])
+        )
+        # Sub-block appears inside the envelope
+        assert "<DEBATE_STATE>" in block
+        assert "</DEBATE_STATE>" in block
+        assert "<PATH_CONTRACTS>" in block
+        assert "</PATH_CONTRACTS>" in block
+        # Sub-block is BEFORE the envelope's closing tag
+        assert block.index("<PATH_CONTRACTS>") < block.index("</DEBATE_STATE>")
+        # Frame content appears
+        assert "frame_rev_count::1" in block
+
+
+# ---------------------------------------------------------------------------
+# Finding I: Door prompt construction never touches the filesystem
+# ---------------------------------------------------------------------------
+
+
+class TestFindingIDoorPromptNoDiskRead:
+    """Finding I (RFC-0001 §3.3) — Door must not look for a non-existent debate thread on disk.
+
+    The simulation reported Door reading a thread file that doesn't exist. The fix is
+    structural: the orchestrator provides everything Door needs through the in-memory
+    DEBATE_STATE envelope. This test pins that invariant by patching ``Path.open`` /
+    ``builtins.open`` while the Door consensus refinement prompt is constructed, and
+    asserting they are never called for any debate-thread path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_door_consensus_refinement_constructs_prompt_without_disk_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Door's consensus-phase refinement prompt is assembled entirely in-memory.
+
+        Patches ``builtins.open`` to raise on any call that mentions the thread id,
+        proving the orchestrator never falls back to a filesystem read.
+        """
+        import builtins
+
+        orch = _make_orchestrator(tmp_path)
+        thread_id = "2026-05-19-finding-i-test"
+
+        real_open = builtins.open
+        offending_opens: list[str] = []
+
+        def guarded_open(path: Any, *args: Any, **kwargs: Any) -> Any:
+            try:
+                spath = str(path)
+            except Exception:
+                spath = ""
+            if thread_id in spath:
+                offending_opens.append(spath)
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", guarded_open)
+
+        # Build a consensus refinement prompt for Door — this is the construction
+        # site Finding I flagged. The orchestrator helper is pure string assembly.
+        prompt = orch._create_refinement_prompt(
+            topic="any topic",
+            thread_id=thread_id,
+            rejector="Wind",
+            feedback="please reframe",
+        )
+
+        assert isinstance(prompt, str)
+        assert thread_id in prompt
+        assert offending_opens == [], (
+            f"Door prompt construction performed disk reads for thread paths: {offending_opens}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Smoke: provider call does not break with path_contracts in state
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeBackwardsCompat:
+    """The added envelope changes must not regress existing VTP prompt assembly."""
+
+    def test_state_without_path_contracts_still_renders(self, tmp_path: Path) -> None:
+        """Pre-#199 callers that pass no path_contracts key still get a valid envelope."""
+        orch = _make_orchestrator(tmp_path)
+        state: dict[str, Any] = {
+            "thread_id": "tid",
+            "topic": "t",
+            "status": "in_progress",
+            "turn_count": 0,
+            "transcript": [],
+        }
+        block = orch._format_debate_state(state)
+        assert block.startswith("<DEBATE_STATE>")
+        assert block.endswith("</DEBATE_STATE>")


### PR DESCRIPTION
## Summary

Implements the **context-compiler** portion of RFC-0001 by injecting a `<PATH_CONTRACTS>` sub-block into the `<DEBATE_STATE>` envelope, plus an explicit `<SYNTHESIS_STATUS>` flag. Folds Findings F (APPROVE/REJECT-vs-no-synthesis conflation) and I (alleged Door disk-read fallback).

Closes #199
Part of #195

## Acceptance — bound to amended RFC

- **RFC §3.2 Lifecycle** — the envelope now reflects each role's latest write per field as the round progresses; storage retains full history.
- **RFC §6 item 1** — `<PATH_CONTRACTS>` renders the **latest revision per field** plus `frame_rev_count` / `verdict_rev_count` / `diff_rev_count` metadata. Earlier revisions stay in storage (I4 append-only) and are never blasted into prompts. The renderer uses the `path_contract.prompt_context_view()` helper exposed by #196.
- **RFC §8 Q3** — token-budget worst-case for 3 paths × 3 fields measured by `test_token_budget_three_paths_under_3600` using `len(block) // 4` (portable approximation). Stays **well under the ~3.6k token ceiling** (single full-lifecycle path with realistic fixture content renders in well under 1k tokens; 3 × that has headroom).

## Finding F — synthesis-status convention chosen

**Decision: explicit `SYNTHESIS_STATUS::<value>` line, always emitted inside `<DEBATE_STATE>`.**

Three values:

| Value | Meaning |
|---|---|
| `PRESENT` | Door has produced/refined a synthesis; `synthesis` field is set |
| `PENDING_INITIAL` | No synthesis yet for the round; `turn_count < 3` |
| `PENDING_REFINEMENT` | Prior synthesis was withdrawn; `synthesis` unset but `turn_count >= 3` |

**Alternative considered:** omit a `<SYNTHESIS>` block entirely when none exists and have Wind's prompt detect absence.

**Rejected because:** it forces the prompt template to parse the whole envelope for *negative* evidence, and "field absent" is fragile under future envelope edits. An explicit flag is a smaller, sharper contract — `#198` prompt logic just matches `SYNTHESIS_STATUS::PRESENT` to decide whether to vote.

**#198 dependency:** the Wind/Wall consensus-approval prompt templates SHOULD branch on this flag rather than checking for `SYNTHESIS::` presence. The exact prompt text is #198's territory; this PR ships the signal #198 needs.

## Finding I — investigation outcome

**Outcome: no code change to Door's prompt construction was needed; a regression-guard test was added.**

The simulation finding alleged "Door looks for a non-existent debate thread on disk." Investigation in the current codebase:

```
$ grep -E 'open\(|Path\(|read_text|\.glob' src/debate_hall_mcp/orchestrator.py
(no matches)
```

The orchestrator's Door prompt construction path (`_create_refinement_prompt` → `format_door_consensus_prompt`) is pure string assembly over in-memory state from `debate_get()`. There is no filesystem fallback to remove.

The test `TestFindingIDoorPromptNoDiskRead::test_door_consensus_refinement_constructs_prompt_without_disk_read` pins this invariant by patching `builtins.open` and asserting **no thread-id-bearing path is opened during prompt construction**. This converts the structural property from "happens to be true today" into "will fail CI if anyone reintroduces a disk-read fallback."

## Files touched

- `src/debate_hall_mcp/context_compiler.py` — adds `render_path_contracts_block()` and `derive_synthesis_status()`; module docstring updated to cover both decision-export (#138) and in-prompt rendering (#199) concerns
- `src/debate_hall_mcp/orchestrator.py` — `_format_debate_state` always emits `SYNTHESIS_STATUS::<value>`; conditionally emits `<PATH_CONTRACTS>` when `debate_state["path_contracts"]` is a non-empty list
- `tests/unit/test_context_compiler_path_contracts.py` — new test module, 15 tests covering renderer, envelope integration, Finding F, Finding I, byte-identity backwards compat, and token budget

## Out of scope (deliberately untouched)

- `src/debate_hall_mcp/path_contract.py` (#196, read-only consumed)
- `src/debate_hall_mcp/path_contract_validator.py` (#200, read-only consumed)
- `src/debate_hall_mcp/prompts/__init__.py` (#198 territory — depends on the SYNTHESIS_STATUS convention this PR ships)
- `src/debate_hall_mcp/state.py` (#197 — persistence will populate the `path_contracts` key the renderer consumes)
- Feature flag wiring (#201/#205)
- Orchestrator consensus loop / halting / Wall reapproval invariants

## Quality gates

- `uv run pytest` — **1536 passed** (1521 baseline + 15 new)
- `uv run ruff check .` — **clean**
- `uv run black --check .` — **clean**
- `uv run mypy src/` — **clean** (strict)

## Test plan

- [x] RED tests committed before implementation (`9ddccf6`) — 11 expected failures + 4 byte-identity guards
- [x] GREEN implementation committed separately (`0c5c44c`) — all 15 tests pass
- [x] Full suite passes, no regressions to existing 1521 tests
- [x] Token-budget assertion at the RFC §8 Q3 ceiling
- [x] Finding I regression guard via `builtins.open` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements RFC-0001 context-compiler: injects a `<PATH_CONTRACTS>` block into `<DEBATE_STATE>` and emits `SYNTHESIS_STATUS` jointly when contracts exist, while keeping the feature-off envelope byte-identical. Closes #199; supports #195 and unblocks prompt work in #198.

- **New Features**
  - Injects `<PATH_CONTRACTS>` with latest per-field values and `frame_rev_count` / `verdict_rev_count` / `diff_rev_count`; omitted when empty.
  - Emits `SYNTHESIS_STATUS::<PRESENT|PENDING_INITIAL|PENDING_REFINEMENT>` only when `<PATH_CONTRACTS>` is present (joint emission). Prompts in #198 should branch on this.
  - Adds `context_compiler.render_path_contracts_block()` and `derive_synthesis_status()`; `DebateOrchestrator._format_debate_state` consumes them; feature-off path is byte-identical to pre-#199.
  - Token budget: stays under ~3.6k tokens for 3 paths × 3 fields; adds a long-form stress test with a documented 9k ceiling.

- **Bug Fixes**
  - Finding I: strengthened the no-disk-read guard for Door prompt construction by patching `builtins.open`, `io.open`, and `pathlib.Path.{open,read_text,read_bytes}`; still no code changes needed.

<sup>Written for commit 157739ec0f025884d144e275b3306d85a105899d. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/218?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

