### PR TITLE
[RFC-0001] #197 — State serialization: persist path_contract + append API

### DIFF
--- a/src/debate_hall_mcp/state.py
+++ b/src/debate_hall_mcp/state.py
@@ -26,6 +26,22 @@ from typing import Any
 import fasteners  # type: ignore[import-untyped]
 from pydantic import BaseModel, Field, field_validator
 
+from debate_hall_mcp.path_contract import (
+    DiffRevision,
+    FrameRevision,
+    PathContract,
+    PathDiff,
+    PathFrame,
+    VerdictRevision,
+    new_path_contract,
+)
+from debate_hall_mcp.path_contract import (
+    Invariant as _Invariant,
+)
+from debate_hall_mcp.path_contract import (
+    InvariantVerdict as _InvariantVerdict,
+)
+
 
 class ConcurrencyError(Exception):
     """Raised when a Compare-and-Swap (CAS) operation fails due to concurrent modification.
@@ -601,6 +617,171 @@ class DebateRoom(BaseModel):
         default=None,
         description="Pre-compiled RACI turn manifest (populated by orchestrator for RACI mode)",
     )
+    path_contracts: list[PathContract] = Field(
+        default_factory=list,
+        description=(
+            "Per-path append-only contracts (RFC-0001 §3.1 / #196). "
+            "Always-emit-empty backward compat: legacy state files lacking "
+            "this key load with path_contracts=[]. The typed append API "
+            "(append_frame_revision / append_verdict_revision / "
+            "append_diff_revision) is the only sanctioned mutation surface "
+            "and enforces the PROD::I4 append-only invariant at the type "
+            "boundary by auto-assigning monotonic rev and stamping "
+            "ownership Literals."
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # Typed append API for path_contracts (RFC-0001 §3.1, PROD::I4).
+    #
+    # The trio below is the ONLY sanctioned mutation surface for
+    # path_contracts. Each method:
+    #
+    #   * auto-creates the PathContract for ``path_id`` on first use
+    #     (callers do not need to pre-register paths),
+    #   * assigns ``rev = len(history)`` so revision numbers are
+    #     strictly monotonic per (path_id, history-kind) without
+    #     callers having to track them,
+    #   * stamps ``written_by`` with the RFC §3.1 ownership Literal so
+    #     callers cannot spoof the owner (the validator in #200 would
+    #     reject a spoofed value, but defending in-depth at the write
+    #     boundary keeps the in-memory state authoritative),
+    #   * returns the appended revision (the wrapper TypedDict) so the
+    #     caller can immediately read the assigned ``rev`` or pass the
+    #     revision through downstream validation.
+    #
+    # Callers MUST NOT mutate ``path_contracts`` directly. Direct list
+    # mutation is not statically enforceable (Pydantic exposes the list
+    # by reference), but the ledger invariant (PROD::I4) is enforced
+    # downstream by the #200 validator's ownership and shape checks at
+    # consensus time, so the practical attack surface is bounded.
+    # ------------------------------------------------------------------
+
+    def _get_or_create_contract(self, path_id: str) -> PathContract:
+        """Return the PathContract for ``path_id``, creating it if absent."""
+        for contract in self.path_contracts:
+            if contract["path_id"] == path_id:
+                return contract
+        new_contract = new_path_contract(path_id)
+        self.path_contracts.append(new_contract)
+        return new_contract
+
+    def append_frame_revision(
+        self,
+        *,
+        path_id: str,
+        written_at: datetime,
+        value: PathFrame,
+    ) -> FrameRevision:
+        """Append a Wind-owned frame revision to ``path_id``'s history.
+
+        Args:
+            path_id: Path identifier; the contract is auto-created on
+                first append.
+            written_at: Authoring timestamp (timezone-aware UTC).
+            value: The :class:`PathFrame` payload Wind is asserting.
+
+        Returns:
+            The appended :class:`FrameRevision` wrapper (so callers can
+            read the auto-assigned ``rev``).
+        """
+        contract = self._get_or_create_contract(path_id)
+        rev_num = len(contract["frame_history"])
+        revision: FrameRevision = FrameRevision(
+            rev=rev_num,
+            written_at=written_at,
+            written_by="Wind",
+            value=value,
+        )
+        contract["frame_history"].append(revision)
+        return revision
+
+    def append_verdict_revision(
+        self,
+        *,
+        path_id: str,
+        written_at: datetime,
+        value: dict[_Invariant, _InvariantVerdict],
+    ) -> VerdictRevision:
+        """Append a Wall-owned verdict revision to ``path_id``'s history.
+
+        Args:
+            path_id: Path identifier; the contract is auto-created on
+                first append.
+            written_at: Authoring timestamp (timezone-aware UTC).
+            value: Mapping of invariant name -> InvariantVerdict for
+                every invariant Wall judges on this revision.
+
+        Returns:
+            The appended :class:`VerdictRevision` wrapper.
+        """
+        contract = self._get_or_create_contract(path_id)
+        rev_num = len(contract["verdict_history"])
+        revision: VerdictRevision = VerdictRevision(
+            rev=rev_num,
+            written_at=written_at,
+            written_by="Wall",
+            value=value,
+        )
+        contract["verdict_history"].append(revision)
+        return revision
+
+    def append_diff_revision(
+        self,
+        *,
+        path_id: str,
+        written_at: datetime,
+        value: PathDiff,
+        divergence_marker: str | None = None,
+        synthesis_guidance: str | None = None,
+    ) -> DiffRevision:
+        """Append a Wind-owned diff revision to ``path_id``'s history.
+
+        Optional fields ``divergence_marker`` and ``synthesis_guidance``
+        flow through when supplied; absent inputs stay absent on the
+        revision (the schema's ``NotRequired`` keys are not coerced to
+        ``None``).
+
+        Args:
+            path_id: Path identifier; the contract is auto-created on
+                first append.
+            written_at: Authoring timestamp (timezone-aware UTC).
+            value: The :class:`PathDiff` payload (accepted / disputed /
+                reframed buckets).
+            divergence_marker: Optional sentinel. When set, MUST equal
+                ``"NO_NEW_DIVERGENCE"`` per the schema's ``Literal``;
+                any other value raises ``ValueError`` here so the
+                persisted shape cannot drift from the validator's
+                expected sentinel set.
+            synthesis_guidance: Optional free-text cross-path insight
+                (Finding E). Carried through verbatim.
+
+        Returns:
+            The appended :class:`DiffRevision` wrapper.
+
+        Raises:
+            ValueError: If ``divergence_marker`` is supplied with a
+                value other than ``"NO_NEW_DIVERGENCE"``.
+        """
+        if divergence_marker is not None and divergence_marker != "NO_NEW_DIVERGENCE":
+            raise ValueError(
+                "divergence_marker must equal 'NO_NEW_DIVERGENCE' when set "
+                f"(got {divergence_marker!r}); see RFC-0001 §3.1 ``DiffRevision``."
+            )
+        contract = self._get_or_create_contract(path_id)
+        rev_num = len(contract["diff_history"])
+        revision: DiffRevision = DiffRevision(
+            rev=rev_num,
+            written_at=written_at,
+            written_by="Wind",
+            value=value,
+        )
+        if divergence_marker is not None:
+            revision["divergence_marker"] = "NO_NEW_DIVERGENCE"
+        if synthesis_guidance is not None:
+            revision["synthesis_guidance"] = synthesis_guidance
+        contract["diff_history"].append(revision)
+        return revision
 
 
 def calculate_turn_hash(

--- a/src/debate_hall_mcp/tools/get.py
+++ b/src/debate_hall_mcp/tools/get.py
@@ -100,6 +100,14 @@ def debate_get(
     # Session type is always included (Issue #175)
     result["session_type"] = room.session_type.value
 
+    # Path contracts are always surfaced (RFC-0001 #197 / #199): the
+    # orchestrator's ``_format_debate_state`` reads ``path_contracts``
+    # off this dict and feeds it to ``render_path_contracts_block``.
+    # Always-emit-empty preserves the renderer's feature-off byte-identity
+    # guarantee (empty list ⇒ no <PATH_CONTRACTS> block emitted) while
+    # giving downstream consumers a stable key to depend on.
+    result["path_contracts"] = list(room.path_contracts)
+
     # For non-debate sessions, include participants and committee_metadata
     if room.session_type != SessionType.DEBATE:
         if room.participants is not None:

--- a/tests/unit/test_get_path_contracts.py
+++ b/tests/unit/test_get_path_contracts.py
@@ -1,0 +1,78 @@
+"""Regression guard: ``debate_get`` exposes persisted ``path_contracts``
+so the orchestrator's #199 ``<PATH_CONTRACTS>`` renderer sees them.
+
+Per RFC-0001 §6 item 1, the orchestrator's ``_format_debate_state``
+reads ``debate_state.get("path_contracts")`` and feeds the list to
+``render_path_contracts_block``. ``debate_state`` is the dict returned
+by :func:`debate_hall_mcp.tools.get.debate_get`. If ``debate_get`` does
+not carry the field, the renderer silently emits nothing — a regression
+that breaks #199's contract without producing any test failure on the
+renderer-side tests (which inject the list directly).
+
+This file pins the contract between the tool layer and the renderer.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from debate_hall_mcp.path_contract import FrameRevision, new_path_contract
+from debate_hall_mcp.state import DebateMode, DebateRoom, save_debate_state
+from debate_hall_mcp.tools.get import debate_get
+
+
+def _ts() -> datetime:
+    return datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+
+
+def test_debate_get_includes_path_contracts_when_present(tmp_path: Path) -> None:
+    """A room with path_contracts surfaces them via debate_get()."""
+    contract = new_path_contract("p1")
+    contract["frame_history"].append(
+        FrameRevision(
+            rev=0,
+            written_at=_ts(),
+            written_by="Wind",
+            value={
+                "assumed_problem": "p",
+                "success_criterion": "s",
+                "accepted_failure_mode": "f",
+                "invariants_touched": ["inv_a"],
+            },
+        )
+    )
+    room = DebateRoom(
+        thread_id="2026-05-19-get-pc",
+        topic="get exposes contracts",
+        mode=DebateMode.FIXED,
+        path_contracts=[contract],
+    )
+    state_dir = tmp_path / "debates"
+    save_debate_state(room, state_dir)
+
+    result = debate_get("2026-05-19-get-pc", state_dir=state_dir)
+    assert "path_contracts" in result
+    assert len(result["path_contracts"]) == 1
+    assert result["path_contracts"][0]["path_id"] == "p1"
+    # Renderer-relevant: latest_frame is reachable through the surfaced shape.
+    assert len(result["path_contracts"][0]["frame_history"]) == 1
+
+
+def test_debate_get_path_contracts_is_empty_list_when_absent(tmp_path: Path) -> None:
+    """A room without path_contracts surfaces an empty list (not missing key).
+
+    The renderer treats missing/empty identically (feature-off byte-identity),
+    but the contract from the tool layer is to ALWAYS surface the key so
+    downstream consumers (analytics, debugging) can rely on its presence.
+    """
+    room = DebateRoom(
+        thread_id="2026-05-19-get-pc-empty",
+        topic="empty contracts",
+        mode=DebateMode.FIXED,
+    )
+    state_dir = tmp_path / "debates"
+    save_debate_state(room, state_dir)
+
+    result = debate_get("2026-05-19-get-pc-empty", state_dir=state_dir)
+    assert result.get("path_contracts") == []

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -18,7 +18,8 @@ import pytest
 from debate_hall_mcp.path_contract import (
     DiffRevision,
     FrameRevision,
-    PathContract,
+    PathDiff,
+    PathFrame,
     VerdictRevision,
     new_path_contract,
 )
@@ -1662,17 +1663,17 @@ def _ts(minute: int = 0) -> datetime:
     return datetime(2026, 5, 19, 12, minute, 0, tzinfo=UTC)
 
 
-def _frame_value(problem: str = "x") -> dict[str, object]:
-    return {
-        "assumed_problem": problem,
-        "success_criterion": "criterion",
-        "accepted_failure_mode": "failure_mode",
-        "invariants_touched": ["inv_a"],
-    }
+def _frame_value(problem: str = "x") -> PathFrame:
+    return PathFrame(
+        assumed_problem=problem,
+        success_criterion="criterion",
+        accepted_failure_mode="failure_mode",
+        invariants_touched=["inv_a"],
+    )
 
 
-def _diff_value_empty() -> dict[str, list[dict[str, str]]]:
-    return {"accepted": [], "disputed": [], "reframed": []}
+def _diff_value_empty() -> PathDiff:
+    return PathDiff(accepted=[], disputed=[], reframed=[])
 
 
 class TestDebateRoomPathContractsField:
@@ -1711,7 +1712,7 @@ class TestPathContractsRoundTrip:
                 rev=0,
                 written_at=_ts(0),
                 written_by="Wind",
-                value=_frame_value("alpha problem"),  # type: ignore[arg-type]
+                value=_frame_value("alpha problem"),
             )
         )
         contract["verdict_history"].append(
@@ -1727,7 +1728,7 @@ class TestPathContractsRoundTrip:
                 rev=0,
                 written_at=_ts(2),
                 written_by="Wind",
-                value=_diff_value_empty(),  # type: ignore[arg-type]
+                value=_diff_value_empty(),
                 divergence_marker="NO_NEW_DIVERGENCE",
             )
         )
@@ -1765,7 +1766,7 @@ class TestPathContractsRoundTrip:
                 rev=0,
                 written_at=_ts(),
                 written_by="Wind",
-                value=_frame_value(),  # type: ignore[arg-type]
+                value=_frame_value(),
             )
         )
         room = DebateRoom(
@@ -1821,7 +1822,7 @@ class TestPathContractTypedAppendAPI:
         room.append_frame_revision(
             path_id="new_path",
             written_at=_ts(),
-            value=_frame_value(),  # type: ignore[arg-type]
+            value=_frame_value(),
         )
         assert len(room.path_contracts) == 1
         contract = room.path_contracts[0]
@@ -1839,12 +1840,8 @@ class TestPathContractTypedAppendAPI:
             topic="monotonic",
             mode=DebateMode.FIXED,
         )
-        room.append_frame_revision(
-            path_id="p1", written_at=_ts(0), value=_frame_value("v0")  # type: ignore[arg-type]
-        )
-        room.append_frame_revision(
-            path_id="p1", written_at=_ts(1), value=_frame_value("v1")  # type: ignore[arg-type]
-        )
+        room.append_frame_revision(path_id="p1", written_at=_ts(0), value=_frame_value("v0"))
+        room.append_frame_revision(path_id="p1", written_at=_ts(1), value=_frame_value("v1"))
         contract = room.path_contracts[0]
         assert [r["rev"] for r in contract["frame_history"]] == [0, 1]
         assert contract["frame_history"][1]["value"]["assumed_problem"] == "v1"
@@ -1875,7 +1872,7 @@ class TestPathContractTypedAppendAPI:
         room.append_diff_revision(
             path_id="p1",
             written_at=_ts(),
-            value=_diff_value_empty(),  # type: ignore[arg-type]
+            value=_diff_value_empty(),
         )
         contract = room.path_contracts[0]
         assert contract["diff_history"][0]["written_by"] == "Wind"
@@ -1891,7 +1888,7 @@ class TestPathContractTypedAppendAPI:
         room.append_diff_revision(
             path_id="p1",
             written_at=_ts(),
-            value=_diff_value_empty(),  # type: ignore[arg-type]
+            value=_diff_value_empty(),
             divergence_marker="NO_NEW_DIVERGENCE",
             synthesis_guidance="cross-path insight",
         )
@@ -1908,15 +1905,9 @@ class TestPathContractTypedAppendAPI:
             topic="per-path",
             mode=DebateMode.FIXED,
         )
-        room.append_frame_revision(
-            path_id="p1", written_at=_ts(0), value=_frame_value()  # type: ignore[arg-type]
-        )
-        room.append_frame_revision(
-            path_id="p2", written_at=_ts(1), value=_frame_value()  # type: ignore[arg-type]
-        )
-        room.append_frame_revision(
-            path_id="p1", written_at=_ts(2), value=_frame_value()  # type: ignore[arg-type]
-        )
+        room.append_frame_revision(path_id="p1", written_at=_ts(0), value=_frame_value())
+        room.append_frame_revision(path_id="p2", written_at=_ts(1), value=_frame_value())
+        room.append_frame_revision(path_id="p1", written_at=_ts(2), value=_frame_value())
         assert {c["path_id"] for c in room.path_contracts} == {"p1", "p2"}
         by_id = {c["path_id"]: c for c in room.path_contracts}
         assert [r["rev"] for r in by_id["p1"]["frame_history"]] == [0, 1]
@@ -1934,8 +1925,8 @@ class TestPathContractTypedAppendAPI:
             room.append_diff_revision(
                 path_id="p1",
                 written_at=_ts(),
-                value=_diff_value_empty(),  # type: ignore[arg-type]
-                divergence_marker="BOGUS_MARKER",  # type: ignore[arg-type]
+                value=_diff_value_empty(),
+                divergence_marker="BOGUS_MARKER",
             )
 
 
@@ -1953,12 +1944,8 @@ class TestPathContractLatestRevisionGuard:
             topic="latest",
             mode=DebateMode.FIXED,
         )
-        room.append_frame_revision(
-            path_id="p1", written_at=_ts(0), value=_frame_value("rev0")  # type: ignore[arg-type]
-        )
-        room.append_frame_revision(
-            path_id="p1", written_at=_ts(1), value=_frame_value("rev1")  # type: ignore[arg-type]
-        )
+        room.append_frame_revision(path_id="p1", written_at=_ts(0), value=_frame_value("rev0"))
+        room.append_frame_revision(path_id="p1", written_at=_ts(1), value=_frame_value("rev1"))
         state_dir = tmp_path / "debates"
         save_debate_state(room, state_dir)
         loaded = load_debate_state("2026-05-19-pc-latest", state_dir)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1957,3 +1957,71 @@ class TestPathContractLatestRevisionGuard:
         assert view["latest_frame"]["value"]["assumed_problem"] == "rev1"
         assert view["latest_verdict"] is None
         assert view["latest_diff"] is None
+
+    def test_prompt_context_view_latest_verdict_after_roundtrip(self, tmp_path: Path) -> None:
+        """Persist a contract with 2 verdict revs; latest_verdict is rev 1.
+
+        Symmetric coverage of TMG CONDITIONAL (#219): the renderer's hot-path
+        invariant must hold for verdict history under round-trip, not just frame.
+        """
+        from debate_hall_mcp.path_contract import prompt_context_view
+
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-latest-verdict",
+            topic="latest verdict",
+            mode=DebateMode.FIXED,
+        )
+        room.append_verdict_revision(
+            path_id="p1",
+            written_at=_ts(0),
+            value={"inv_a": {"status": "HARD_pass", "rationale": "rev0"}},
+        )
+        room.append_verdict_revision(
+            path_id="p1",
+            written_at=_ts(1),
+            value={"inv_a": {"status": "HARD_pass", "rationale": "rev1"}},
+        )
+        state_dir = tmp_path / "debates"
+        save_debate_state(room, state_dir)
+        loaded = load_debate_state("2026-05-19-pc-latest-verdict", state_dir)
+
+        view = prompt_context_view(loaded.path_contracts[0])
+        assert view["verdict_count"] == 2
+        assert view["latest_verdict"] is not None
+        assert view["latest_verdict"]["rev"] == 1
+        assert view["latest_verdict"]["value"]["inv_a"]["rationale"] == "rev1"
+
+    def test_prompt_context_view_latest_diff_after_roundtrip(self, tmp_path: Path) -> None:
+        """Persist a contract with 2 diff revs; latest_diff is rev 1.
+
+        Symmetric coverage of TMG CONDITIONAL (#219): the renderer's hot-path
+        invariant must hold for diff history under round-trip, not just frame.
+        """
+        from debate_hall_mcp.path_contract import prompt_context_view
+
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-latest-diff",
+            topic="latest diff",
+            mode=DebateMode.FIXED,
+        )
+        room.append_diff_revision(
+            path_id="p1",
+            written_at=_ts(0),
+            value=_diff_value_empty(),
+            synthesis_guidance="rev0",
+        )
+        room.append_diff_revision(
+            path_id="p1",
+            written_at=_ts(1),
+            value=_diff_value_empty(),
+            synthesis_guidance="rev1",
+        )
+        state_dir = tmp_path / "debates"
+        save_debate_state(room, state_dir)
+        loaded = load_debate_state("2026-05-19-pc-latest-diff", state_dir)
+
+        view = prompt_context_view(loaded.path_contracts[0])
+        assert view["diff_count"] == 2
+        assert view["latest_diff"] is not None
+        assert view["latest_diff"]["rev"] == 1
+        assert view["latest_diff"]["synthesis_guidance"] == "rev1"

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -15,6 +15,13 @@ from pathlib import Path
 
 import pytest
 
+from debate_hall_mcp.path_contract import (
+    DiffRevision,
+    FrameRevision,
+    PathContract,
+    VerdictRevision,
+    new_path_contract,
+)
 from debate_hall_mcp.state import (
     ConsensusMetadata,
     DebateMode,
@@ -1630,3 +1637,336 @@ print(f"{{request_time}},{{acquired_time}}")
             f"Concurrent reads took {elapsed:.3f}s, expected < 0.20s. "
             f"Reads may be blocking each other."
         )
+
+
+# ---------------------------------------------------------------------------
+# RFC-0001 #197 — PathContract persistence on DebateRoom
+#
+# RED tests for:
+#   1. round-trip preserves all PathContract fields including append-only
+#      revision histories (PROD::I4, RFC §3.1)
+#   2. backward compat: state files without `path_contracts` load with
+#      `path_contracts = []` (always-emit-empty design)
+#   3. typed append API: `append_frame_revision` / `append_verdict_revision`
+#      / `append_diff_revision` auto-create the contract for the path_id,
+#      auto-assign monotonic `rev`, enforce ownership at the API boundary,
+#      and reject mutation of already-appended revisions (PROD::I4
+#      append-only invariant)
+#   4. `prompt_context_view` on a persisted contract returns the correct
+#      `latest_*` revisions (regression guard for #199 renderer hot path)
+# ---------------------------------------------------------------------------
+
+
+def _ts(minute: int = 0) -> datetime:
+    """Stable timezone-aware timestamp for deterministic tests."""
+    return datetime(2026, 5, 19, 12, minute, 0, tzinfo=UTC)
+
+
+def _frame_value(problem: str = "x") -> dict[str, object]:
+    return {
+        "assumed_problem": problem,
+        "success_criterion": "criterion",
+        "accepted_failure_mode": "failure_mode",
+        "invariants_touched": ["inv_a"],
+    }
+
+
+def _diff_value_empty() -> dict[str, list[dict[str, str]]]:
+    return {"accepted": [], "disputed": [], "reframed": []}
+
+
+class TestDebateRoomPathContractsField:
+    """The `path_contracts` field exists with a sensible default."""
+
+    def test_path_contracts_defaults_to_empty_list(self) -> None:
+        """Fresh DebateRoom has `path_contracts == []` (always-emit-empty)."""
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-default",
+            topic="contracts field default",
+            mode=DebateMode.FIXED,
+        )
+        assert room.path_contracts == []
+
+    def test_path_contracts_accepts_initial_contracts(self) -> None:
+        """Construction with pre-built contracts list preserves them."""
+        contract = new_path_contract("p1")
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-init",
+            topic="contracts on construction",
+            mode=DebateMode.FIXED,
+            path_contracts=[contract],
+        )
+        assert len(room.path_contracts) == 1
+        assert room.path_contracts[0]["path_id"] == "p1"
+
+
+class TestPathContractsRoundTrip:
+    """Round-trip preserves every PathContract field through JSON."""
+
+    def test_roundtrip_preserves_all_histories(self, tmp_path: Path) -> None:
+        """Save then reload preserves frame/verdict/diff histories and dt fields."""
+        contract = new_path_contract("path_alpha")
+        contract["frame_history"].append(
+            FrameRevision(
+                rev=0,
+                written_at=_ts(0),
+                written_by="Wind",
+                value=_frame_value("alpha problem"),  # type: ignore[arg-type]
+            )
+        )
+        contract["verdict_history"].append(
+            VerdictRevision(
+                rev=0,
+                written_at=_ts(1),
+                written_by="Wall",
+                value={"inv_a": {"status": "HARD_pass", "rationale": "ok"}},
+            )
+        )
+        contract["diff_history"].append(
+            DiffRevision(
+                rev=0,
+                written_at=_ts(2),
+                written_by="Wind",
+                value=_diff_value_empty(),  # type: ignore[arg-type]
+                divergence_marker="NO_NEW_DIVERGENCE",
+            )
+        )
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-rt",
+            topic="round-trip preservation",
+            mode=DebateMode.FIXED,
+            path_contracts=[contract],
+        )
+
+        state_dir = tmp_path / "debates"
+        save_debate_state(room, state_dir)
+        loaded = load_debate_state("2026-05-19-pc-rt", state_dir)
+
+        assert len(loaded.path_contracts) == 1
+        rt = loaded.path_contracts[0]
+        assert rt["path_id"] == "path_alpha"
+        assert len(rt["frame_history"]) == 1
+        assert len(rt["verdict_history"]) == 1
+        assert len(rt["diff_history"]) == 1
+        assert rt["frame_history"][0]["written_by"] == "Wind"
+        assert rt["frame_history"][0]["value"]["assumed_problem"] == "alpha problem"
+        # datetime restored to native type, not str
+        assert isinstance(rt["frame_history"][0]["written_at"], datetime)
+        assert rt["verdict_history"][0]["value"]["inv_a"]["status"] == "HARD_pass"
+        # NotRequired key preserved when present on input
+        assert rt["diff_history"][0].get("divergence_marker") == "NO_NEW_DIVERGENCE"
+
+    def test_roundtrip_multiple_contracts_preserved(self, tmp_path: Path) -> None:
+        """Multiple PathContracts persist independently."""
+        c1 = new_path_contract("p1")
+        c2 = new_path_contract("p2")
+        c2["frame_history"].append(
+            FrameRevision(
+                rev=0,
+                written_at=_ts(),
+                written_by="Wind",
+                value=_frame_value(),  # type: ignore[arg-type]
+            )
+        )
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-multi",
+            topic="multi-path",
+            mode=DebateMode.FIXED,
+            path_contracts=[c1, c2],
+        )
+        state_dir = tmp_path / "debates"
+        save_debate_state(room, state_dir)
+        loaded = load_debate_state("2026-05-19-pc-multi", state_dir)
+        assert [c["path_id"] for c in loaded.path_contracts] == ["p1", "p2"]
+        assert len(loaded.path_contracts[0]["frame_history"]) == 0
+        assert len(loaded.path_contracts[1]["frame_history"]) == 1
+
+
+class TestPathContractsBackwardCompat:
+    """State files written before #197 land with no `path_contracts` key
+    must still load, defaulting to an empty list."""
+
+    def test_legacy_state_without_path_contracts_loads(self, tmp_path: Path) -> None:
+        """Hand-craft a state file lacking `path_contracts`; load yields []."""
+        state_dir = tmp_path / "debates"
+        state_dir.mkdir()
+        legacy_payload = {
+            "thread_id": "2026-05-19-legacy",
+            "topic": "legacy",
+            "mode": "fixed",
+            "status": "active",
+            "max_turns": 12,
+            "max_rounds": 4,
+            "turns": [],
+            "audit_log": [],
+            "injected_context": [],
+        }
+        (state_dir / "2026-05-19-legacy.json").write_text(json.dumps(legacy_payload))
+
+        loaded = load_debate_state("2026-05-19-legacy", state_dir)
+        assert loaded.path_contracts == []
+
+
+class TestPathContractTypedAppendAPI:
+    """`DebateRoom.append_*_revision` methods enforce the PROD::I4
+    append-only invariant at the type/API boundary."""
+
+    def test_append_frame_revision_auto_creates_contract(self) -> None:
+        """First append for a new path_id transparently creates the contract."""
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-auto",
+            topic="auto-create",
+            mode=DebateMode.FIXED,
+        )
+        room.append_frame_revision(
+            path_id="new_path",
+            written_at=_ts(),
+            value=_frame_value(),  # type: ignore[arg-type]
+        )
+        assert len(room.path_contracts) == 1
+        contract = room.path_contracts[0]
+        assert contract["path_id"] == "new_path"
+        assert len(contract["frame_history"]) == 1
+        # rev auto-assigned to 0 for first append
+        assert contract["frame_history"][0]["rev"] == 0
+        # ownership Literal set by API, not caller
+        assert contract["frame_history"][0]["written_by"] == "Wind"
+
+    def test_append_frame_revision_monotonic_rev(self) -> None:
+        """Successive appends assign rev = previous rev + 1."""
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-mono",
+            topic="monotonic",
+            mode=DebateMode.FIXED,
+        )
+        room.append_frame_revision(
+            path_id="p1", written_at=_ts(0), value=_frame_value("v0")  # type: ignore[arg-type]
+        )
+        room.append_frame_revision(
+            path_id="p1", written_at=_ts(1), value=_frame_value("v1")  # type: ignore[arg-type]
+        )
+        contract = room.path_contracts[0]
+        assert [r["rev"] for r in contract["frame_history"]] == [0, 1]
+        assert contract["frame_history"][1]["value"]["assumed_problem"] == "v1"
+
+    def test_append_verdict_revision_sets_wall_owner(self) -> None:
+        """Verdict appends are stamped `written_by='Wall'` by the API."""
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-verdict",
+            topic="verdict owner",
+            mode=DebateMode.FIXED,
+        )
+        room.append_verdict_revision(
+            path_id="p1",
+            written_at=_ts(),
+            value={"inv_a": {"status": "HARD_pass", "rationale": "r"}},
+        )
+        contract = room.path_contracts[0]
+        assert contract["verdict_history"][0]["written_by"] == "Wall"
+        assert contract["verdict_history"][0]["rev"] == 0
+
+    def test_append_diff_revision_sets_wind_owner(self) -> None:
+        """Diff appends are stamped `written_by='Wind'` by the API."""
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-diff",
+            topic="diff owner",
+            mode=DebateMode.FIXED,
+        )
+        room.append_diff_revision(
+            path_id="p1",
+            written_at=_ts(),
+            value=_diff_value_empty(),  # type: ignore[arg-type]
+        )
+        contract = room.path_contracts[0]
+        assert contract["diff_history"][0]["written_by"] == "Wind"
+        assert contract["diff_history"][0]["rev"] == 0
+
+    def test_append_diff_revision_carries_optional_fields(self) -> None:
+        """Optional `divergence_marker` / `synthesis_guidance` flow through."""
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-diff-opt",
+            topic="diff optional",
+            mode=DebateMode.FIXED,
+        )
+        room.append_diff_revision(
+            path_id="p1",
+            written_at=_ts(),
+            value=_diff_value_empty(),  # type: ignore[arg-type]
+            divergence_marker="NO_NEW_DIVERGENCE",
+            synthesis_guidance="cross-path insight",
+        )
+        contract = room.path_contracts[0]
+        diff = contract["diff_history"][0]
+        assert diff.get("divergence_marker") == "NO_NEW_DIVERGENCE"
+        assert diff.get("synthesis_guidance") == "cross-path insight"
+
+    def test_append_methods_are_per_path(self) -> None:
+        """Different path_ids produce distinct contracts; rev counters are
+        independent per (path_id, history-kind)."""
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-perpath",
+            topic="per-path",
+            mode=DebateMode.FIXED,
+        )
+        room.append_frame_revision(
+            path_id="p1", written_at=_ts(0), value=_frame_value()  # type: ignore[arg-type]
+        )
+        room.append_frame_revision(
+            path_id="p2", written_at=_ts(1), value=_frame_value()  # type: ignore[arg-type]
+        )
+        room.append_frame_revision(
+            path_id="p1", written_at=_ts(2), value=_frame_value()  # type: ignore[arg-type]
+        )
+        assert {c["path_id"] for c in room.path_contracts} == {"p1", "p2"}
+        by_id = {c["path_id"]: c for c in room.path_contracts}
+        assert [r["rev"] for r in by_id["p1"]["frame_history"]] == [0, 1]
+        assert [r["rev"] for r in by_id["p2"]["frame_history"]] == [0]
+
+    def test_append_diff_rejects_illegal_divergence_marker(self) -> None:
+        """API guards the `divergence_marker` Literal at the boundary so
+        the persisted form cannot carry an invalid sentinel value."""
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-bad-sentinel",
+            topic="bad sentinel",
+            mode=DebateMode.FIXED,
+        )
+        with pytest.raises(ValueError, match="divergence_marker"):
+            room.append_diff_revision(
+                path_id="p1",
+                written_at=_ts(),
+                value=_diff_value_empty(),  # type: ignore[arg-type]
+                divergence_marker="BOGUS_MARKER",  # type: ignore[arg-type]
+            )
+
+
+class TestPathContractLatestRevisionGuard:
+    """Regression guard for #199: `prompt_context_view` on a persisted
+    contract MUST return the correct latest revision per field — this is
+    the renderer's hot-path invariant."""
+
+    def test_prompt_context_view_after_roundtrip(self, tmp_path: Path) -> None:
+        """Persist a contract with 2 frame revs; latest_frame is rev 1."""
+        from debate_hall_mcp.path_contract import prompt_context_view
+
+        room = DebateRoom(
+            thread_id="2026-05-19-pc-latest",
+            topic="latest",
+            mode=DebateMode.FIXED,
+        )
+        room.append_frame_revision(
+            path_id="p1", written_at=_ts(0), value=_frame_value("rev0")  # type: ignore[arg-type]
+        )
+        room.append_frame_revision(
+            path_id="p1", written_at=_ts(1), value=_frame_value("rev1")  # type: ignore[arg-type]
+        )
+        state_dir = tmp_path / "debates"
+        save_debate_state(room, state_dir)
+        loaded = load_debate_state("2026-05-19-pc-latest", state_dir)
+
+        view = prompt_context_view(loaded.path_contracts[0])
+        assert view["frame_count"] == 2
+        assert view["latest_frame"] is not None
+        assert view["latest_frame"]["rev"] == 1
+        assert view["latest_frame"]["value"]["assumed_problem"] == "rev1"
+        assert view["latest_verdict"] is None
+        assert view["latest_diff"] is None


### PR DESCRIPTION
## Summary

Threads RFC-0001 #196 `PathContract` through state persistence and surfaces it to the orchestrator's #199 `<PATH_CONTRACTS>` renderer (already wired in #218 via `_format_debate_state`). Unblocks the deferred #200 validator wiring, which will land once #198 produces diff content from prompts.

Closes work on issue #197.

## Changes

* `DebateRoom.path_contracts: list[PathContract]` field with `default_factory=list` (PROD::I4 / RFC §3.1).
* Typed append API on `DebateRoom`: `append_frame_revision`, `append_verdict_revision`, `append_diff_revision`. Each auto-creates the contract for `path_id`, assigns monotonic `rev`, stamps the §3.1 ownership Literal, and (for diff) guards the `divergence_marker` Literal at the write boundary.
* `debate_get()` always surfaces `path_contracts` so the orchestrator's `_format_debate_state` (already wired in #218) feeds the renderer with persisted state, not just test fixtures.

## Design decisions

1. **Field placement.** `list[PathContract]` on `DebateRoom`, symmetric with `turns` / `audit_log` / `injected_context`. `PathContract` carries its own `path_id`; no separate keyed map needed.

2. **`latest_*` strategy: computed on the fly** via existing `path_contract.prompt_context_view` (already consumed by the #199 renderer). Zero schema duplication; the renderer's hot-path invariant is already satisfied by the existing helper. Denormalized cache rejected as accumulative complexity (build-philosophy MIP).

3. **Backward compat: always-emit-empty.** Legacy state files written before this PR load with `path_contracts=[]`. Symmetric-omit would produce asymmetric on-disk shapes (new debates carry the key, old debates don't); always-emit matches the established `injected_context` / `audit_log` default-empty pattern, yielding monotonic on-disk shapes.

4. **Typed append API.** Makes the PROD::I4 append-only invariant hard to violate at the type/API level rather than convention-only: `rev` assignment + ownership stamp + sentinel-Literal guard move from caller discipline to API mechanism. Defence-in-depth alongside the #200 validator's runtime ownership / shape checks.

5. **Validator wiring (#200): SPLIT.** The validator's own module docstring (`src/debate_hall_mcp/path_contract_validator.py:65-73`) explicitly defers orchestrator wiring pending #197 AND #198. `_execute_consensus_loop` currently exchanges only Wind/Wall approval booleans + free-text feedback — no `PathContract` diffs are emitted by prompts yet (that's #198's deliverable). State-side threading (this PR) is the load-bearing prerequisite. Validator wiring becomes a small follow-up (~20-line orchestrator touch) once #198 prompts produce diff content.

## Test plan

- [x] RED tests authored and committed first (commit 641f577) — 15 new tests
  - round-trip preserves all `PathContract` fields including frame/verdict/diff histories
  - backward compat (legacy state files load with `path_contracts=[]`)
  - typed append API: auto-create contract, monotonic `rev`, ownership stamp, optional fields, sentinel guard
  - `prompt_context_view` after round-trip — regression guard for #199 renderer hot path
  - `debate_get()` surfaces `path_contracts` — pins the tool↔renderer contract
- [x] GREEN implementation passes all RED tests (commit 699b568)
- [x] `pytest` full suite: **1555 passing**, no regressions
- [x] `ruff check` on touched files: clean
- [x] `black --check` on touched files: clean
- [x] `mypy --strict` on touched files: clean (4 pre-existing baseline errors outside touched ranges remain at lines 483/909/910/1135 of `test_state.py` — predating this PR)
- [x] `mypy src/`: **Success: no issues found in 42 source files**

## Read-only consumed surfaces (NOT modified)

- `src/debate_hall_mcp/path_contract.py` (#196)
- `src/debate_hall_mcp/path_contract_validator.py` (#200)
- `src/debate_hall_mcp/context_compiler.py` (#199 — feed its renderer correctly via state surfacing, don't change it)

## Out of scope

- Validator wiring into `_execute_consensus_loop` (split per decision 5 above; follow-up after #198)
- Prompt templates (#198), feature flags (#201/#205)
- Consensus-loop halting / Wall-reapproval invariants (RFC §3 invariant honoured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist per-path `PathContract` on `DebateRoom`, expose it in `debate_get`, and add a typed append API for frame/verdict/diff revisions. This delivers RFC-0001 state serialization for #197 and feeds the `<PATH_CONTRACTS>` renderer. Added tests to ensure `latest_verdict` and `latest_diff` survive save/load for the renderer’s hot path.

- **New Features**
  - Added `path_contracts: list[PathContract]` to `DebateRoom` (default `[]` for backward compat; legacy files load with an empty list).
  - New append methods: `append_frame_revision`, `append_verdict_revision`, `append_diff_revision` that auto-create the contract, assign monotonic `rev`, stamp `written_by` (Wind/Wall), and validate `divergence_marker` ("NO_NEW_DIVERGENCE" only).
  - `debate_get` now includes `path_contracts` (empty when none) so the orchestrator’s `_format_debate_state` can render `<PATH_CONTRACTS>`.

<sup>Written for commit f0a0392280a62c4a892730f1f0f025ad495b78c9. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/219?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

