### PR TITLE
feat(rfc-0001): #198 Wind/Wall/Door path_contract prompt branches

### DIFF
--- a/src/debate_hall_mcp/prompts/__init__.py
+++ b/src/debate_hall_mcp/prompts/__init__.py
@@ -430,7 +430,52 @@ CLOSING_AUTHORITY::[
 """
 
 
-def format_wind_user_prompt(topic: str, thread_id: str) -> str:
+def _wind_initial_path_contract_block() -> str:
+    """RFC-0001 path_contract block for Wind's INITIAL turn (PENDING_INITIAL)."""
+    return """
+[RFC-0001 — path_contract additions]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE> (emitted by the context
+compiler IFF the path_contract feature is on):
+  * SYNTHESIS_STATUS::PENDING_INITIAL  → this is the INITIAL Wind turn; emit one
+    PATH_CONTRACT_FRAME JSON block per path as shown below.
+  * (line absent)                       → path_contract is OFF for this debate;
+    ignore the JSON block instruction and respond with the standard Wind output.
+
+At the end of your response, for EACH path you proposed, append a fenced JSON block
+labeled with a heading. Use this exact shape so Wall and Door can parse it:
+
+### PATH_CONTRACT_FRAME (path_1)
+```json
+{
+  "path_id": "path_1",
+  "path_label": "Obvious | Adjacent | Heretical",
+  "assumed_problem": "the version of the problem this path addresses",
+  "success_criterion": "how we'd know this path worked",
+  "accepted_failure_mode": "what this path explicitly trades away",
+  "invariants_touched": ["topic-specific snake_case names, semantically distinct per orthogonal concern"]
+}
+```
+
+Repeat the heading + JSON block for path_2 and path_3.
+
+`invariants_touched` is a list of topic-specific snake_case identifiers chosen for
+THIS debate's concerns (e.g. `spec_grammar_coherence`, `sync_api_contract`,
+`audit_trail_completeness`). The names are NOT drawn from a fixed enum — Wall holds
+the naming discipline and may add invariants you didn't flag. Use semantically
+distinct names per orthogonal concern; do NOT collapse two unrelated concerns onto
+one name. Empty list is allowed if a path touches no invariant.
+
+Wall will score EACH invariant on this list independently with HARD_pass /
+HARD_fail / SOFT_disputed. In the later consensus turn, every HARD_fail invariant
+will require its OWN qualifying diff entry (a reframe on invariant X cannot
+substitute for a HARD_fail on invariant Y). Surface invariants honestly now —
+naming the same concern twice forces two independent scorings downstream.
+"""
+
+
+def format_wind_user_prompt(
+    topic: str, thread_id: str, *, path_contract_enabled: bool = False
+) -> str:
     """Format user prompt for Wind (PATHOS) agent in auto-orchestration.
 
     Per VTP (Virtual Tool Preload), the orchestrator injects debate state into
@@ -439,10 +484,14 @@ def format_wind_user_prompt(topic: str, thread_id: str) -> str:
     Args:
         topic: The debate topic to explore
         thread_id: Thread ID for reference
+        path_contract_enabled: When True (RFC-0001 feature on), inject the
+            PATH_CONTRACT_FRAME instruction block. When False (default), the
+            prompt is byte-identical to the pre-#218 shape (CRS Finding 3).
 
     Returns:
         Formatted user prompt with thread reference and task instructions
     """
+    path_contract_section = _wind_initial_path_contract_block() if path_contract_enabled else ""
     return f"""You are participating in a Wind/Wall/Door debate.
 
 Topic: {topic}
@@ -461,49 +510,55 @@ As Wind, you bring PATHOS - divergent thinking and creative expansion:
 
 Do NOT provide a single final answer or render judgment on which option is best.
 Your role is to EXPAND possibilities before Wall validates and Door synthesizes.
-
-[RFC-0001 — path_contract additions]
-Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE> (emitted by the context
-compiler IFF the path_contract feature is on):
-  * SYNTHESIS_STATUS::PENDING_INITIAL  → this is the INITIAL Wind turn; emit one
-    PATH_CONTRACT_FRAME JSON block per path as shown below.
-  * (line absent)                       → path_contract is OFF for this debate;
-    ignore the JSON block instruction and respond with the standard Wind output.
-
-At the end of your response, for EACH path you proposed, append a fenced JSON block
-labeled with a heading. Use this exact shape so Wall and Door can parse it:
-
-### PATH_CONTRACT_FRAME (path_1)
-```json
-{{
-  "path_id": "path_1",
-  "path_label": "Obvious | Adjacent | Heretical",
-  "assumed_problem": "the version of the problem this path addresses",
-  "success_criterion": "how we'd know this path worked",
-  "accepted_failure_mode": "what this path explicitly trades away",
-  "invariants_touched": ["topic-specific snake_case names, semantically distinct per orthogonal concern"]
-}}
-```
-
-Repeat the heading + JSON block for path_2 and path_3.
-
-`invariants_touched` is a list of topic-specific snake_case identifiers chosen for
-THIS debate's concerns (e.g. `spec_grammar_coherence`, `sync_api_contract`,
-`audit_trail_completeness`). The names are NOT drawn from a fixed enum — Wall holds
-the naming discipline and may add invariants you didn't flag. Use semantically
-distinct names per orthogonal concern; do NOT collapse two unrelated concerns onto
-one name. Empty list is allowed if a path touches no invariant.
-
-Wall will score EACH invariant on this list independently with HARD_pass /
-HARD_fail / SOFT_disputed. In the later consensus turn, every HARD_fail invariant
-will require its OWN qualifying diff entry (a reframe on invariant X cannot
-substitute for a HARD_fail on invariant Y). Surface invariants honestly now —
-naming the same concern twice forces two independent scorings downstream.
-
+{path_contract_section}
 Respond using the OCTAVE response format defined in your system prompt."""
 
 
-def format_wall_user_prompt(topic: str, thread_id: str) -> str:
+def _wall_initial_path_contract_block() -> str:
+    """RFC-0001 path_contract block for Wall's INITIAL turn (PENDING_INITIAL only).
+
+    The PRESENT branch belongs to ``format_wall_approval_prompt`` (the consensus
+    turn). Including it here would be dead code because the initial Wall turn
+    always sees SYNTHESIS_STATUS::PENDING_INITIAL (Wind has just spoken; no
+    synthesis exists yet). CRS Finding 2 (PR #221 rework).
+    """
+    return """
+[RFC-0001 — path_contract additions]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
+  * SYNTHESIS_STATUS::PENDING_INITIAL  → Wind's PATH_CONTRACT_FRAME blocks are
+    available above; produce your PATH_CONTRACT_VERDICT blocks as instructed below.
+  * (line absent)                       → path_contract is OFF for this debate;
+    ignore the JSON block instruction and respond with the standard Wall output.
+
+Wind's response includes one PATH_CONTRACT_FRAME JSON block per path. For EACH path,
+append a fenced JSON block labeled with a heading, scoring every invariant Wind
+flagged in that path's `invariants_touched` list. You MAY add invariants Wind did
+not flag if your discipline catches an orthogonal concern Wind missed; use the
+same topic-specific snake_case naming convention.
+
+IMPORTANT — heading format: use the LITERAL heading text below exactly. Do not
+substitute the path's label (Obvious / Adjacent / Heretical) for the heading;
+downstream tooling locates these blocks by the literal `PATH_CONTRACT_VERDICT
+(path_N)` heading.
+
+### PATH_CONTRACT_VERDICT (path_1)
+```json
+{
+  "path_id": "path_1",
+  "verdicts": [
+    {"invariant": "halting", "status": "HARD_pass | HARD_fail | SOFT_disputed", "rationale": "one sentence of evidence"}
+  ]
+}
+```
+
+Status values are a closed set: HARD_pass, HARD_fail, SOFT_disputed.
+HARD verdicts are non-negotiable. SOFT_disputed are tradeable — Wind may push back.
+"""
+
+
+def format_wall_user_prompt(
+    topic: str, thread_id: str, *, path_contract_enabled: bool = False
+) -> str:
     """Format user prompt for Wall (ETHOS) agent in auto-orchestration.
 
     Per VTP (Virtual Tool Preload), the orchestrator injects debate state into
@@ -512,10 +567,14 @@ def format_wall_user_prompt(topic: str, thread_id: str) -> str:
     Args:
         topic: The debate topic to validate
         thread_id: Thread ID for reference
+        path_contract_enabled: When True, inject the PATH_CONTRACT_VERDICT
+            instruction block keyed on PENDING_INITIAL. When False (default),
+            the prompt is byte-identical to the pre-#218 shape (CRS Finding 3).
 
     Returns:
         Formatted user prompt with thread reference and task instructions
     """
+    path_contract_section = _wall_initial_path_contract_block() if path_contract_enabled else ""
     return f"""You are participating in a Wind/Wall/Door debate.
 
 Topic: {topic}
@@ -535,47 +594,40 @@ As Wall, you bring ETHOS - rigorous validation and constraint identification:
 
 Do NOT explore new possibilities or synthesize solutions.
 Your role is to VALIDATE before Door synthesizes.
-
-[RFC-0001 — path_contract additions]
-Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
-  * SYNTHESIS_STATUS::PENDING_INITIAL  → Wind's PATH_CONTRACT_FRAME blocks are
-    available above; produce your PATH_CONTRACT_VERDICT blocks as instructed below.
-  * SYNTHESIS_STATUS::PRESENT          → a Door synthesis already exists and is
-    being refined; the latest path_contract verdict revision is visible in the
-    <PATH_CONTRACTS> sub-block. You are appending a NEW verdict revision that
-    re-validates against the refined synthesis (the prior verdict revision stays
-    in storage for provenance).
-  * (line absent)                       → path_contract is OFF for this debate;
-    ignore the JSON block instruction and respond with the standard Wall output.
-
-Wind's response includes one PATH_CONTRACT_FRAME JSON block per path. For EACH path,
-append a fenced JSON block labeled with a heading, scoring every invariant Wind
-flagged in that path's `invariants_touched` list. You MAY add invariants Wind did
-not flag if your discipline catches an orthogonal concern Wind missed; use the
-same topic-specific snake_case naming convention.
-
-IMPORTANT — heading format: use the LITERAL heading text below exactly. Do not
-substitute the path's label (Obvious / Adjacent / Heretical) for the heading;
-downstream tooling locates these blocks by the literal `PATH_CONTRACT_VERDICT
-(path_N)` heading.
-
-### PATH_CONTRACT_VERDICT (path_1)
-```json
-{{
-  "path_id": "path_1",
-  "verdicts": [
-    {{"invariant": "halting", "status": "HARD_pass | HARD_fail | SOFT_disputed", "rationale": "one sentence of evidence"}}
-  ]
-}}
-```
-
-Status values are a closed set: HARD_pass, HARD_fail, SOFT_disputed.
-HARD verdicts are non-negotiable. SOFT_disputed are tradeable — Wind may push back.
-
+{path_contract_section}
 Respond using the OCTAVE response format defined in your system prompt."""
 
 
-def format_door_user_prompt(topic: str, thread_id: str) -> str:
+def _door_initial_path_contract_block() -> str:
+    """RFC-0001 path_contract block for Door's INITIAL synthesis (PENDING_INITIAL).
+
+    CRS Finding 1 (PR #221 rework): the context compiler emits
+    SYNTHESIS_STATUS::PENDING_INITIAL on Door's initial turn (synthesis is
+    unset; turn_count == 2 → still < 3 per ``derive_synthesis_status``). The
+    prior implementation keyed on PRESENT, which never matched — the agent
+    would see PENDING_INITIAL and lack instructions for it.
+    """
+    return """
+[RFC-0001 — path_contract awareness, INITIAL synthesis]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
+  * SYNTHESIS_STATUS::PENDING_INITIAL — this is the INITIAL Door turn. The
+    <PATH_CONTRACTS> sub-block carries FRAME and VERDICT revisions only; you
+    are producing the synthesis that flips SYNTHESIS_STATUS to PRESENT on the
+    next envelope.
+  * (line absent) — path_contract is OFF for this debate; ignore path_contract
+    references and produce a standard Door synthesis.
+
+Wind has emitted PATH_CONTRACT_FRAME blocks; Wall has emitted PATH_CONTRACT_VERDICT blocks.
+At this initial synthesis turn, no PATH_CONTRACT_DIFF exists yet (Wind emits it later in the
+consensus phase). Read FRAME and VERDICT for context, but DO NOT cite or invent
+`accepted`/`disputed`/`reframed` entries — those become available only in the consensus
+refinement turn, where a separate synthesis prompt enforces the citation rule.
+"""
+
+
+def format_door_user_prompt(
+    topic: str, thread_id: str, *, path_contract_enabled: bool = False
+) -> str:
     """Format user prompt for Door (LOGOS) agent in auto-orchestration.
 
     Per VTP (Virtual Tool Preload), the orchestrator injects debate state into
@@ -584,10 +636,14 @@ def format_door_user_prompt(topic: str, thread_id: str) -> str:
     Args:
         topic: The debate topic to synthesize
         thread_id: Thread ID for reference
+        path_contract_enabled: When True, inject the path_contract awareness
+            block keyed on PENDING_INITIAL. When False (default), the prompt
+            is byte-identical to the pre-#218 shape (CRS Finding 3).
 
     Returns:
         Formatted user prompt with thread reference and task instructions
     """
+    path_contract_section = _door_initial_path_contract_block() if path_contract_enabled else ""
     return f"""You are participating in a Wind/Wall/Door debate.
 
 Topic: {topic}
@@ -607,71 +663,17 @@ As Door, you bring LOGOS - convergent integration and structural synthesis:
 
 Do NOT simply average or compromise between positions.
 Your role is to INTEGRATE and create something that honors both while transcending the apparent conflict.
-
-[RFC-0001 — path_contract awareness, INITIAL synthesis]
-Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
-  * SYNTHESIS_STATUS::PRESENT (during initial synthesis is set after this turn
-    completes) — at this initial Door turn, the <PATH_CONTRACTS> sub-block carries
-    FRAME and VERDICT revisions only; you are producing the synthesis that flips
-    SYNTHESIS_STATUS to PRESENT on the next envelope.
-  * (line absent) — path_contract is OFF for this debate; ignore path_contract
-    references and produce a standard Door synthesis.
-
-Wind has emitted PATH_CONTRACT_FRAME blocks; Wall has emitted PATH_CONTRACT_VERDICT blocks.
-At this initial synthesis turn, no PATH_CONTRACT_DIFF exists yet (Wind emits it later in the
-consensus phase). Read FRAME and VERDICT for context, but DO NOT cite or invent
-`accepted`/`disputed`/`reframed` entries — those become available only in the consensus
-refinement turn, where a separate synthesis prompt enforces the citation rule.
-
+{path_contract_section}
 Respond using the OCTAVE response format defined in your system prompt."""
 
 
-def format_door_consensus_prompt(
-    topic: str, thread_id: str, rejector: str, feedback: str | None
-) -> str:
-    """Format user prompt for Door (LOGOS) refinement in the CONSENSUS phase.
+def _door_consensus_path_contract_block() -> str:
+    """RFC-0001 path_contract citation rule for Door's CONSENSUS refinement.
 
-    This is the consensus-phase Door synthesis prompt. Unlike
-    ``format_door_user_prompt`` (which produces the INITIAL synthesis before any
-    PATH_CONTRACT_DIFF exists), this prompt fires after Wind has emitted
-    PATH_CONTRACT_DIFF blocks during consensus review. It carries the full
-    RFC-0001 path_contract citation rule:
-
-    - cite every non-empty category (accepted / disputed / reframed) across paths
-    - when any path has HARD_fail, cite either a `reframed` entry or an
-      `accepted` entry whose `terminal_rationale` explains unreframeability
-    - reference contract entries inline as ``[path_N.accepted: <invariant>]``,
-      ``[path_N.disputed: <invariant>]``, ``[path_N.reframed: <invariant>]``
-
-    Args:
-        topic: The debate topic being synthesized
-        thread_id: Thread ID for state access (VTP)
-        rejector: The role that rejected (Wind or Wall)
-        feedback: Feedback from the rejector (may be None)
-
-    Returns:
-        Formatted user prompt for Door's consensus-phase refinement turn
+    Covers PRESENT (refining the still-on-table synthesis) and
+    PENDING_REFINEMENT (the prior synthesis was withdrawn after rejection).
     """
-    feedback_text = feedback if feedback else "No specific feedback provided."
-    return f"""You are participating in a Wind/Wall/Door debate REFINEMENT PHASE (consensus).
-
-Topic: {topic}
-Thread ID: {thread_id}
-Your Role: Door (LOGOS) - Synthesis Refiner
-
-The current debate state is provided above in <DEBATE_STATE> tags.
-
-{rejector} has REJECTED your synthesis with the following feedback:
-{feedback_text}
-
-Your task: Refine your synthesis to address {rejector}'s concerns.
-
-As Door (LOGOS), create a refined synthesis that:
-- Addresses the specific feedback from {rejector}
-- Maintains integration of Wind's possibilities and Wall's constraints
-- Demonstrates how this refinement improves the emergent solution
-- Preserves concrete, actionable implementation steps
-
+    return """
 [RFC-0001 — path_contract citation rule, CONSENSUS phase]
 Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
   * SYNTHESIS_STATUS::PRESENT  → a prior synthesis exists (visible in the envelope)
@@ -713,32 +715,70 @@ acknowledge it explicitly (e.g. "path_N had no new divergence; original frame st
 rather than fabricating citations for empty categories. NO_NEW_DIVERGENCE may
 coexist with non-empty `disputed` (RFC §3.3 Finding D); cite any disputed entries
 present even when the sentinel is set.
+"""
 
-Respond with your refined synthesis using the OCTAVE response format."""
 
+def format_door_consensus_prompt(
+    topic: str,
+    thread_id: str,
+    rejector: str,
+    feedback: str | None,
+    *,
+    path_contract_enabled: bool = False,
+) -> str:
+    """Format user prompt for Door (LOGOS) refinement in the CONSENSUS phase.
 
-def format_wind_approval_prompt(topic: str, thread_id: str) -> str:
-    """Format user prompt for Wind (PATHOS) consensus approval review.
+    This is the consensus-phase Door synthesis prompt. Unlike
+    ``format_door_user_prompt`` (which produces the INITIAL synthesis before any
+    PATH_CONTRACT_DIFF exists), this prompt fires after Wind has emitted
+    PATH_CONTRACT_DIFF blocks during consensus review. It carries the full
+    RFC-0001 path_contract citation rule:
 
-    Per VTP (Virtual Tool Preload), the orchestrator injects debate state into
-    the prompt via <DEBATE_STATE> tags. Agents receive state passively.
+    - cite every non-empty category (accepted / disputed / reframed) across paths
+    - when any path has HARD_fail, cite either a `reframed` entry or an
+      `accepted` entry whose `terminal_rationale` explains unreframeability
+    - reference contract entries inline as ``[path_N.accepted: <invariant>]``,
+      ``[path_N.disputed: <invariant>]``, ``[path_N.reframed: <invariant>]``
 
     Args:
-        topic: The debate topic
-        thread_id: Thread ID for reference
+        topic: The debate topic being synthesized
+        thread_id: Thread ID for state access (VTP)
+        rejector: The role that rejected (Wind or Wall)
+        feedback: Feedback from the rejector (may be None)
+        path_contract_enabled: When True, inject the path_contract citation
+            rule block. When False (default), the prompt is byte-identical to
+            the pre-#218 shape (CRS Finding 3).
 
     Returns:
-        Formatted user prompt for consensus review
+        Formatted user prompt for Door's consensus-phase refinement turn
     """
-    return f"""You are participating in a Wind/Wall/Door debate CONSENSUS PHASE.
+    feedback_text = feedback if feedback else "No specific feedback provided."
+    path_contract_section = _door_consensus_path_contract_block() if path_contract_enabled else ""
+    return f"""You are participating in a Wind/Wall/Door debate REFINEMENT PHASE (consensus).
 
 Topic: {topic}
 Thread ID: {thread_id}
-Your Role: Wind (PATHOS) - Consensus Reviewer + Path Refiner
+Your Role: Door (LOGOS) - Synthesis Refiner
 
-The current debate state including your prior PATH_CONTRACT_FRAME blocks, Wall's
-PATH_CONTRACT_VERDICT blocks, and Door's synthesis is provided above in <DEBATE_STATE> tags.
+The current debate state is provided above in <DEBATE_STATE> tags.
 
+{rejector} has REJECTED your synthesis with the following feedback:
+{feedback_text}
+
+Your task: Refine your synthesis to address {rejector}'s concerns.
+
+As Door (LOGOS), create a refined synthesis that:
+- Addresses the specific feedback from {rejector}
+- Maintains integration of Wind's possibilities and Wall's constraints
+- Demonstrates how this refinement improves the emergent solution
+- Preserves concrete, actionable implementation steps
+{path_contract_section}
+Respond with your refined synthesis using the OCTAVE response format."""
+
+
+def _wind_consensus_path_contract_block() -> str:
+    """RFC-0001 path_contract block for Wind's consensus approval turn."""
+    return """
 [RFC-0001 — constraint-as-catalyst behaviour]
 Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
   * SYNTHESIS_STATUS::PRESENT             → Door's initial synthesis is on the
@@ -770,18 +810,18 @@ For EACH path, append a fenced JSON block labeled with a heading:
 
 ### PATH_CONTRACT_DIFF (path_1)
 ```json
-{{
+{
   "path_id": "path_1",
   "accepted": [
-    {{"invariant": "halting", "rationale": "...", "terminal_rationale": "<only when accepting a HARD_fail with no creative reframe>"}}
+    {"invariant": "halting", "rationale": "...", "terminal_rationale": "<only when accepting a HARD_fail with no creative reframe>"}
   ],
   "disputed": [
-    {{"invariant": "single_wall_coherence", "rationale": "why this SOFT_disputed verdict opens a richer path if relaxed"}}
+    {"invariant": "single_wall_coherence", "rationale": "why this SOFT_disputed verdict opens a richer path if relaxed"}
   ],
   "reframed": [
-    {{"invariant": "re_approval", "new_possibility": "the NEW possibility this constraint reveals — must be substantively different from the original path"}}
+    {"invariant": "re_approval", "new_possibility": "the NEW possibility this constraint reveals — must be substantively different from the original path"}
   ]
-}}
+}
 ```
 
 If a path has no HARD_fail verdicts and you genuinely have nothing new to add, emit
@@ -792,14 +832,14 @@ SOFT_disputed — never when any verdict is HARD_fail.
 
 ### PATH_CONTRACT_DIFF (path_N)
 ```json
-{{
+{
   "path_id": "path_N",
   "accepted": [],
   "disputed": [],
   "reframed": [],
   "divergence_marker": "NO_NEW_DIVERGENCE",
   "rationale": "<one sentence on why no new possibility opens>"
-}}
+}
 ```
 
 Honesty over performative ideation.
@@ -811,27 +851,123 @@ INVALID for HARD_fail paths — for any path with one or more HARD_fail verdicts
 produce a real diff (an `accepted` entry with `terminal_rationale` explaining why the
 failure is unreframeable, OR a `reframed` entry with `new_possibility` that addresses
 the failure). The sentinel cannot substitute for constraint-as-catalyst proof.
+"""
 
-Then APPROVE / REJECT Door's synthesis as before:
 
+def format_wind_approval_prompt(
+    topic: str, thread_id: str, *, path_contract_enabled: bool = False
+) -> str:
+    """Format user prompt for Wind (PATHOS) consensus approval review.
+
+    Per VTP (Virtual Tool Preload), the orchestrator injects debate state into
+    the prompt via <DEBATE_STATE> tags. Agents receive state passively.
+
+    Args:
+        topic: The debate topic
+        thread_id: Thread ID for reference
+        path_contract_enabled: When True, inject the constraint-as-catalyst
+            PATH_CONTRACT_DIFF instruction block. When False (default), the
+            prompt is byte-identical to the pre-#218 shape (CRS Finding 3).
+
+    Returns:
+        Formatted user prompt for consensus review
+    """
+    if path_contract_enabled:
+        path_contract_section = _wind_consensus_path_contract_block()
+        state_reference = (
+            "The current debate state including your prior PATH_CONTRACT_FRAME blocks, "
+            "Wall's\nPATH_CONTRACT_VERDICT blocks, and Door's synthesis is provided above "
+            "in <DEBATE_STATE> tags."
+        )
+        approve_criterion = (
+            "- APPROVE - if Door's synthesis honors Wind's expansion AND cites your diff entries\n"
+            "- REJECT - if the synthesis fails to capture creative potential or ignores your reframes"
+        )
+        example_block = (
+            "\nExample:\nAPPROVE\n\n[your three PATH_CONTRACT_DIFF blocks here]\n\n"
+            "The synthesis successfully integrates the reframed possibilities while respecting\n"
+            "Wall's HARD constraints."
+        )
+    else:
+        path_contract_section = ""
+        state_reference = (
+            "The current debate state including Door's synthesis is provided above in "
+            "<DEBATE_STATE> tags."
+        )
+        approve_criterion = (
+            "- APPROVE - if Door's synthesis honors Wind's creative expansion\n"
+            "- REJECT - if the synthesis fails to capture creative potential"
+        )
+        example_block = (
+            "\nExample:\nAPPROVE\n\n"
+            "The synthesis successfully integrates the creative possibilities while respecting\n"
+            "the boundaries of the discussion."
+        )
+    return f"""You are participating in a Wind/Wall/Door debate CONSENSUS PHASE.
+
+Topic: {topic}
+Thread ID: {thread_id}
+Your Role: Wind (PATHOS) - Consensus Reviewer + Path Refiner
+
+{state_reference}
+{path_contract_section}
 RESPONSE FORMAT:
 Start your response with exactly one of:
-- APPROVE - if Door's synthesis honors Wind's expansion AND cites your diff entries
-- REJECT - if the synthesis fails to capture creative potential or ignores your reframes
+{approve_criterion}
 
 If you REJECT, provide specific feedback on what is missing or needs refinement.
 Door will use your feedback to create a refined synthesis.
-
-Example:
-APPROVE
-
-[your three PATH_CONTRACT_DIFF blocks here]
-
-The synthesis successfully integrates the reframed possibilities while respecting
-Wall's HARD constraints."""
+{example_block}"""
 
 
-def format_wall_approval_prompt(topic: str, thread_id: str) -> str:
+def _wall_consensus_path_contract_block() -> str:
+    """RFC-0001 path_contract block for Wall's CONSENSUS approval turn.
+
+    CRS Finding 2 (PR #221 rework): Wall's consensus turn was previously
+    overlooked. The path_contract verdict-revision instructions that were
+    misplaced inside ``format_wall_user_prompt`` (initial-only → dead code)
+    belong here, covering both PRESENT (initial review) and PENDING_REFINEMENT
+    (after a prior synthesis was withdrawn).
+    """
+    return """
+[RFC-0001 — path_contract verdict revision, CONSENSUS phase]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
+  * SYNTHESIS_STATUS::PRESENT          → Door's synthesis is on the table and you
+    are appending a NEW PATH_CONTRACT_VERDICT revision re-validating Wind's
+    PATH_CONTRACT_DIFF entries against the synthesis. The prior verdict revision
+    stays in storage for provenance.
+  * SYNTHESIS_STATUS::PENDING_REFINEMENT → a prior synthesis was withdrawn after
+    rejection. The <PATH_CONTRACTS> sub-block carries the latest DIFF revision
+    Wind appended; append a NEW verdict revision keyed to the same path_ids that
+    scores Wind's reframes against your constraint discipline.
+  * (line absent)                       → path_contract is OFF for this debate;
+    cast APPROVE/REJECT on Door's synthesis without emitting PATH_CONTRACT_VERDICT
+    blocks.
+
+For EACH path, append a fenced JSON block labeled with a heading. Score every
+invariant under your discipline — HARD_fail any reframed entry whose
+`new_possibility` does not actually address the original failure; HARD_pass any
+that does; SOFT_disputed where the trade-off is real but tradeable.
+
+### PATH_CONTRACT_VERDICT (path_1)
+```json
+{
+  "path_id": "path_1",
+  "verdicts": [
+    {"invariant": "halting", "status": "HARD_pass | HARD_fail | SOFT_disputed", "rationale": "one sentence of evidence against the refined synthesis"}
+  ]
+}
+```
+
+Use the LITERAL heading text `PATH_CONTRACT_VERDICT (path_N)` so downstream
+tooling can locate the blocks. Status values are the closed set: HARD_pass,
+HARD_fail, SOFT_disputed.
+"""
+
+
+def format_wall_approval_prompt(
+    topic: str, thread_id: str, *, path_contract_enabled: bool = False
+) -> str:
     """Format user prompt for Wall (ETHOS) consensus approval review.
 
     Per VTP (Virtual Tool Preload), the orchestrator injects debate state into
@@ -840,10 +976,16 @@ def format_wall_approval_prompt(topic: str, thread_id: str) -> str:
     Args:
         topic: The debate topic
         thread_id: Thread ID for reference
+        path_contract_enabled: When True, inject the consensus-phase
+            PATH_CONTRACT_VERDICT revision instruction block (CRS Finding 2
+            rework — these instructions were previously absent from Wall's
+            consensus turn). When False (default), the prompt is byte-identical
+            to the pre-#218 shape (CRS Finding 3).
 
     Returns:
         Formatted user prompt for consensus review
     """
+    path_contract_section = _wall_consensus_path_contract_block() if path_contract_enabled else ""
     return f"""You are participating in a Wind/Wall/Door debate CONSENSUS PHASE.
 
 Topic: {topic}
@@ -859,7 +1001,7 @@ As Wall (ETHOS), evaluate whether the synthesis:
 - Addresses the risks with appropriate mitigations
 - Maintains structural integrity and feasibility
 - Does not violate hard constraints
-
+{path_contract_section}
 RESPONSE FORMAT:
 Start your response with exactly one of:
 - APPROVE - if the synthesis properly addresses constraints

--- a/src/debate_hall_mcp/prompts/__init__.py
+++ b/src/debate_hall_mcp/prompts/__init__.py
@@ -463,6 +463,13 @@ Do NOT provide a single final answer or render judgment on which option is best.
 Your role is to EXPAND possibilities before Wall validates and Door synthesizes.
 
 [RFC-0001 — path_contract additions]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE> (emitted by the context
+compiler IFF the path_contract feature is on):
+  * SYNTHESIS_STATUS::PENDING_INITIAL  → this is the INITIAL Wind turn; emit one
+    PATH_CONTRACT_FRAME JSON block per path as shown below.
+  * (line absent)                       → path_contract is OFF for this debate;
+    ignore the JSON block instruction and respond with the standard Wind output.
+
 At the end of your response, for EACH path you proposed, append a fenced JSON block
 labeled with a heading. Use this exact shape so Wall and Door can parse it:
 
@@ -474,13 +481,24 @@ labeled with a heading. Use this exact shape so Wall and Door can parse it:
   "assumed_problem": "the version of the problem this path addresses",
   "success_criterion": "how we'd know this path worked",
   "accepted_failure_mode": "what this path explicitly trades away",
-  "hard_invariants_touched": ["pick from: halting, single_wall_coherence, re_approval, per_turn_role_contract — only those that genuinely apply"]
+  "invariants_touched": ["topic-specific snake_case names, semantically distinct per orthogonal concern"]
 }}
 ```
 
-Repeat the heading + JSON block for path_2 and path_3. Use the closed enum values
-verbatim for hard_invariants_touched. Empty list is allowed if a path touches no
-invariant.
+Repeat the heading + JSON block for path_2 and path_3.
+
+`invariants_touched` is a list of topic-specific snake_case identifiers chosen for
+THIS debate's concerns (e.g. `spec_grammar_coherence`, `sync_api_contract`,
+`audit_trail_completeness`). The names are NOT drawn from a fixed enum — Wall holds
+the naming discipline and may add invariants you didn't flag. Use semantically
+distinct names per orthogonal concern; do NOT collapse two unrelated concerns onto
+one name. Empty list is allowed if a path touches no invariant.
+
+Wall will score EACH invariant on this list independently with HARD_pass /
+HARD_fail / SOFT_disputed. In the later consensus turn, every HARD_fail invariant
+will require its OWN qualifying diff entry (a reframe on invariant X cannot
+substitute for a HARD_fail on invariant Y). Surface invariants honestly now —
+naming the same concern twice forces two independent scorings downstream.
 
 Respond using the OCTAVE response format defined in your system prompt."""
 
@@ -519,9 +537,22 @@ Do NOT explore new possibilities or synthesize solutions.
 Your role is to VALIDATE before Door synthesizes.
 
 [RFC-0001 — path_contract additions]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
+  * SYNTHESIS_STATUS::PENDING_INITIAL  → Wind's PATH_CONTRACT_FRAME blocks are
+    available above; produce your PATH_CONTRACT_VERDICT blocks as instructed below.
+  * SYNTHESIS_STATUS::PRESENT          → a Door synthesis already exists and is
+    being refined; the latest path_contract verdict revision is visible in the
+    <PATH_CONTRACTS> sub-block. You are appending a NEW verdict revision that
+    re-validates against the refined synthesis (the prior verdict revision stays
+    in storage for provenance).
+  * (line absent)                       → path_contract is OFF for this debate;
+    ignore the JSON block instruction and respond with the standard Wall output.
+
 Wind's response includes one PATH_CONTRACT_FRAME JSON block per path. For EACH path,
 append a fenced JSON block labeled with a heading, scoring every invariant Wind
-flagged in that path's `hard_invariants_touched` list.
+flagged in that path's `invariants_touched` list. You MAY add invariants Wind did
+not flag if your discipline catches an orthogonal concern Wind missed; use the
+same topic-specific snake_case naming convention.
 
 IMPORTANT — heading format: use the LITERAL heading text below exactly. Do not
 substitute the path's label (Obvious / Adjacent / Heretical) for the heading;
@@ -578,6 +609,14 @@ Do NOT simply average or compromise between positions.
 Your role is to INTEGRATE and create something that honors both while transcending the apparent conflict.
 
 [RFC-0001 — path_contract awareness, INITIAL synthesis]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
+  * SYNTHESIS_STATUS::PRESENT (during initial synthesis is set after this turn
+    completes) — at this initial Door turn, the <PATH_CONTRACTS> sub-block carries
+    FRAME and VERDICT revisions only; you are producing the synthesis that flips
+    SYNTHESIS_STATUS to PRESENT on the next envelope.
+  * (line absent) — path_contract is OFF for this debate; ignore path_contract
+    references and produce a standard Door synthesis.
+
 Wind has emitted PATH_CONTRACT_FRAME blocks; Wall has emitted PATH_CONTRACT_VERDICT blocks.
 At this initial synthesis turn, no PATH_CONTRACT_DIFF exists yet (Wind emits it later in the
 consensus phase). Read FRAME and VERDICT for context, but DO NOT cite or invent
@@ -634,6 +673,15 @@ As Door (LOGOS), create a refined synthesis that:
 - Preserves concrete, actionable implementation steps
 
 [RFC-0001 — path_contract citation rule, CONSENSUS phase]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
+  * SYNTHESIS_STATUS::PRESENT  → a prior synthesis exists (visible in the envelope)
+    and you are refining it under the citation rule below.
+  * SYNTHESIS_STATUS::PENDING_REFINEMENT → the prior synthesis was withdrawn after
+    rejection; the <PATH_CONTRACTS> sub-block carries the latest DIFF revision
+    Wind appended during consensus — cite from that revision.
+  * (line absent)               → path_contract is OFF for this debate; produce a
+    standard Door refinement without path_contract citations.
+
 Wind has now emitted PATH_CONTRACT_DIFF blocks containing accepted / disputed /
 reframed entries (in addition to the earlier PATH_CONTRACT_FRAME and PATH_CONTRACT_VERDICT
 blocks). Your refined synthesis must cite EVERY non-empty category (accepted /
@@ -641,18 +689,30 @@ disputed / reframed) across the paths' contracts. If a category is empty for all
 paths, do NOT invent entries — instead briefly note its absence (e.g. "no constraints
 disputed; Wind accepted Wall's verdict in full").
 
-Additional rule: when any path has a HARD_fail verdict in Wall's output, your
+Additional rule (per-invariant): for EACH HARD_fail verdict on a path, your
 synthesis must cite, for that path, EITHER a `reframed` entry that addresses the
 failure OR an `accepted` entry whose `terminal_rationale` explains why the failure
-is unreframeable. Silent omission is invalid — this is the constraint-as-catalyst proof.
+is unreframeable. A reframe on invariant X does NOT discharge a HARD_fail on
+invariant Y — each HARD_fail invariant requires its own citation. Silent omission
+is invalid — this is the constraint-as-catalyst proof.
+
+Cross-path synthesis insight: when a DiffRevision carries the optional
+`synthesis_guidance` field (RFC §3.3 Finding E — Wind's record of cross-path or
+emergent insight that doesn't fit any single per-path entry), your synthesis MUST
+cite it explicitly alongside the per-path citations. Treat `synthesis_guidance`
+as a first-class citation target; silently dropping it loses the inter-path
+emergent pattern Wind surfaced.
 
 Reference contract entries explicitly in your synthesis text using the form
 `[path_N.accepted: <invariant>]`, `[path_N.disputed: <invariant>]`, or
-`[path_N.reframed: <invariant>]` so a reader can verify the citation.
+`[path_N.reframed: <invariant>]` so a reader can verify the citation. Cite
+`synthesis_guidance` inline as `[synthesis_guidance: <one-line summary>]`.
 
 If a path's PATH_CONTRACT_DIFF carries `divergence_marker: NO_NEW_DIVERGENCE`,
 acknowledge it explicitly (e.g. "path_N had no new divergence; original frame stands")
-rather than fabricating citations for empty categories.
+rather than fabricating citations for empty categories. NO_NEW_DIVERGENCE may
+coexist with non-empty `disputed` (RFC §3.3 Finding D); cite any disputed entries
+present even when the sentinel is set.
 
 Respond with your refined synthesis using the OCTAVE response format."""
 
@@ -680,6 +740,18 @@ The current debate state including your prior PATH_CONTRACT_FRAME blocks, Wall's
 PATH_CONTRACT_VERDICT blocks, and Door's synthesis is provided above in <DEBATE_STATE> tags.
 
 [RFC-0001 — constraint-as-catalyst behaviour]
+Branch on the SYNTHESIS_STATUS line inside <DEBATE_STATE>:
+  * SYNTHESIS_STATUS::PRESENT             → Door's initial synthesis is on the
+    table; you are reviewing it for the first time and appending your first
+    PATH_CONTRACT_DIFF revision.
+  * SYNTHESIS_STATUS::PENDING_REFINEMENT  → an earlier synthesis was withdrawn
+    after rejection; the <PATH_CONTRACTS> sub-block shows the prior DIFF revision
+    you appended. Append a NEW DIFF revision keyed to the same path_ids; the
+    prior revision stays in storage for provenance.
+  * (line absent)                          → path_contract is OFF for this debate;
+    cast APPROVE/REJECT on Door's synthesis without emitting PATH_CONTRACT_DIFF
+    blocks.
+
 Wall has critiqued each of your paths. Wall has authority over HARD invariants — accept
 these as the new floor of possibility. Wall does NOT have authority over SOFT_disputed
 entries — you may push back on them with rationale.

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -176,7 +176,9 @@ class TestInitialDoorOmitsPathContractCitation:
         yet (educational), but it MUST NOT carry the citation syntax or the
         accepted/disputed/reframed mandate that forces fabrication.
         """
-        prompt = format_door_user_prompt(topic="Test", thread_id="2026-01-30-test")
+        prompt = format_door_user_prompt(
+            topic="Test", thread_id="2026-01-30-test", path_contract_enabled=True
+        )
         # The citation syntax for diff entries belongs only to the consensus prompt.
         assert "[path_N.accepted:" not in prompt
         assert "[path_N.disputed:" not in prompt
@@ -187,7 +189,9 @@ class TestInitialDoorOmitsPathContractCitation:
 
     def test_initial_door_prompt_still_acknowledges_frame_and_verdict(self) -> None:
         """Initial Door prompt should still note that FRAME and VERDICT exist (those are emitted by turn 1 / turn 2)."""
-        prompt = format_door_user_prompt(topic="Test", thread_id="2026-01-30-test")
+        prompt = format_door_user_prompt(
+            topic="Test", thread_id="2026-01-30-test", path_contract_enabled=True
+        )
         assert "PATH_CONTRACT_FRAME" in prompt
         assert "PATH_CONTRACT_VERDICT" in prompt
 
@@ -201,25 +205,63 @@ class TestPathContractPromptsBranchOnSynthesisStatus:
     PENDING_REFINEMENT, PRESENT. The Wind/Wall/Door prompts must instruct
     the agent on how to branch deterministically on each value rather than
     inferring intent from heuristics (Finding F prompt-portion).
+
+    CRS rework (PR #221 follow-up): correct the branching against the
+    actual values emitted by ``derive_synthesis_status``:
+      * Wind initial turn  → PENDING_INITIAL  (no synthesis, turn_count < 3)
+      * Wall initial turn  → PENDING_INITIAL  (Wind has just spoken)
+      * Door initial turn  → PENDING_INITIAL  (Wind+Wall spoken; turn_count == 2)
+      * Wind consensus     → PRESENT or PENDING_REFINEMENT
+      * Wall consensus     → PRESENT or PENDING_REFINEMENT
+      * Door consensus     → PRESENT or PENDING_REFINEMENT
     """
 
     def test_wind_initial_prompt_references_synthesis_status_pending_initial(self) -> None:
         """Wind initial prompt must direct the agent on PENDING_INITIAL handling."""
-        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        prompt = format_wind_user_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
         assert "SYNTHESIS_STATUS" in prompt
         assert "PENDING_INITIAL" in prompt
 
-    def test_wall_prompt_references_synthesis_status_present(self) -> None:
-        """Wall reads existing contract under PRESENT (refinement phase)."""
-        prompt = format_wall_user_prompt(topic="T", thread_id="2026-05-21-t")
-        assert "SYNTHESIS_STATUS" in prompt
-        assert "PRESENT" in prompt
+    def test_wall_initial_prompt_references_synthesis_status_pending_initial(self) -> None:
+        """Wall initial prompt keys on PENDING_INITIAL (Wind has proposed, Wall validates).
 
-    def test_door_initial_prompt_references_synthesis_status_present(self) -> None:
-        """Door initial prompt branches on PRESENT (consumes existing contract)."""
-        prompt = format_door_user_prompt(topic="T", thread_id="2026-05-21-t")
+        CRS Finding 2 (rework): the prior PRESENT branch in ``format_wall_user_prompt``
+        was dead code because the initial Wall turn always sees PENDING_INITIAL. The
+        consensus turn (``format_wall_approval_prompt``) carries the PRESENT branch.
+        """
+        prompt = format_wall_user_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
         assert "SYNTHESIS_STATUS" in prompt
-        assert "PRESENT" in prompt
+        assert "PENDING_INITIAL" in prompt
+
+    def test_wall_initial_prompt_does_not_carry_present_consensus_branch(self) -> None:
+        """The initial-only Wall prompt MUST NOT instruct the agent to emit a
+        NEW verdict revision under PRESENT — that path is unreachable at the
+        initial turn. Consensus PRESENT lives in ``format_wall_approval_prompt``.
+        """
+        prompt = format_wall_user_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
+        # The "NEW verdict revision" instruction language belongs only to the
+        # consensus prompt (Wall approval).
+        assert "NEW verdict revision" not in prompt
+        assert "appending a NEW verdict" not in prompt
+
+    def test_door_initial_prompt_references_synthesis_status_pending_initial(self) -> None:
+        """Door initial prompt branches on PENDING_INITIAL.
+
+        CRS Finding 1 (rework): the context compiler emits PENDING_INITIAL on
+        Door's initial turn (synthesis is unset; turn_count == 2 → still < 3).
+        Keying on PRESENT was the bug that prompted CRS BLOCKED.
+        """
+        prompt = format_door_user_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
+        assert "SYNTHESIS_STATUS" in prompt
+        assert "PENDING_INITIAL" in prompt
 
 
 class TestWindInitialPromptInvariantNamingFindingA:
@@ -233,14 +275,18 @@ class TestWindInitialPromptInvariantNamingFindingA:
 
     def test_wind_initial_prompt_does_not_advertise_closed_enum(self) -> None:
         """Wind prompt must not instruct the agent to pick from the superseded enum."""
-        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        prompt = format_wind_user_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
         assert "halting, single_wall_coherence, re_approval, per_turn_role_contract" not in prompt
         assert "closed enum" not in prompt
         assert "pick from: halting" not in prompt
 
     def test_wind_initial_prompt_advertises_topic_specific_snake_case(self) -> None:
         """Wind prompt must teach the agent Wall-discipline naming convention."""
-        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        prompt = format_wind_user_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
         assert "snake_case" in prompt
         assert "invariants_touched" in prompt
         assert "topic-specific" in prompt or "topic specific" in prompt
@@ -258,10 +304,53 @@ class TestPerInvariantContentRuleSurfacedToAgents:
 
     def test_wind_initial_prompt_warns_about_per_invariant_obligation(self) -> None:
         """Wind initial prompt must surface that invariants are independently scored."""
-        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        prompt = format_wind_user_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
         # The path may touch multiple invariants; Wall scores each independently.
         text = prompt.lower()
         assert "each" in text and "invariant" in text
+
+
+class TestOffModeByteIdentity:
+    """RFC-0001 #221 CRS Finding 3 — off-mode prompt byte-identity.
+
+    When ``path_contract_enabled`` is ``False`` (the default), Wind/Wall/Door
+    prompts MUST NOT carry any path_contract instruction block. This preserves
+    byte-identity for callers that have the feature disabled (pre-#218 prompt
+    shape) and avoids wasting tokens / confusing the LLM in standard debates.
+
+    Signal: presence of the ``[RFC-0001 — path_contract`` header marks the
+    injected block. Its absence in off-mode is the byte-identity guarantee.
+    """
+
+    def test_wind_off_mode_has_no_path_contract_block(self) -> None:
+        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "[RFC-0001 — path_contract" not in prompt
+        assert "PATH_CONTRACT_FRAME" not in prompt
+        assert "invariants_touched" not in prompt
+        assert "SYNTHESIS_STATUS" not in prompt
+
+    def test_wall_off_mode_has_no_path_contract_block(self) -> None:
+        prompt = format_wall_user_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "[RFC-0001 — path_contract" not in prompt
+        assert "PATH_CONTRACT_VERDICT" not in prompt
+        assert "HARD_pass" not in prompt
+        assert "SYNTHESIS_STATUS" not in prompt
+
+    def test_door_off_mode_has_no_path_contract_block(self) -> None:
+        prompt = format_door_user_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "[RFC-0001 — path_contract" not in prompt
+        assert "PATH_CONTRACT_FRAME" not in prompt
+        assert "PATH_CONTRACT_VERDICT" not in prompt
+        assert "SYNTHESIS_STATUS" not in prompt
+
+    def test_wind_off_mode_still_includes_topic_and_thread(self) -> None:
+        """Byte-identity for off-mode does not strip topic/thread injection."""
+        prompt = format_wind_user_prompt(topic="UNIQUE_TOPIC_42", thread_id="2026-05-21-unique")
+        assert "UNIQUE_TOPIC_42" in prompt
+        assert "2026-05-21-unique" in prompt
+        assert "DEBATE_STATE" in prompt
 
 
 class TestPromptConsistency:

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -192,6 +192,81 @@ class TestInitialDoorOmitsPathContractCitation:
         assert "PATH_CONTRACT_VERDICT" in prompt
 
 
+class TestPathContractPromptsBranchOnSynthesisStatus:
+    """RFC-0001 #198 — prompt branches keyed off the SYNTHESIS_STATUS line.
+
+    Per the #218 joint-emission contract, the context compiler emits
+    ``SYNTHESIS_STATUS::<value>`` inside ``<DEBATE_STATE>`` IFF
+    ``<PATH_CONTRACTS>`` is also emitted. Values: PENDING_INITIAL,
+    PENDING_REFINEMENT, PRESENT. The Wind/Wall/Door prompts must instruct
+    the agent on how to branch deterministically on each value rather than
+    inferring intent from heuristics (Finding F prompt-portion).
+    """
+
+    def test_wind_initial_prompt_references_synthesis_status_pending_initial(self) -> None:
+        """Wind initial prompt must direct the agent on PENDING_INITIAL handling."""
+        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "SYNTHESIS_STATUS" in prompt
+        assert "PENDING_INITIAL" in prompt
+
+    def test_wall_prompt_references_synthesis_status_present(self) -> None:
+        """Wall reads existing contract under PRESENT (refinement phase)."""
+        prompt = format_wall_user_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "SYNTHESIS_STATUS" in prompt
+        assert "PRESENT" in prompt
+
+    def test_door_initial_prompt_references_synthesis_status_present(self) -> None:
+        """Door initial prompt branches on PRESENT (consumes existing contract)."""
+        prompt = format_door_user_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "SYNTHESIS_STATUS" in prompt
+        assert "PRESENT" in prompt
+
+
+class TestWindInitialPromptInvariantNamingFindingA:
+    """RFC-0001 §3.3 Finding A — ``Invariant = str`` with Wall-discipline naming.
+
+    The pre-amendment closed enum ``[halting, single_wall_coherence, re_approval,
+    per_turn_role_contract]`` is SUPERSEDED. Wind's initial prompt must instruct
+    Wall-discipline snake_case naming, semantically distinct per orthogonal
+    concern; it MUST NOT bind invariants to that flow-shaped closed enum.
+    """
+
+    def test_wind_initial_prompt_does_not_advertise_closed_enum(self) -> None:
+        """Wind prompt must not instruct the agent to pick from the superseded enum."""
+        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        assert (
+            "halting, single_wall_coherence, re_approval, per_turn_role_contract"
+            not in prompt
+        )
+        assert "closed enum" not in prompt
+        assert "pick from: halting" not in prompt
+
+    def test_wind_initial_prompt_advertises_topic_specific_snake_case(self) -> None:
+        """Wind prompt must teach the agent Wall-discipline naming convention."""
+        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "snake_case" in prompt
+        assert "invariants_touched" in prompt
+        assert "topic-specific" in prompt or "topic specific" in prompt
+
+
+class TestPerInvariantContentRuleSurfacedToAgents:
+    """RFC-0001 §3.2 (Finding C) — REQUIRED CONTENT RULE is per-invariant.
+
+    Each HARD_fail invariant under ``accepted`` or ``reframed`` requires its
+    OWN rationale entry (a `reframed` entry on invariant X does NOT satisfy
+    HARD_fail on invariant Y). The Wind initial prompt must surface that
+    invariants are independently scored so downstream consensus turns can
+    honour the per-entry obligation.
+    """
+
+    def test_wind_initial_prompt_warns_about_per_invariant_obligation(self) -> None:
+        """Wind initial prompt must surface that invariants are independently scored."""
+        prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
+        # The path may touch multiple invariants; Wall scores each independently.
+        text = prompt.lower()
+        assert "each" in text and "invariant" in text
+
+
 class TestPromptConsistency:
     """Tests for consistency across all prompt functions."""
 

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -234,10 +234,7 @@ class TestWindInitialPromptInvariantNamingFindingA:
     def test_wind_initial_prompt_does_not_advertise_closed_enum(self) -> None:
         """Wind prompt must not instruct the agent to pick from the superseded enum."""
         prompt = format_wind_user_prompt(topic="T", thread_id="2026-05-21-t")
-        assert (
-            "halting, single_wall_coherence, re_approval, per_turn_role_contract"
-            not in prompt
-        )
+        assert "halting, single_wall_coherence, re_approval, per_turn_role_contract" not in prompt
         assert "closed enum" not in prompt
         assert "pick from: halting" not in prompt
 

--- a/tests/unit/test_prompts_consensus.py
+++ b/tests/unit/test_prompts_consensus.py
@@ -128,7 +128,11 @@ class TestConsensusDoorCarriesPathContractCitation:
 
     def test_consensus_door_prompt_demands_path_contract_diff_citation(self) -> None:
         prompt = format_door_consensus_prompt(
-            topic="Test", thread_id="2026-01-30-test", rejector="Wind", feedback="needs more rigor"
+            topic="Test",
+            thread_id="2026-01-30-test",
+            rejector="Wind",
+            feedback="needs more rigor",
+            path_contract_enabled=True,
         )
         assert "PATH_CONTRACT_DIFF" in prompt
         assert "accepted" in prompt
@@ -137,7 +141,11 @@ class TestConsensusDoorCarriesPathContractCitation:
 
     def test_consensus_door_prompt_includes_citation_syntax_example(self) -> None:
         prompt = format_door_consensus_prompt(
-            topic="Test", thread_id="2026-01-30-test", rejector="Wall", feedback=None
+            topic="Test",
+            thread_id="2026-01-30-test",
+            rejector="Wall",
+            feedback=None,
+            path_contract_enabled=True,
         )
         # The bracketed citation syntax that lets a reader verify each claim.
         assert "[path_N.accepted:" in prompt
@@ -146,7 +154,11 @@ class TestConsensusDoorCarriesPathContractCitation:
 
     def test_consensus_door_prompt_enforces_hard_fail_rule(self) -> None:
         prompt = format_door_consensus_prompt(
-            topic="Test", thread_id="2026-01-30-test", rejector="Wind", feedback="x"
+            topic="Test",
+            thread_id="2026-01-30-test",
+            rejector="Wind",
+            feedback="x",
+            path_contract_enabled=True,
         )
         # The constraint-as-catalyst proof obligation.
         assert "HARD_fail" in prompt
@@ -172,7 +184,11 @@ class TestConsensusDoorCarriesPathContractCitation:
 
     def test_consensus_door_prompt_acknowledges_divergence_marker(self) -> None:
         prompt = format_door_consensus_prompt(
-            topic="Test", thread_id="2026-01-30-test", rejector="Wind", feedback=None
+            topic="Test",
+            thread_id="2026-01-30-test",
+            rejector="Wind",
+            feedback=None,
+            path_contract_enabled=True,
         )
         # Door must know how to react to NO_NEW_DIVERGENCE rather than fabricating citations.
         assert "NO_NEW_DIVERGENCE" in prompt
@@ -187,7 +203,9 @@ class TestWindConsensusSentinelIsJsonCompatible:
     """
 
     def test_wind_consensus_prompt_emits_sentinel_inside_json(self) -> None:
-        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        prompt = format_wind_approval_prompt(
+            topic="Test", thread_id="2026-01-30-test", path_contract_enabled=True
+        )
         # The schema field carries the sentinel; raw NO_NEW_DIVERGENCE without JSON
         # framing is the bug being fixed.
         assert "divergence_marker" in prompt
@@ -196,7 +214,9 @@ class TestWindConsensusSentinelIsJsonCompatible:
     def test_wind_consensus_prompt_sentinel_block_parses_as_json(self) -> None:
         """The example sentinel block in the prompt must be valid JSON when
         extracted (after str.format brace-escaping is applied)."""
-        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        prompt = format_wind_approval_prompt(
+            topic="Test", thread_id="2026-01-30-test", path_contract_enabled=True
+        )
         # Locate a JSON object containing divergence_marker and ensure it parses.
         # The prompt embeds the example with literal braces (already unescaped by f-string).
         marker_idx = prompt.find('"divergence_marker"')
@@ -235,13 +255,21 @@ class TestDoorConsensusCitesSynthesisGuidanceFindingE:
 
     def test_consensus_door_prompt_mentions_synthesis_guidance(self) -> None:
         prompt = format_door_consensus_prompt(
-            topic="T", thread_id="2026-05-21-t", rejector="Wind", feedback=None
+            topic="T",
+            thread_id="2026-05-21-t",
+            rejector="Wind",
+            feedback=None,
+            path_contract_enabled=True,
         )
         assert "synthesis_guidance" in prompt
 
     def test_consensus_door_prompt_demands_citation_when_present(self) -> None:
         prompt = format_door_consensus_prompt(
-            topic="T", thread_id="2026-05-21-t", rejector="Wind", feedback=None
+            topic="T",
+            thread_id="2026-05-21-t",
+            rejector="Wind",
+            feedback=None,
+            path_contract_enabled=True,
         )
         idx = prompt.find("synthesis_guidance")
         assert idx != -1
@@ -254,23 +282,169 @@ class TestDoorConsensusCitesSynthesisGuidanceFindingE:
 class TestConsensusPromptsBranchOnSynthesisStatus:
     """RFC-0001 #198 — consensus prompts branch on SYNTHESIS_STATUS.
 
-    * Wind consensus turn fires under PENDING_REFINEMENT (a prior synthesis
-      was withdrawn) — the prompt must reference this value.
-    * Door consensus turn fires under PRESENT during refinement; the prompt
-      must reference SYNTHESIS_STATUS so the agent reads the envelope.
+    * Wind consensus turn fires under PRESENT (initial review) or PENDING_REFINEMENT
+      (after a prior synthesis was withdrawn).
+    * Wall consensus turn (CRS Finding 2 rework) fires under PRESENT (initial review)
+      or PENDING_REFINEMENT and MUST carry the path_contract verdict-revision
+      instructions that were previously misplaced in ``format_wall_user_prompt``.
+    * Door consensus turn fires under PRESENT during refinement, or
+      PENDING_REFINEMENT after rejection. TMG Finding 5 requires explicit
+      assertion of the PENDING_REFINEMENT branch.
     """
 
     def test_wind_approval_prompt_references_pending_refinement(self) -> None:
-        prompt = format_wind_approval_prompt(topic="T", thread_id="2026-05-21-t")
+        prompt = format_wind_approval_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
         assert "SYNTHESIS_STATUS" in prompt
         assert "PENDING_REFINEMENT" in prompt
 
-    def test_door_consensus_prompt_references_synthesis_status(self) -> None:
+    def test_door_consensus_prompt_references_synthesis_status_present(self) -> None:
         prompt = format_door_consensus_prompt(
-            topic="T", thread_id="2026-05-21-t", rejector="Wind", feedback=None
+            topic="T",
+            thread_id="2026-05-21-t",
+            rejector="Wind",
+            feedback=None,
+            path_contract_enabled=True,
         )
         assert "SYNTHESIS_STATUS" in prompt
         assert "PRESENT" in prompt
+
+    def test_door_consensus_prompt_references_pending_refinement(self) -> None:
+        """TMG Finding 5: Door consensus must explicitly cover PENDING_REFINEMENT.
+
+        Code already handles this branch but the prior test suite only asserted
+        the PRESENT branch; this asserts the PENDING_REFINEMENT branch too so
+        regressions are caught.
+        """
+        prompt = format_door_consensus_prompt(
+            topic="T",
+            thread_id="2026-05-21-t",
+            rejector="Wall",
+            feedback="x",
+            path_contract_enabled=True,
+        )
+        assert "PENDING_REFINEMENT" in prompt
+
+
+class TestWallApprovalPromptCarriesPathContractConsensus:
+    """RFC-0001 #221 CRS Finding 2 — Wall consensus prompt must carry the
+    path_contract verdict-revision instructions.
+
+    The previous implementation placed the PRESENT branch (instructing Wall to
+    emit a NEW verdict revision against the refined synthesis) inside
+    ``format_wall_user_prompt`` — but that function is only called for Wall's
+    INITIAL turn (when SYNTHESIS_STATUS is always PENDING_INITIAL). The PRESENT
+    branch was therefore dead code. The instructions belong in the consensus-
+    phase prompt: ``format_wall_approval_prompt``.
+    """
+
+    def test_wall_approval_prompt_references_synthesis_status(self) -> None:
+        prompt = format_wall_approval_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
+        assert "SYNTHESIS_STATUS" in prompt
+
+    def test_wall_approval_prompt_references_present(self) -> None:
+        prompt = format_wall_approval_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
+        assert "PRESENT" in prompt
+
+    def test_wall_approval_prompt_references_pending_refinement(self) -> None:
+        prompt = format_wall_approval_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
+        assert "PENDING_REFINEMENT" in prompt
+
+    def test_wall_approval_prompt_mentions_verdict_revision(self) -> None:
+        """Wall's consensus turn appends a NEW PATH_CONTRACT_VERDICT revision
+        re-validating against the refined synthesis. The prompt must surface
+        this obligation so the agent does not silently skip it.
+        """
+        prompt = format_wall_approval_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
+        assert "PATH_CONTRACT_VERDICT" in prompt
+        # The "new verdict revision" language is the load-bearing instruction.
+        assert "verdict revision" in prompt.lower() or "new verdict" in prompt.lower()
+
+
+class TestDoorConsensusCoexistenceRuleFindingD:
+    """TMG Finding 6 — RFC-0001 §3.3 Finding D coexistence rule.
+
+    ``divergence_marker: NO_NEW_DIVERGENCE`` MAY coexist with non-empty
+    ``disputed`` entries (the sentinel only requires zero HARD_fail verdicts,
+    not zero disputed entries). The Door consensus prompt must instruct the
+    agent to cite the disputed entries even when the sentinel is present —
+    otherwise the cross-path emergent insight is silently dropped.
+
+    The implementation already covers this; the test asserts the instruction
+    appears within a tight semantic window so a future regression that drops
+    the coexistence clause is caught immediately.
+    """
+
+    def test_door_consensus_prompt_covers_no_new_divergence_with_disputed(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="T",
+            thread_id="2026-05-21-t",
+            rejector="Wind",
+            feedback=None,
+            path_contract_enabled=True,
+        )
+        # The coexistence clause must appear: NO_NEW_DIVERGENCE may coexist with
+        # non-empty `disputed`; cite any disputed entries present even when the
+        # sentinel is set.
+        assert "NO_NEW_DIVERGENCE" in prompt
+        idx = prompt.find("NO_NEW_DIVERGENCE")
+        # The "coexist" language and the "disputed" mention must appear in the
+        # same instruction window.
+        window = prompt[idx : idx + 600]
+        assert (
+            "coexist" in window.lower()
+        ), "Finding D coexistence rule must use the word 'coexist' near NO_NEW_DIVERGENCE"
+        assert (
+            "disputed" in window.lower()
+        ), "Finding D coexistence rule must reference 'disputed' near NO_NEW_DIVERGENCE"
+
+
+class TestConsensusOffModeByteIdentity:
+    """RFC-0001 #221 CRS Finding 3 — off-mode prompt byte-identity for consensus prompts.
+
+    When ``path_contract_enabled`` is ``False`` (the default), the
+    Wind/Wall consensus and Door refinement prompts MUST NOT carry any
+    path_contract instruction block.
+    """
+
+    def test_wind_approval_off_mode_has_no_path_contract_block(self) -> None:
+        prompt = format_wind_approval_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "[RFC-0001 — path_contract" not in prompt
+        assert "PATH_CONTRACT_DIFF" not in prompt
+        assert "SYNTHESIS_STATUS" not in prompt
+        assert "NO_NEW_DIVERGENCE" not in prompt
+        # The basic APPROVE/REJECT machinery must still be present.
+        assert "APPROVE" in prompt
+        assert "REJECT" in prompt
+
+    def test_wall_approval_off_mode_has_no_path_contract_block(self) -> None:
+        prompt = format_wall_approval_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "[RFC-0001 — path_contract" not in prompt
+        assert "PATH_CONTRACT_VERDICT" not in prompt
+        assert "SYNTHESIS_STATUS" not in prompt
+        assert "APPROVE" in prompt
+        assert "REJECT" in prompt
+
+    def test_door_consensus_off_mode_has_no_path_contract_block(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="T", thread_id="2026-05-21-t", rejector="Wind", feedback="x"
+        )
+        assert "[RFC-0001 — path_contract" not in prompt
+        assert "PATH_CONTRACT_DIFF" not in prompt
+        assert "SYNTHESIS_STATUS" not in prompt
+        assert "synthesis_guidance" not in prompt
+        # Standard refinement language must remain.
+        assert "REJECTED" in prompt
+        assert "refine" in prompt.lower()
 
 
 class TestWindConsensusPerInvariantContentRule:
@@ -282,7 +456,9 @@ class TestWindConsensusPerInvariantContentRule:
     """
 
     def test_wind_consensus_prompt_mentions_each_invariant_obligation(self) -> None:
-        prompt = format_wind_approval_prompt(topic="T", thread_id="2026-05-21-t")
+        prompt = format_wind_approval_prompt(
+            topic="T", thread_id="2026-05-21-t", path_contract_enabled=True
+        )
         assert "HARD_fail" in prompt
         # The per-invariant phrasing must be explicit (substitution disallowed).
         assert "each HARD_fail invariant" in prompt or "every HARD_fail invariant" in prompt
@@ -297,7 +473,9 @@ class TestWindConsensusSentinelGatedOnHardFail:
 
     def test_wind_consensus_prompt_gates_sentinel_on_no_hard_fail(self) -> None:
         """Sentinel instruction must explicitly require zero HARD_fail verdicts."""
-        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        prompt = format_wind_approval_prompt(
+            topic="Test", thread_id="2026-01-30-test", path_contract_enabled=True
+        )
         # The precondition language must be present in some form.
         assert (
             "no HARD_fail" in prompt
@@ -306,7 +484,9 @@ class TestWindConsensusSentinelGatedOnHardFail:
     def test_wind_consensus_prompt_forbids_sentinel_on_hard_fail_paths(self) -> None:
         """Prompt must explicitly state that NO_NEW_DIVERGENCE is invalid for
         any path with one or more HARD_fail verdicts."""
-        prompt = format_wind_approval_prompt(topic="Test", thread_id="2026-01-30-test")
+        prompt = format_wind_approval_prompt(
+            topic="Test", thread_id="2026-01-30-test", path_contract_enabled=True
+        )
         # The counterpart prohibition must be present.
         assert (
             "INVALID for HARD_fail paths" in prompt

--- a/tests/unit/test_prompts_consensus.py
+++ b/tests/unit/test_prompts_consensus.py
@@ -223,6 +223,74 @@ class TestWindConsensusSentinelIsJsonCompatible:
         assert parsed["reframed"] == []
 
 
+class TestDoorConsensusCitesSynthesisGuidanceFindingE:
+    """RFC-0001 §3.3 Finding E — ``synthesis_guidance`` on DiffRevision.
+
+    Wind may record cross-path / synthesis-level insight in
+    ``DiffRevision.synthesis_guidance`` (NotRequired). When present, Door's
+    consensus citation rule (§5.4) is EXTENDED to require explicit citation
+    alongside per-path citations. The prompt must surface this obligation so
+    the agent does not silently drop the cross-path insight.
+    """
+
+    def test_consensus_door_prompt_mentions_synthesis_guidance(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="T", thread_id="2026-05-21-t", rejector="Wind", feedback=None
+        )
+        assert "synthesis_guidance" in prompt
+
+    def test_consensus_door_prompt_demands_citation_when_present(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="T", thread_id="2026-05-21-t", rejector="Wind", feedback=None
+        )
+        idx = prompt.find("synthesis_guidance")
+        assert idx != -1
+        # Within a ~400 char window around the mention, the prompt must use the
+        # word "cite" (or "citation") so the obligation is unambiguous.
+        window = prompt[max(0, idx - 200) : idx + 400].lower()
+        assert "cite" in window or "citation" in window
+
+
+class TestConsensusPromptsBranchOnSynthesisStatus:
+    """RFC-0001 #198 — consensus prompts branch on SYNTHESIS_STATUS.
+
+    * Wind consensus turn fires under PENDING_REFINEMENT (a prior synthesis
+      was withdrawn) — the prompt must reference this value.
+    * Door consensus turn fires under PRESENT during refinement; the prompt
+      must reference SYNTHESIS_STATUS so the agent reads the envelope.
+    """
+
+    def test_wind_approval_prompt_references_pending_refinement(self) -> None:
+        prompt = format_wind_approval_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "SYNTHESIS_STATUS" in prompt
+        assert "PENDING_REFINEMENT" in prompt
+
+    def test_door_consensus_prompt_references_synthesis_status(self) -> None:
+        prompt = format_door_consensus_prompt(
+            topic="T", thread_id="2026-05-21-t", rejector="Wind", feedback=None
+        )
+        assert "SYNTHESIS_STATUS" in prompt
+        assert "PRESENT" in prompt
+
+
+class TestWindConsensusPerInvariantContentRule:
+    """RFC-0001 §3.2 / Finding C — per-invariant REQUIRED CONTENT RULE.
+
+    Wind's consensus prompt must instruct that EACH HARD_fail invariant
+    requires its OWN qualifying entry (cross-invariant substitution is
+    invalid).
+    """
+
+    def test_wind_consensus_prompt_mentions_each_invariant_obligation(self) -> None:
+        prompt = format_wind_approval_prompt(topic="T", thread_id="2026-05-21-t")
+        assert "HARD_fail" in prompt
+        # The per-invariant phrasing must be explicit (substitution disallowed).
+        assert (
+            "each HARD_fail invariant" in prompt
+            or "every HARD_fail invariant" in prompt
+        )
+
+
 class TestWindConsensusSentinelGatedOnHardFail:
     """RFC-0001 follow-up: Wind's NO_NEW_DIVERGENCE sentinel must be gated on
     the absence of HARD_fail verdicts for the path. Otherwise it conflicts with

--- a/tests/unit/test_prompts_consensus.py
+++ b/tests/unit/test_prompts_consensus.py
@@ -285,10 +285,7 @@ class TestWindConsensusPerInvariantContentRule:
         prompt = format_wind_approval_prompt(topic="T", thread_id="2026-05-21-t")
         assert "HARD_fail" in prompt
         # The per-invariant phrasing must be explicit (substitution disallowed).
-        assert (
-            "each HARD_fail invariant" in prompt
-            or "every HARD_fail invariant" in prompt
-        )
+        assert "each HARD_fail invariant" in prompt or "every HARD_fail invariant" in prompt
 
 
 class TestWindConsensusSentinelGatedOnHardFail:


### PR DESCRIPTION
## Summary

Implements RFC-0001 sub-issue #198 — the four prompt-template updates that
make Wind/Wall/Door consume the `<PATH_CONTRACTS>` block and the
`SYNTHESIS_STATUS::<value>` line emitted by the #218 context compiler. Folds
the prompt-portion of Finding F.

- **Finding F prompt-portion**: Wind initial keys off `PENDING_INITIAL`,
  Wind consensus off `PENDING_REFINEMENT`, Wall + Door initial + Door
  consensus off `PRESENT`. Off-mode (no SYNTHESIS_STATUS line) falls back to
  byte-identical pre-#218 behaviour per the #218 joint-emission contract.
- **Finding A (§3.1 / §3.3)**: Wind initial drops the superseded closed enum
  `[halting, single_wall_coherence, re_approval, per_turn_role_contract]`;
  `hard_invariants_touched` renamed to `invariants_touched`; field
  instruction teaches Wall-discipline snake_case naming, topic-specific per
  orthogonal concern (`Invariant = str`).
- **Finding C (§3.2)**: REQUIRED CONTENT RULE surfaced as **per-invariant**
  in Wind initial (independent scoring downstream) and Door consensus (each
  HARD_fail invariant requires its own citation; cross-invariant
  substitution invalid).
- **Finding D (§3.3)**: `NO_NEW_DIVERGENCE` may coexist with non-empty
  `disputed` — Door consensus prompt instructs to cite disputed entries
  even when the sentinel is set.
- **Finding E (§3.3)**: Door consensus must cite `synthesis_guidance`
  explicitly when present — added inline citation syntax
  `[synthesis_guidance: <one-line summary>]` and obligation language.

## Door split preserved

- `format_door_user_prompt` (initial) — **lacks** PATH_CONTRACT_DIFF
  citation rule (asserted by `TestInitialDoorOmitsPathContractCitation`).
- `format_door_consensus_prompt` (consensus) — **carries** PATH_CONTRACT_DIFF
  citation rule + the new synthesis_guidance citation (asserted by
  `TestConsensusDoorCarriesPathContractCitation` and the new
  `TestDoorConsensusCitesSynthesisGuidanceFindingE`).

## Scope discipline

- No changes to `orchestrator.py` (Finding F boundary).
- No changes to `features.py` or `tier_config` (#201's surface).
- TDD trail: separate RED commit `375dcc8` (9 failing tests) and GREEN commit
  `716ebcc` (all 67 prompt tests passing; full 1575-test suite green).

## References

- Amended RFC: `docs/rfc-0001-path-contract-wind-learning-loop.md`
  - §3.1 — `Invariant = str` schema (Finding A binds acceptance over the
    superseded §8.1 enum)
  - §3.2 — per-invariant REQUIRED CONTENT RULE (Finding C)
  - §3.3 — Findings C / D / E / F prompt-side obligations
- #218 (merged in #219 sequence) — `SYNTHESIS_STATUS` joint-emission contract

## Test plan

- [x] RED commit shows 9 failing tests across path_contract branch
      acceptance criteria
- [x] GREEN commit shows all 67 prompt tests pass
- [x] `uv run pytest` — 1575 passed
- [x] `uv run mypy src/` — 0 issues
- [x] `uv run ruff check .` — 0 issues
- [x] Door split asserted: initial lacks PATH_CONTRACT_DIFF citation;
      consensus carries it
- [x] Off-mode byte-identical envelope preserved (no SYNTHESIS_STATUS line
      when `path_contracts` is empty)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements RFC-0001 sub-issue #198 with correct `SYNTHESIS_STATUS` branching across Wind/Wall/Door, fixes Door initial to `PENDING_INITIAL`, restores Wall consensus verdict-revision, and adds a `path_contract_enabled` flag to keep off-mode prompts byte-identical.

- **New Features**
  - Wind initial: branches on `PENDING_INITIAL`, emits `PATH_CONTRACT_FRAME`, renames `hard_invariants_touched`→`invariants_touched`, teaches topic-specific snake_case, and notes per-invariant scoring.
  - Wall initial: branches on `PENDING_INITIAL`; scores `invariants_touched` (may add missing invariants). Wall consensus: adds `PATH_CONTRACT_VERDICT` revision for `PRESENT`/`PENDING_REFINEMENT`.
  - Door initial: branches on `PENDING_INITIAL`; consumes FRAME/VERDICT only; split preserved (no `PATH_CONTRACT_DIFF` citation).
  - Door consensus: branches on `PRESENT`/`PENDING_REFINEMENT`; must cite accepted/disputed/reframed per path, require per-invariant coverage for any HARD_fail, explicitly cite `synthesis_guidance`, and handle `NO_NEW_DIVERGENCE` even with `disputed`.
  - Wind consensus: branches on `PRESENT`/`PENDING_REFINEMENT`; appends `PATH_CONTRACT_DIFF` revisions; `NO_NEW_DIVERGENCE` gated on no HARD_fail; off-mode skips DIFF blocks. All prompts accept `path_contract_enabled: bool = False` by default to preserve off-mode byte identity.

- **Tests**
  - Added coverage for all branches (initial and consensus), off-mode byte-identity, `synthesis_guidance` citation, `NO_NEW_DIVERGENCE` coexistence with `disputed`, sentinel JSON validity, and Wall consensus verdict-revision presence.

<sup>Written for commit 3d04b7f3a3c23cd37f955c50dadd0b3ae4c97d22. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/221?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

## Follow-ups

- **CE finding (deferred to #223)** — prompt-injection trust boundary: the
  Wind/Wall/Door prompts trust the `SYNTHESIS_STATUS::` line inside
  `<DEBATE_STATE>` to drive branching, but topic/transcript content
  injected upstream could spoof that line and force an agent into the
  wrong branch. Mitigation (envelope sanitization in the context compiler
  to escape or reject `SYNTHESIS_STATUS::` substrings outside the
  trusted insertion point) is tracked in
  [#223](https://github.com/elevanaltd/debate-hall-mcp/issues/223) and is
  out-of-scope for this PR.
- **CRS Finding 4 (advisory, partially addressed)** — DRY: the
  per-function `path_contract` blocks have been extracted into private
  helpers (`_wind_initial_path_contract_block`,
  `_wall_initial_path_contract_block`,
  `_door_initial_path_contract_block`,
  `_wind_consensus_path_contract_block`,
  `_wall_consensus_path_contract_block`,
  `_door_consensus_path_contract_block`). The `[RFC-0001 — path_contract`
  header is intentionally duplicated to keep each helper self-contained;
  further consolidation can land in a focused refactor if desired.
