### PR TITLE
[RFC-0001] #205 — features.is_enabled wrapper (ADR-0003 migration shim)

### DIFF
--- a/src/debate_hall_mcp/features.py
+++ b/src/debate_hall_mcp/features.py
@@ -1,0 +1,148 @@
+"""Feature-flag wrapper module (RFC-0001 #205, ADR-0003 migration shim).
+
+Single entry point for all flag checks. Today delegates to ``TierSettings``;
+when ADR-0003's Unified SDK lands, only the body of :func:`is_enabled` changes
+— **call sites stay unchanged**. This is the "build aligned with ADR-0003 from
+the outset" intent operationalized without the ~7-week cost of building the
+full Stratified Layer architecture up front.
+
+ADR-0003 migration path
+-----------------------
+
+Today (this module)::
+
+    def is_enabled(flag_name, context):
+        # Delegate to TierSettings.<flag>_enabled
+        ...
+
+Future (after ADR-0003 Phase 1)::
+
+    def is_enabled(flag_name, context):
+        # Route via Unified SDK to the correct Stratified Layer:
+        #   Layer 1 (Entitlements)  -> JWT/session
+        #   Layer 2 (Operational)   -> local cache via pub/sub
+        #   Layer 3 (Experimentation) -> vendor SDK (LaunchDarkly/Unleash)
+        return feature_sdk.is_enabled(flag_name, context)
+
+The signature is forward-compatible: :class:`FeatureContext` already carries
+``tier_config`` and is the natural slot for future ``tenant_id`` / ``user_id``
+/ request-metadata fields the Unified SDK needs for Layer 1/3 resolution.
+
+Refuse-to-degrade contract
+--------------------------
+
+Unknown flags raise :class:`KeyError`. This is deliberate (mirrors PROD::I5
+SOVEREIGN_SAFETY_OVERRIDE and ADR-0003's auditability requirement): a
+mistyped flag name must fail loudly at the call site rather than silently
+return ``False`` and disable the safety check the caller meant to gate on.
+
+Type system note (per #196 lesson)
+----------------------------------
+
+``TypedDict`` and ``Literal`` are imported from ``typing_extensions`` (not
+``typing``). Under Pydantic 2 + Python 3.11, ``pydantic.TypeAdapter(...)``
+requires the ``typing_extensions`` flavour for runtime introspection of
+``TypedDict`` types; this matches the convention established in
+``debate_hall_mcp.path_contract`` (#196).
+"""
+
+from __future__ import annotations
+
+from typing_extensions import Literal, TypedDict  # noqa: UP035
+
+from debate_hall_mcp.config import TierConfig
+
+__all__ = [
+    "FLAG_REGISTRY",
+    "FeatureContext",
+    "FlagSpec",
+    "LifecyclePolicy",
+    "is_enabled",
+]
+
+
+class LifecyclePolicy(TypedDict):
+    """ADR-0003 §1 mandates this metadata on every flag.
+
+    Fields:
+
+    * ``layer``: Stratified Layer per ADR-0003 §1
+      (1=entitlement, 2=operational, 3=experimentation).
+    * ``owner``: Team or individual responsible for the flag's lifecycle.
+    * ``sunset_date``: ISO date string; ``None`` = no planned removal.
+    * ``classification``: ADR-0003 lifecycle classification used by the
+      Auto-Decommissioning subsystem (ADR-0003 "Lifecycle Management").
+    """
+
+    layer: Literal["entitlement", "operational", "experimentation"]
+    owner: str
+    sunset_date: str | None
+    classification: Literal["temporary_experiment", "permanent_toggle", "kill_switch"]
+
+
+class FlagSpec(TypedDict):
+    """Schema for a single registered feature flag.
+
+    ADR-0003's future Policy Engine reads :data:`FLAG_REGISTRY` (a mapping of
+    flag-name to :class:`FlagSpec`) to drive layer routing and lifecycle
+    automation.
+    """
+
+    name: str
+    description: str
+    default: bool
+    lifecycle: LifecyclePolicy
+
+
+class FeatureContext(TypedDict):
+    """Per-call context passed to :func:`is_enabled`.
+
+    Today carries only ``tier_config``. Forward-compatible: future ADR-0003
+    Unified SDK consumers will extend this with ``tenant_id`` / ``user_id``
+    / request metadata for Layer 1 (entitlement) and Layer 3 (experimentation)
+    resolution. Existing call sites need not change when those fields are added.
+    """
+
+    tier_config: TierConfig
+
+
+FLAG_REGISTRY: dict[str, FlagSpec] = {
+    "path_contract": {
+        "name": "path_contract",
+        "description": "Enable RFC-0001 path_contract Wind learning loop",
+        "default": False,
+        "lifecycle": {
+            "layer": "experimentation",  # ADR-0003 Layer 3
+            "owner": "debate-hall-mcp-core",
+            "sunset_date": None,
+            "classification": "temporary_experiment",
+        },
+    },
+}
+
+
+def is_enabled(flag_name: str, context: FeatureContext) -> bool:
+    """Return whether ``flag_name`` is enabled in the given ``context``.
+
+    Resolution (current implementation):
+
+    1. ``flag_name`` MUST be registered in :data:`FLAG_REGISTRY`; unknown
+       flags raise :class:`KeyError` (refuse-to-degrade).
+    2. Look up ``context["tier_config"].settings.<flag_name>_enabled``; if
+       present, return its boolean value.
+    3. Otherwise, return :data:`FLAG_REGISTRY` ``[flag_name]["default"]``.
+
+    Raises:
+        KeyError: If ``flag_name`` is not registered in :data:`FLAG_REGISTRY`.
+            The error message includes the flag name and the string
+            ``FLAG_REGISTRY`` so the call site can locate the registration
+            point quickly.
+    """
+    if flag_name not in FLAG_REGISTRY:
+        raise KeyError(
+            f"Unknown feature flag: {flag_name!r}. "
+            f"Register it in FLAG_REGISTRY (debate_hall_mcp.features)."
+        )
+    settings = context["tier_config"].settings
+    attr = f"{flag_name}_enabled"
+    return bool(getattr(settings, attr, FLAG_REGISTRY[flag_name]["default"]))

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -1,0 +1,122 @@
+"""Unit tests for ``debate_hall_mcp.features`` (RFC-0001 #205).
+
+Covers the ADR-0003 migration-shim wrapper:
+
+* ``is_enabled(flag, ctx)`` returns ``True``/``False`` per
+  ``TierSettings.<flag>_enabled`` when present.
+* ``is_enabled(flag, ctx)`` returns the FLAG_REGISTRY default when the
+  TierSettings attribute is missing (current main, pre-#201 state).
+* ``is_enabled("undefined_flag", ctx)`` raises ``KeyError`` mentioning the
+  flag name and FLAG_REGISTRY (NO silent ``False``; mirrors PROD::I5
+  refuse-to-degrade invariant).
+* ``FLAG_REGISTRY["path_contract"]`` carries ADR-0003 Layer 3 lifecycle
+  metadata: ``layer="experimentation"``, ``classification="temporary_experiment"``,
+  ``default=False``, ``owner="debate-hall-mcp-core"``, ``sunset_date=None``.
+* Pydantic ``TypeAdapter(FlagSpec)`` validates a registry entry — forward-compat
+  smoke test that mirrors the #196 ``typing_extensions.TypedDict`` lesson
+  (Pydantic 2 + Python 3.11 ``TypeAdapter`` requires ``typing_extensions``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import TypeAdapter
+
+from debate_hall_mcp import features
+from debate_hall_mcp.config import (
+    FallbackConfig,
+    RoleConfig,
+    TierConfig,
+    TierSettings,
+)
+
+
+def _make_tier_config(**settings_kwargs: object) -> TierConfig:
+    """Build a minimal TierConfig with overridable TierSettings kwargs.
+
+    Uses ``model_construct`` for settings so we can inject attributes (like
+    ``path_contract_enabled``) that are NOT yet declared on TierSettings —
+    this models the post-#201 world without requiring #201 to land first.
+    """
+    role = RoleConfig(provider="cli", cli="claude")
+    base_settings = TierSettings(fallback=FallbackConfig())
+    if settings_kwargs:
+        # ``model_copy(update=...)`` would reject unknown fields; we use
+        # ``__dict__`` mutation to simulate a future TierSettings carrying
+        # ``<flag>_enabled`` attributes (#201's scope).
+        for key, value in settings_kwargs.items():
+            object.__setattr__(base_settings, key, value)
+    return TierConfig(wind=role, wall=role, door=role, settings=base_settings)
+
+
+# ---------------------------------------------------------------------------
+# is_enabled() behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_returns_true_when_tier_settings_attr_true() -> None:
+    ctx: features.FeatureContext = {
+        "tier_config": _make_tier_config(path_contract_enabled=True),
+    }
+    assert features.is_enabled("path_contract", ctx) is True
+
+
+def test_is_enabled_returns_false_when_tier_settings_attr_false() -> None:
+    ctx: features.FeatureContext = {
+        "tier_config": _make_tier_config(path_contract_enabled=False),
+    }
+    assert features.is_enabled("path_contract", ctx) is False
+
+
+def test_is_enabled_returns_registry_default_when_tier_settings_attr_missing() -> None:
+    # On current main TierSettings has NO path_contract_enabled attribute
+    # (added in #201). Wrapper must fall back to FLAG_REGISTRY default (False).
+    ctx: features.FeatureContext = {"tier_config": _make_tier_config()}
+    assert features.is_enabled("path_contract", ctx) is False
+    assert features.FLAG_REGISTRY["path_contract"]["default"] is False
+
+
+def test_is_enabled_unknown_flag_raises_keyerror_with_clear_message() -> None:
+    ctx: features.FeatureContext = {"tier_config": _make_tier_config()}
+    with pytest.raises(KeyError) as excinfo:
+        features.is_enabled("undefined_flag", ctx)
+    message = str(excinfo.value)
+    assert "undefined_flag" in message
+    assert "FLAG_REGISTRY" in message
+
+
+# ---------------------------------------------------------------------------
+# FLAG_REGISTRY / lifecycle metadata (ADR-0003 Layer 3)
+# ---------------------------------------------------------------------------
+
+
+def test_flag_registry_path_contract_has_adr_0003_layer3_metadata() -> None:
+    spec = features.FLAG_REGISTRY["path_contract"]
+    assert spec["name"] == "path_contract"
+    assert spec["default"] is False
+    lifecycle = spec["lifecycle"]
+    assert lifecycle["layer"] == "experimentation"  # ADR-0003 Layer 3
+    assert lifecycle["classification"] == "temporary_experiment"
+    assert lifecycle["owner"] == "debate-hall-mcp-core"
+    assert lifecycle["sunset_date"] is None
+
+
+# ---------------------------------------------------------------------------
+# Pydantic TypeAdapter smoke test (forward-compat per #196 lesson)
+# ---------------------------------------------------------------------------
+
+
+def test_flag_spec_validates_via_pydantic_typeadapter() -> None:
+    adapter = TypeAdapter(features.FlagSpec)
+    validated = adapter.validate_python(features.FLAG_REGISTRY["path_contract"])
+    assert validated["name"] == "path_contract"
+    assert validated["lifecycle"]["layer"] == "experimentation"
+
+
+def test_lifecycle_policy_validates_via_pydantic_typeadapter() -> None:
+    adapter = TypeAdapter(features.LifecyclePolicy)
+    validated = adapter.validate_python(
+        features.FLAG_REGISTRY["path_contract"]["lifecycle"]
+    )
+    assert validated["layer"] == "experimentation"
+    assert validated["classification"] == "temporary_experiment"

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -115,8 +115,6 @@ def test_flag_spec_validates_via_pydantic_typeadapter() -> None:
 
 def test_lifecycle_policy_validates_via_pydantic_typeadapter() -> None:
     adapter = TypeAdapter(features.LifecyclePolicy)
-    validated = adapter.validate_python(
-        features.FLAG_REGISTRY["path_contract"]["lifecycle"]
-    )
+    validated = adapter.validate_python(features.FLAG_REGISTRY["path_contract"]["lifecycle"])
     assert validated["layer"] == "experimentation"
     assert validated["classification"] == "temporary_experiment"


### PR DESCRIPTION
## Summary

Introduces `src/debate_hall_mcp/features.py` as the single entry point for all feature-flag checks in `debate-hall-mcp`. This is the ADR-0003 migration shim called out in RFC §6 step 4 and RFC §8 decision 5: today the wrapper delegates to `TierSettings` via `getattr`; when ADR-0003's Unified SDK lands, only the body of `is_enabled()` changes — call sites are unchanged.

This PR **gates #201** (the feature flag itself / call-site rewiring). No existing call sites are touched here; #201 will route call sites through this wrapper.

## What lands

`src/debate_hall_mcp/features.py` exports:

- `is_enabled(flag_name, context) -> bool`
- `FLAG_REGISTRY: dict[str, FlagSpec]`
- `FlagSpec`, `LifecyclePolicy`, `FeatureContext` (TypedDicts)

`path_contract` is registered with ADR-0003 Layer 3 metadata (per ADR-0003 §1 "Stratified Layers" / "Experimentation" tier):

- `lifecycle.layer = "experimentation"` (ADR-0003 Layer 3)
- `classification = "temporary_experiment"`
- `default = False`
- `owner = "debate-hall-mcp-core"`
- `sunset_date = None`

### Refuse-to-degrade contract

Unknown flag names raise `KeyError` (no silent `False`), per #205 acceptance and mirroring PROD::I5 SOVEREIGN_SAFETY_OVERRIDE: a mistyped flag must fail loudly at the call site rather than silently disable the safety check the caller meant to gate on.

### Type system note (per #196 / PR #216 lesson)

`TypedDict` and `Literal` are imported from `typing_extensions`, not `typing`. Under Pydantic 2 + Python 3.11, `pydantic.TypeAdapter(...)` requires the `typing_extensions` flavour for runtime introspection of `TypedDict` types. This matches the convention established in `debate_hall_mcp.path_contract` (#196). A smoke test (`test_flag_spec_validates_via_pydantic_typeadapter`) pins the forward-compat guarantee.

## Quality gates (worktree, Python 3.11.15)

- `uv run pytest`: **1564 passed**
- `uv run ruff check .`: All checks passed
- `uv run black --check .`: All done (124 files clean)
- `uv run mypy src/`: Success, no issues found in 43 source files

## Test plan

- [x] RED tests committed before implementation (commit `1a5eeaf`) — `ImportError` on collection proves module absence
- [x] GREEN implementation in separate commit (`51ebb5b`)
- [x] `is_enabled()` returns `TierSettings.<flag>_enabled` when present (True/False cases)
- [x] `is_enabled()` returns `FLAG_REGISTRY[flag]["default"]` when TierSettings attribute is missing (current main, pre-#201 state)
- [x] `is_enabled("undefined_flag", ctx)` raises `KeyError` mentioning the flag name and `FLAG_REGISTRY`
- [x] `FLAG_REGISTRY["path_contract"]` carries the full ADR-0003 Layer 3 lifecycle metadata
- [x] `pydantic.TypeAdapter(FlagSpec)` and `TypeAdapter(LifecyclePolicy)` validate registry entries (forward-compat smoke)
- [x] Full test suite green; no regressions

## Out of scope (deferred)

- **Call-site rewiring** (`path_contract.py`, `state.py`, `context_compiler.py`, `path_contract_validator.py`, prompt templates) — that is **#201**.
- Unified SDK / Policy Engine / Layer 1-3 infrastructure — full ADR-0003 build-out, ~7 weeks, deliberately not in scope.
- Per-tenant / per-user flag resolution (`FeatureContext` is forward-compatible but not exercised in v1).

## References

- Closes #205
- Part of #195
- Gates #201
- RFC-0001 §6 step 4 (`docs/rfc-0001-path-contract-wind-learning-loop.md`)
- RFC-0001 §8 decision 5
- ADR-0003 §1 Stratified Layers + lifecycle_policy mandate (`docs/adr/adr-0003-stratified-feature-flag-architecture.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single feature-flag entrypoint `debate_hall_mcp.features.is_enabled()` and a central `FLAG_REGISTRY`, creating the ADR-0003 migration shim with no call-site changes. Closes #205 and gates #201.

- Introduces `debate_hall_mcp.features` exporting `is_enabled`, `FLAG_REGISTRY`, and `FlagSpec`, `LifecyclePolicy`, `FeatureContext`.
- Resolution: delegates to `TierSettings.<flag>_enabled` when present; otherwise falls back to the registry default.
- Refuse-to-degrade: unknown flags raise `KeyError` (no silent False).
- Registers `path_contract` (default False) with ADR-0003 Layer 3 metadata: `layer="experimentation"`, `classification="temporary_experiment"`, `owner="debate-hall-mcp-core"`, `sunset_date=None`.

<sup>Written for commit 51ebb5b8fde3cd98669d8e71928f2b8a0c007d69. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/220?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

