### PR TITLE
feat(rfc-0001): #201 wire path_contract_enabled through features.is_enabled()

### DIFF
--- a/src/debate_hall_mcp/config.py
+++ b/src/debate_hall_mcp/config.py
@@ -139,6 +139,16 @@ class TierSettings(BaseModel):
         default=True,
         description="Show token counts per turn in VTP transcript injection (observability, opt-out)",
     )
+    path_contract_enabled: bool = Field(
+        default=False,
+        description=(
+            "RFC-0001 path_contract Wind learning loop feature flag "
+            "(§6 step 4, §11.2 row 6). Default OFF; A/B treatment build "
+            "sets ON via tiers.yaml. Access via features.is_enabled("
+            "'path_contract', ctx) — NEVER read this attribute directly "
+            "from call sites (#201 single-source-of-truth invariant)."
+        ),
+    )
 
 
 class TierConfig(BaseModel):

--- a/src/debate_hall_mcp/config.py
+++ b/src/debate_hall_mcp/config.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictBool
 
 
 class RoleConfig(BaseModel):
@@ -139,14 +139,17 @@ class TierSettings(BaseModel):
         default=True,
         description="Show token counts per turn in VTP transcript injection (observability, opt-out)",
     )
-    path_contract_enabled: bool = Field(
+    path_contract_enabled: StrictBool = Field(
         default=False,
         description=(
             "RFC-0001 path_contract Wind learning loop feature flag "
             "(§6 step 4, §11.2 row 6). Default OFF; A/B treatment build "
             "sets ON via tiers.yaml. Access via features.is_enabled("
             "'path_contract', ctx) — NEVER read this attribute directly "
-            "from call sites (#201 single-source-of-truth invariant)."
+            "from call sites (#201 single-source-of-truth invariant). "
+            "Declared StrictBool (PR #222 CE review) so Pydantic refuses "
+            "non-bool inputs at construction (PROD::I2 — semantic validity "
+            "precedes processing; no silent coercion of 'true'/1/'yes')."
         ),
     )
 

--- a/src/debate_hall_mcp/features.py
+++ b/src/debate_hall_mcp/features.py
@@ -128,9 +128,24 @@ def is_enabled(flag_name: str, context: FeatureContext) -> bool:
 
     1. ``flag_name`` MUST be registered in :data:`FLAG_REGISTRY`; unknown
        flags raise :class:`KeyError` (refuse-to-degrade).
-    2. Look up ``context["tier_config"].settings.<flag_name>_enabled``; if
-       present, return its boolean value.
-    3. Otherwise, return :data:`FLAG_REGISTRY` ``[flag_name]["default"]``.
+    2. The context's ``tier_config.settings`` is validated:
+
+       * ``None`` ⇒ fail-safe-off (return ``False``)
+       * not a Pydantic ``BaseModel`` instance ⇒ fail-safe-off
+         (rejects dicts, plain objects, mocks)
+
+       This is the CE hardening from #220 review (carry-forward to #201).
+       Per PROD::I2 (UNIVERSAL_OCTAVE_BINDING — "semantic validity precedes
+       processing; junk in = rejection out"), a malformed settings object
+       must not silently flip the feature state.
+    3. Look up ``<flag_name>_enabled`` on the settings object. The
+       attribute's value MUST be a real ``bool`` — truthy non-bool values
+       (``1``, ``"true"``, ``[1]``) ⇒ fail-safe-off. Strict identity, not
+       coercion, mirrors PROD::I5 (SOVEREIGN_SAFETY_OVERRIDE): the
+       kill-switch only fires on an unambiguous ``True``.
+    4. If the attribute is absent (legacy ``TierSettings`` lacking the
+       field — the pre-#201 state), return ``FLAG_REGISTRY[flag_name][
+       "default"]`` (which is itself a real ``bool``).
 
     Raises:
         KeyError: If ``flag_name`` is not registered in :data:`FLAG_REGISTRY`.
@@ -138,11 +153,28 @@ def is_enabled(flag_name: str, context: FeatureContext) -> bool:
             ``FLAG_REGISTRY`` so the call site can locate the registration
             point quickly.
     """
+    from pydantic import BaseModel  # local import keeps module import cycle-safe
+
     if flag_name not in FLAG_REGISTRY:
         raise KeyError(
             f"Unknown feature flag: {flag_name!r}. "
             f"Register it in FLAG_REGISTRY (debate_hall_mcp.features)."
         )
-    settings = context["tier_config"].settings
+
+    # Hardening step 2 — validate the settings carrier (CE #220 carry-forward).
+    tier_config = context.get("tier_config") if isinstance(context, dict) else None
+    settings = getattr(tier_config, "settings", None)
+    if settings is None or not isinstance(settings, BaseModel):
+        # Fail-safe-off: malformed context ⇒ flag is OFF, never coerced.
+        return False
+
     attr = f"{flag_name}_enabled"
-    return bool(getattr(settings, attr, FLAG_REGISTRY[flag_name]["default"]))
+    default = FLAG_REGISTRY[flag_name]["default"]
+    value = getattr(settings, attr, default)
+
+    # Hardening step 3 — strict bool, no truthy coercion. ``True`` and
+    # ``False`` are the only acceptable values; anything else (str, int,
+    # list, None) ⇒ fail-safe-off.
+    if not isinstance(value, bool):
+        return False
+    return value

--- a/src/debate_hall_mcp/features.py
+++ b/src/debate_hall_mcp/features.py
@@ -171,11 +171,20 @@ def is_enabled(flag_name: str, context: FeatureContext) -> bool:
     # warning naming the reason so operators can diagnose silent disables.
     tier_config = context.get("tier_config") if isinstance(context, dict) else None
     settings = getattr(tier_config, "settings", None)
+    # CE PR #222 re-block: warning logs MUST NOT format raw caller-supplied
+    # values (e.g. via %r). Logs are part of the PROD::I4
+    # (VERIFIABLE_EVENT_LEDGER) audit surface; embedding arbitrary caller
+    # payload turns diagnostics into a data-exfiltration channel. Across
+    # all three fail-safe-off branches below we log ONLY type names — the
+    # operator retains diagnostic value (the type mismatch) without the
+    # raw value leaking.
     if settings is None:
         logger.warning(
-            "features.is_enabled(%r): fail-safe-off — tier_config.settings is None; "
-            "returning False (PROD::I2 strict parsing, PROD::I5 fail-safe-off).",
+            "features.is_enabled(%r): fail-safe-off — tier_config.settings type=%s "
+            "(expected TierSettings, got None); returning False "
+            "(PROD::I2 strict parsing, PROD::I5 fail-safe-off).",
             flag_name,
+            type(settings).__name__,
         )
         return False
     # CE PR #222 finding #2: narrow to TierSettings (the canonical settings
@@ -185,8 +194,8 @@ def is_enabled(flag_name: str, context: FeatureContext) -> bool:
     # types, register them as an explicit tuple here.
     if not isinstance(settings, TierSettings):
         logger.warning(
-            "features.is_enabled(%r): fail-safe-off — settings is %s, "
-            "expected TierSettings; returning False.",
+            "features.is_enabled(%r): fail-safe-off — settings type=%s "
+            "(expected TierSettings); returning False.",
             flag_name,
             type(settings).__name__,
         )
@@ -202,14 +211,17 @@ def is_enabled(flag_name: str, context: FeatureContext) -> bool:
     # defense-in-depth against bypass construction (object.__setattr__,
     # ``model_construct``, future fields that allow extra=True, etc.).
     if not isinstance(value, bool):
+        # NB: ``value`` is caller-controlled; we log ONLY its type name to
+        # avoid leaking arbitrary payload into the audit log (CE PR #222
+        # re-block). ``attr`` is derived from the registered flag name and
+        # is therefore safe to log literally.
         logger.warning(
-            "features.is_enabled(%r): fail-safe-off — %s.%s is %r (type %s), "
-            "expected bool; returning False (defense-in-depth against bypass "
-            "construction).",
+            "features.is_enabled(%r): fail-safe-off — %s.%s value type=%s "
+            "(expected bool); returning False (defense-in-depth against "
+            "bypass construction).",
             flag_name,
             type(settings).__name__,
             attr,
-            value,
             type(value).__name__,
         )
         return False

--- a/src/debate_hall_mcp/features.py
+++ b/src/debate_hall_mcp/features.py
@@ -48,9 +48,11 @@ requires the ``typing_extensions`` flavour for runtime introspection of
 
 from __future__ import annotations
 
+import logging
+
 from typing_extensions import Literal, TypedDict  # noqa: UP035
 
-from debate_hall_mcp.config import TierConfig
+from debate_hall_mcp.config import TierConfig, TierSettings
 
 __all__ = [
     "FLAG_REGISTRY",
@@ -59,6 +61,8 @@ __all__ = [
     "LifecyclePolicy",
     "is_enabled",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 class LifecyclePolicy(TypedDict):
@@ -131,13 +135,16 @@ def is_enabled(flag_name: str, context: FeatureContext) -> bool:
     2. The context's ``tier_config.settings`` is validated:
 
        * ``None`` ⇒ fail-safe-off (return ``False``)
-       * not a Pydantic ``BaseModel`` instance ⇒ fail-safe-off
-         (rejects dicts, plain objects, mocks)
+       * not a :class:`debate_hall_mcp.config.TierSettings` instance ⇒
+         fail-safe-off (rejects dicts, plain objects, mocks, AND wrong
+         Pydantic models with a same-named field — CE PR #222 finding #2).
 
-       This is the CE hardening from #220 review (carry-forward to #201).
-       Per PROD::I2 (UNIVERSAL_OCTAVE_BINDING — "semantic validity precedes
-       processing; junk in = rejection out"), a malformed settings object
-       must not silently flip the feature state.
+       This is the CE hardening from #220 review (carry-forward to #201)
+       plus the PR #222 narrowing. Per PROD::I2 (UNIVERSAL_OCTAVE_BINDING —
+       "semantic validity precedes processing; junk in = rejection out"),
+       a malformed settings object must not silently flip the feature
+       state. Per PROD::I4 (VERIFIABLE_EVENT_LEDGER), each fail-safe-off
+       branch logs a warning naming the rejection reason.
     3. Look up ``<flag_name>_enabled`` on the settings object. The
        attribute's value MUST be a real ``bool`` — truthy non-bool values
        (``1``, ``"true"``, ``[1]``) ⇒ fail-safe-off. Strict identity, not
@@ -153,28 +160,57 @@ def is_enabled(flag_name: str, context: FeatureContext) -> bool:
             ``FLAG_REGISTRY`` so the call site can locate the registration
             point quickly.
     """
-    from pydantic import BaseModel  # local import keeps module import cycle-safe
-
     if flag_name not in FLAG_REGISTRY:
         raise KeyError(
             f"Unknown feature flag: {flag_name!r}. "
             f"Register it in FLAG_REGISTRY (debate_hall_mcp.features)."
         )
 
-    # Hardening step 2 — validate the settings carrier (CE #220 carry-forward).
+    # Hardening step 2 — validate the settings carrier (CE PR #222 review).
+    # PROD::I4 (VERIFIABLE_EVENT_LEDGER): each fail-safe-off branch logs a
+    # warning naming the reason so operators can diagnose silent disables.
     tier_config = context.get("tier_config") if isinstance(context, dict) else None
     settings = getattr(tier_config, "settings", None)
-    if settings is None or not isinstance(settings, BaseModel):
-        # Fail-safe-off: malformed context ⇒ flag is OFF, never coerced.
+    if settings is None:
+        logger.warning(
+            "features.is_enabled(%r): fail-safe-off — tier_config.settings is None; "
+            "returning False (PROD::I2 strict parsing, PROD::I5 fail-safe-off).",
+            flag_name,
+        )
+        return False
+    # CE PR #222 finding #2: narrow to TierSettings (the canonical settings
+    # type for this wrapper). Accepting any pydantic.BaseModel is too
+    # permissive — a wrong settings model with a same-named field would
+    # otherwise pass and return True. If future flags need other settings
+    # types, register them as an explicit tuple here.
+    if not isinstance(settings, TierSettings):
+        logger.warning(
+            "features.is_enabled(%r): fail-safe-off — settings is %s, "
+            "expected TierSettings; returning False.",
+            flag_name,
+            type(settings).__name__,
+        )
         return False
 
     attr = f"{flag_name}_enabled"
     default = FLAG_REGISTRY[flag_name]["default"]
     value = getattr(settings, attr, default)
 
-    # Hardening step 3 — strict bool, no truthy coercion. ``True`` and
-    # ``False`` are the only acceptable values; anything else (str, int,
-    # list, None) ⇒ fail-safe-off.
+    # Hardening step 3 — strict bool, no truthy coercion. With StrictBool
+    # on TierSettings.path_contract_enabled (CE PR #222 finding #1), normal
+    # construction cannot land a non-bool here. This branch is retained as
+    # defense-in-depth against bypass construction (object.__setattr__,
+    # ``model_construct``, future fields that allow extra=True, etc.).
     if not isinstance(value, bool):
+        logger.warning(
+            "features.is_enabled(%r): fail-safe-off — %s.%s is %r (type %s), "
+            "expected bool; returning False (defense-in-depth against bypass "
+            "construction).",
+            flag_name,
+            type(settings).__name__,
+            attr,
+            value,
+            type(value).__name__,
+        )
         return False
     return value

--- a/src/debate_hall_mcp/orchestrator.py
+++ b/src/debate_hall_mcp/orchestrator.py
@@ -259,7 +259,23 @@ class DebateOrchestrator:
         # envelope is byte-identical to the pre-#199 shape. #198's prompt
         # branches depend on this joint emission contract — SYNTHESIS_STATUS
         # only matters when contracts are being tracked.
-        path_contracts_block = render_path_contracts_block(debate_state.get("path_contracts") or [])
+        #
+        # PR #201 — flag gate (RFC §6 step 4, §11.2 row 6):
+        # Route through features.is_enabled('path_contract', ctx) so an
+        # off-flag debate produces a byte-identical envelope to a fresh
+        # one EVEN IF path_contracts has been populated (defence-in-depth
+        # against state-leak through the rendering boundary; the #202
+        # off-mode byte-identity acceptance criterion).
+        from debate_hall_mcp import features as _features
+
+        path_contract_on = _features.is_enabled(
+            "path_contract", {"tier_config": self.tier_config}
+        )
+        path_contracts_block = (
+            render_path_contracts_block(debate_state.get("path_contracts") or [])
+            if path_contract_on
+            else ""
+        )
         if path_contracts_block:
             # Insert SYNTHESIS_STATUS just before the </DEBATE_STATE> closer,
             # alongside the contracts block, so both appear jointly inside the

--- a/src/debate_hall_mcp/orchestrator.py
+++ b/src/debate_hall_mcp/orchestrator.py
@@ -268,9 +268,7 @@ class DebateOrchestrator:
         # off-mode byte-identity acceptance criterion).
         from debate_hall_mcp import features as _features
 
-        path_contract_on = _features.is_enabled(
-            "path_contract", {"tier_config": self.tier_config}
-        )
+        path_contract_on = _features.is_enabled("path_contract", {"tier_config": self.tier_config})
         path_contracts_block = (
             render_path_contracts_block(debate_state.get("path_contracts") or [])
             if path_contract_on

--- a/tests/unit/test_context_compiler_path_contracts.py
+++ b/tests/unit/test_context_compiler_path_contracts.py
@@ -106,11 +106,16 @@ def _contract_full(path_id: str = "path_1") -> PathContract:
 
 
 def _make_orchestrator(tmp_path: Path) -> DebateOrchestrator:
+    # #201: orchestrator <PATH_CONTRACTS>/SYNTHESIS_STATUS emission is gated
+    # on features.is_enabled("path_contract", ctx). Tests in this module
+    # exercise the on-mode rendering / joint-emission contract, so flip the
+    # TierSettings flag ON. Off-mode byte-identity is verified in
+    # tests/unit/test_path_contract_flag_wiring.py.
     tier_config = TierConfig(
         wind=RoleConfig(provider="cli", cli="claude"),
         wall=RoleConfig(provider="cli", cli="codex"),
         door=RoleConfig(provider="cli", cli="gemini"),
-        settings=TierSettings(),
+        settings=TierSettings(path_contract_enabled=True),
     )
     return DebateOrchestrator(tier_config, tmp_path)
 

--- a/tests/unit/test_path_contract_flag_wiring.py
+++ b/tests/unit/test_path_contract_flag_wiring.py
@@ -275,6 +275,38 @@ class TestIsEnabledHardening:
             for record in caplog.records
         ), f"Expected warning log naming the non-bool flag-value reason, got: {caplog.records}"
 
+    def test_warning_logs_do_not_leak_raw_caller_supplied_value(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # CE PR #222 review finding (re-block): the warning log in the
+        # non-bool-flag-value branch previously formatted the raw caller-
+        # supplied value via ``%r`` — turning a diagnostic log into a
+        # data-exfiltration channel for arbitrary caller payload.
+        # PROD::I4 (VERIFIABLE_EVENT_LEDGER) audit surface MUST NOT carry
+        # raw caller-controlled values; only the type name is permitted.
+        #
+        # This test injects a sentinel string via ``object.__setattr__``
+        # (the same defense-in-depth bypass path the prior test exercises)
+        # and asserts the sentinel does NOT appear anywhere in the captured
+        # log text. The type name (``str``) MUST still appear so operators
+        # retain diagnostic value.
+        sentinel = "INJECTED_SECRET_SENTINEL_xyz_do_not_leak"
+        settings = TierSettings()
+        object.__setattr__(settings, "path_contract_enabled", sentinel)
+        role = RoleConfig(provider="cli", cli="claude")
+        tier_config = TierConfig(wind=role, wall=role, door=role, settings=settings)
+        ctx: features.FeatureContext = {"tier_config": tier_config}
+        with caplog.at_level(logging.WARNING, logger="debate_hall_mcp.features"):
+            assert features.is_enabled("path_contract", ctx) is False
+        assert sentinel not in caplog.text, (
+            f"Warning log leaked raw caller-supplied value. "
+            f"Sentinel {sentinel!r} found in caplog.text: {caplog.text!r}"
+        )
+        # Diagnostic value preserved: the type name must still be logged.
+        assert (
+            "str" in caplog.text
+        ), f"Type-only diagnostic missing from warning log: {caplog.text!r}"
+
 
 # ---------------------------------------------------------------------------
 # 4. Orchestrator gating — off-mode byte-identity (#202 acceptance criterion)

--- a/tests/unit/test_path_contract_flag_wiring.py
+++ b/tests/unit/test_path_contract_flag_wiring.py
@@ -1,0 +1,338 @@
+"""RED tests for RFC-0001 #201 — path_contract_enabled flag wiring (RFC §6 / §11.2 row 6).
+
+Covers three concerns:
+
+1. **TierSettings field**: ``path_contract_enabled`` is declared on
+   ``TierSettings`` with ``default=False``. Until #201 lands, the field
+   does not exist and these tests fail with ``AttributeError``.
+
+2. **Orchestrator gating (off-mode byte-identity)**: With the flag
+   ``False``, ``DebateOrchestrator._format_debate_state`` MUST NOT emit
+   the ``<PATH_CONTRACTS>`` block nor ``SYNTHESIS_STATUS::`` — even when
+   the in-memory ``path_contracts`` list is non-empty. This is the
+   acceptance criterion called out by #202 (byte-identity to pre-#218).
+
+3. **features.is_enabled hardening (CE carry-forward from #220 review)**:
+   The wrapper MUST reject malformed contexts (``None`` settings,
+   non-Pydantic settings, non-boolean flag value) by returning ``False``
+   rather than coercing. This closes the "malformed settings silently
+   disables/enables feature" hole flagged in #220 review.
+
+TDD Discipline: RED ⇒ these tests fail on current ``main`` (no
+``path_contract_enabled`` field; orchestrator emits ``<PATH_CONTRACTS>``
+unconditionally on non-empty list; ``features.is_enabled`` does not
+validate ``settings`` type).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from debate_hall_mcp import features
+from debate_hall_mcp.config import (
+    FallbackConfig,
+    RoleConfig,
+    TierConfig,
+    TierSettings,
+)
+from debate_hall_mcp.orchestrator import DebateOrchestrator
+from debate_hall_mcp.path_contract import (
+    FrameRevision,
+    PathContract,
+    new_path_contract,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _ts(minute: int = 0) -> datetime:
+    return datetime(2026, 5, 19, 12, minute, 0, tzinfo=UTC)
+
+
+def _contract_frame_only(path_id: str = "path_1") -> PathContract:
+    contract = new_path_contract(path_id)
+    contract["frame_history"].append(
+        FrameRevision(
+            rev=0,
+            written_at=_ts(),
+            written_by="Wind",
+            value={
+                "assumed_problem": "users cannot reset their password without contacting support",
+                "success_criterion": "password reset completes in under 60 seconds end-to-end",
+                "accepted_failure_mode": (
+                    "email delivery latency may exceed 60s in adverse network conditions"
+                ),
+                "invariants_touched": ["halting", "single_wall_coherence"],
+            },
+        )
+    )
+    return contract
+
+
+def _make_orchestrator(tmp_path: Path, *, path_contract_enabled: bool) -> DebateOrchestrator:
+    settings = TierSettings(path_contract_enabled=path_contract_enabled)
+    tier_config = TierConfig(
+        wind=RoleConfig(provider="cli", cli="claude"),
+        wall=RoleConfig(provider="cli", cli="codex"),
+        door=RoleConfig(provider="cli", cli="gemini"),
+        settings=settings,
+    )
+    return DebateOrchestrator(tier_config, tmp_path)
+
+
+def _base_state(*, path_contracts: list[PathContract]) -> dict[str, Any]:
+    return {
+        "thread_id": "test-thread",
+        "topic": "test topic",
+        "status": "ACTIVE",
+        "turn_count": 1,
+        "path_contracts": path_contracts,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. TierSettings field declaration (#201 scope)
+# ---------------------------------------------------------------------------
+
+
+class TestTierSettingsPathContractEnabledField:
+    """``path_contract_enabled: bool = False`` is declared on TierSettings."""
+
+    def test_default_is_false(self) -> None:
+        settings = TierSettings()
+        assert settings.path_contract_enabled is False
+
+    def test_can_be_set_true(self) -> None:
+        settings = TierSettings(path_contract_enabled=True)
+        assert settings.path_contract_enabled is True
+
+    def test_is_declared_on_model_schema(self) -> None:
+        # Must be a real Pydantic field, not a runtime ``__dict__`` attribute.
+        # Locks in the "single source of truth" intent — call sites route via
+        # features.is_enabled(), and the field must exist on the schema so
+        # mypy + the YAML loader recognise it.
+        assert "path_contract_enabled" in TierSettings.model_fields
+        field = TierSettings.model_fields["path_contract_enabled"]
+        assert field.default is False
+        assert field.annotation is bool
+
+
+# ---------------------------------------------------------------------------
+# 2. features.is_enabled wired into TierSettings field (no synthetic injection)
+# ---------------------------------------------------------------------------
+
+
+class TestIsEnabledReadsRealTierSettingsField:
+    """Post-#201, ``features.is_enabled`` reads the real field, not an
+    injected ``__dict__`` attribute (the #205 work used ``object.__setattr__``
+    to simulate the future state — that workaround MUST become unnecessary).
+    """
+
+    def _ctx(self, path_contract_enabled: bool) -> features.FeatureContext:
+        settings = TierSettings(path_contract_enabled=path_contract_enabled)
+        role = RoleConfig(provider="cli", cli="claude")
+        return {
+            "tier_config": TierConfig(
+                wind=role, wall=role, door=role, settings=settings
+            )
+        }
+
+    def test_returns_true_when_field_true(self) -> None:
+        assert features.is_enabled("path_contract", self._ctx(True)) is True
+
+    def test_returns_false_when_field_false(self) -> None:
+        assert features.is_enabled("path_contract", self._ctx(False)) is False
+
+    def test_returns_false_by_default_for_default_tier_settings(self) -> None:
+        # Default TierSettings() has path_contract_enabled=False, so the
+        # wrapper must return False — this is the rollout-sequence step 1
+        # ("Flag-off in main") invariant from the #201 issue body.
+        role = RoleConfig(provider="cli", cli="claude")
+        tier_config = TierConfig(
+            wind=role, wall=role, door=role, settings=TierSettings()
+        )
+        ctx: features.FeatureContext = {"tier_config": tier_config}
+        assert features.is_enabled("path_contract", ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. CE hardening (carry-forward from #220 review)
+# ---------------------------------------------------------------------------
+
+
+class TestIsEnabledHardening:
+    """``features.is_enabled`` validates ``context`` shape strictly.
+
+    Per PROD::I2 (UNIVERSAL_OCTAVE_BINDING — semantic validity precedes
+    processing): malformed settings ⇒ fail-safe-off, never silent coerce.
+    Per PROD::I5 (SOVEREIGN_SAFETY_OVERRIDE): the off-mode default is the
+    kill-switch, so any ambiguity resolves to False — not to a stack
+    trace deep inside a downstream call site.
+    """
+
+    def test_settings_is_none_returns_false(self) -> None:
+        # A bogus context where ``tier_config.settings`` is None must
+        # fail-safe-off, not raise AttributeError downstream.
+        class _FakeTier:
+            settings = None
+
+        ctx: features.FeatureContext = {"tier_config": _FakeTier()}  # type: ignore[typeddict-item]
+        assert features.is_enabled("path_contract", ctx) is False
+
+    def test_settings_is_dict_returns_false(self) -> None:
+        # A dict masquerading as TierSettings must be rejected — Pydantic
+        # normally enforces this at TierConfig construction, but the
+        # wrapper is the chokepoint and must not assume the caller
+        # constructed the context via Pydantic.
+        class _FakeTier:
+            settings = {"path_contract_enabled": True}
+
+        ctx: features.FeatureContext = {"tier_config": _FakeTier()}  # type: ignore[typeddict-item]
+        assert features.is_enabled("path_contract", ctx) is False
+
+    def test_flag_value_non_bool_returns_false(self) -> None:
+        # A truthy non-bool value (e.g. the string "true" from a
+        # mis-typed YAML file that bypassed Pydantic) must NOT be
+        # truthy-coerced. Strict bool-only.
+        settings = TierSettings()
+        # Inject a non-bool to simulate a malformed runtime mutation.
+        object.__setattr__(settings, "path_contract_enabled", "true")
+        role = RoleConfig(provider="cli", cli="claude")
+        tier_config = TierConfig(
+            wind=role, wall=role, door=role, settings=settings
+        )
+        ctx: features.FeatureContext = {"tier_config": tier_config}
+        assert features.is_enabled("path_contract", ctx) is False
+
+    def test_flag_value_integer_one_returns_false(self) -> None:
+        # ``1`` is truthy in Python but is NOT bool — must be rejected.
+        settings = TierSettings()
+        object.__setattr__(settings, "path_contract_enabled", 1)
+        role = RoleConfig(provider="cli", cli="claude")
+        tier_config = TierConfig(
+            wind=role, wall=role, door=role, settings=settings
+        )
+        ctx: features.FeatureContext = {"tier_config": tier_config}
+        assert features.is_enabled("path_contract", ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Orchestrator gating — off-mode byte-identity (#202 acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDebateStateRespectsPathContractFlag:
+    """``DebateOrchestrator._format_debate_state`` routes the
+    ``<PATH_CONTRACTS>`` / ``SYNTHESIS_STATUS`` emission through
+    ``features.is_enabled("path_contract", ...)``.
+
+    Off-mode contract (flag=False): byte-identical to pre-#218 — no
+    ``<PATH_CONTRACTS>`` block, no ``SYNTHESIS_STATUS::`` line — even
+    when in-memory ``path_contracts`` is non-empty (defence in depth
+    against state-leak through the rendering boundary).
+
+    On-mode contract (flag=True): existing PR #218 joint emission
+    contract holds — non-empty list ⇒ both ``<PATH_CONTRACTS>`` block
+    and ``SYNTHESIS_STATUS::`` emitted.
+    """
+
+    def test_flag_off_omits_path_contracts_block_even_when_list_non_empty(
+        self, tmp_path: Path
+    ) -> None:
+        orchestrator = _make_orchestrator(tmp_path, path_contract_enabled=False)
+        state = _base_state(path_contracts=[_contract_frame_only("path_1")])
+
+        result = orchestrator._format_debate_state(state)
+
+        assert "<PATH_CONTRACTS>" not in result
+        assert "</PATH_CONTRACTS>" not in result
+        assert "SYNTHESIS_STATUS::" not in result
+
+    def test_flag_off_byte_identical_to_empty_list_envelope(
+        self, tmp_path: Path
+    ) -> None:
+        # The whole point of off-mode: a debate that happens to have
+        # accumulated path_contracts (e.g. left over from a treatment
+        # build) MUST produce the same envelope as a fresh debate with
+        # no contracts. This is the #202 acceptance criterion.
+        orchestrator = _make_orchestrator(tmp_path, path_contract_enabled=False)
+        with_contracts = orchestrator._format_debate_state(
+            _base_state(path_contracts=[_contract_frame_only("path_1")])
+        )
+        without_contracts = orchestrator._format_debate_state(
+            _base_state(path_contracts=[])
+        )
+        assert with_contracts == without_contracts
+
+    def test_flag_on_emits_path_contracts_block_when_list_non_empty(
+        self, tmp_path: Path
+    ) -> None:
+        orchestrator = _make_orchestrator(tmp_path, path_contract_enabled=True)
+        state = _base_state(path_contracts=[_contract_frame_only("path_1")])
+
+        result = orchestrator._format_debate_state(state)
+
+        assert "<PATH_CONTRACTS>" in result
+        assert "</PATH_CONTRACTS>" in result
+        assert "SYNTHESIS_STATUS::" in result
+
+    def test_flag_on_with_empty_list_still_omits_block(
+        self, tmp_path: Path
+    ) -> None:
+        # The pre-existing #218 joint emission contract: empty list ⇒
+        # no block, regardless of flag state. This guards against
+        # accidentally emitting empty <PATH_CONTRACTS></PATH_CONTRACTS>
+        # tags when the flag is on but no contracts exist yet.
+        orchestrator = _make_orchestrator(tmp_path, path_contract_enabled=True)
+        state = _base_state(path_contracts=[])
+
+        result = orchestrator._format_debate_state(state)
+
+        assert "<PATH_CONTRACTS>" not in result
+        assert "SYNTHESIS_STATUS::" not in result
+
+
+# ---------------------------------------------------------------------------
+# 5. Direct attribute-read audit (single source of truth invariant)
+# ---------------------------------------------------------------------------
+
+
+class TestNoDirectAttributeReads:
+    """Production code (under ``src/``) MUST NOT read
+    ``tier_config.settings.path_contract_enabled`` directly. Every check
+    routes through ``features.is_enabled()``. The wrapper itself is the
+    only sanctioned reader.
+
+    This test greps the installed package and fails if anything else
+    references the attribute path.
+    """
+
+    def test_no_direct_reads_outside_features_module(self) -> None:
+        import re
+        from pathlib import Path as _Path
+
+        src_root = _Path(__file__).resolve().parents[2] / "src" / "debate_hall_mcp"
+        pattern = re.compile(r"\.path_contract_enabled\b")
+        offenders: list[str] = []
+        for py_file in src_root.rglob("*.py"):
+            # features.py is the single sanctioned reader (via
+            # ``getattr(settings, attr, ...)``); allow it.
+            if py_file.name == "features.py":
+                continue
+            text = py_file.read_text(encoding="utf-8")
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                if pattern.search(line):
+                    offenders.append(f"{py_file.relative_to(src_root)}:{line_no}: {line.strip()}")
+        assert offenders == [], (
+            "Direct `.path_contract_enabled` attribute reads found outside "
+            "features.py. All call sites must route through "
+            "features.is_enabled('path_contract', ctx):\n  "
+            + "\n  ".join(offenders)
+        )

--- a/tests/unit/test_path_contract_flag_wiring.py
+++ b/tests/unit/test_path_contract_flag_wiring.py
@@ -134,11 +134,7 @@ class TestIsEnabledReadsRealTierSettingsField:
     def _ctx(self, path_contract_enabled: bool) -> features.FeatureContext:
         settings = TierSettings(path_contract_enabled=path_contract_enabled)
         role = RoleConfig(provider="cli", cli="claude")
-        return {
-            "tier_config": TierConfig(
-                wind=role, wall=role, door=role, settings=settings
-            )
-        }
+        return {"tier_config": TierConfig(wind=role, wall=role, door=role, settings=settings)}
 
     def test_returns_true_when_field_true(self) -> None:
         assert features.is_enabled("path_contract", self._ctx(True)) is True
@@ -151,9 +147,7 @@ class TestIsEnabledReadsRealTierSettingsField:
         # wrapper must return False — this is the rollout-sequence step 1
         # ("Flag-off in main") invariant from the #201 issue body.
         role = RoleConfig(provider="cli", cli="claude")
-        tier_config = TierConfig(
-            wind=role, wall=role, door=role, settings=TierSettings()
-        )
+        tier_config = TierConfig(wind=role, wall=role, door=role, settings=TierSettings())
         ctx: features.FeatureContext = {"tier_config": tier_config}
         assert features.is_enabled("path_contract", ctx) is False
 
@@ -201,9 +195,7 @@ class TestIsEnabledHardening:
         # Inject a non-bool to simulate a malformed runtime mutation.
         object.__setattr__(settings, "path_contract_enabled", "true")
         role = RoleConfig(provider="cli", cli="claude")
-        tier_config = TierConfig(
-            wind=role, wall=role, door=role, settings=settings
-        )
+        tier_config = TierConfig(wind=role, wall=role, door=role, settings=settings)
         ctx: features.FeatureContext = {"tier_config": tier_config}
         assert features.is_enabled("path_contract", ctx) is False
 
@@ -212,9 +204,7 @@ class TestIsEnabledHardening:
         settings = TierSettings()
         object.__setattr__(settings, "path_contract_enabled", 1)
         role = RoleConfig(provider="cli", cli="claude")
-        tier_config = TierConfig(
-            wind=role, wall=role, door=role, settings=settings
-        )
+        tier_config = TierConfig(wind=role, wall=role, door=role, settings=settings)
         ctx: features.FeatureContext = {"tier_config": tier_config}
         assert features.is_enabled("path_contract", ctx) is False
 
@@ -251,9 +241,7 @@ class TestFormatDebateStateRespectsPathContractFlag:
         assert "</PATH_CONTRACTS>" not in result
         assert "SYNTHESIS_STATUS::" not in result
 
-    def test_flag_off_byte_identical_to_empty_list_envelope(
-        self, tmp_path: Path
-    ) -> None:
+    def test_flag_off_byte_identical_to_empty_list_envelope(self, tmp_path: Path) -> None:
         # The whole point of off-mode: a debate that happens to have
         # accumulated path_contracts (e.g. left over from a treatment
         # build) MUST produce the same envelope as a fresh debate with
@@ -262,14 +250,10 @@ class TestFormatDebateStateRespectsPathContractFlag:
         with_contracts = orchestrator._format_debate_state(
             _base_state(path_contracts=[_contract_frame_only("path_1")])
         )
-        without_contracts = orchestrator._format_debate_state(
-            _base_state(path_contracts=[])
-        )
+        without_contracts = orchestrator._format_debate_state(_base_state(path_contracts=[]))
         assert with_contracts == without_contracts
 
-    def test_flag_on_emits_path_contracts_block_when_list_non_empty(
-        self, tmp_path: Path
-    ) -> None:
+    def test_flag_on_emits_path_contracts_block_when_list_non_empty(self, tmp_path: Path) -> None:
         orchestrator = _make_orchestrator(tmp_path, path_contract_enabled=True)
         state = _base_state(path_contracts=[_contract_frame_only("path_1")])
 
@@ -279,9 +263,7 @@ class TestFormatDebateStateRespectsPathContractFlag:
         assert "</PATH_CONTRACTS>" in result
         assert "SYNTHESIS_STATUS::" in result
 
-    def test_flag_on_with_empty_list_still_omits_block(
-        self, tmp_path: Path
-    ) -> None:
+    def test_flag_on_with_empty_list_still_omits_block(self, tmp_path: Path) -> None:
         # The pre-existing #218 joint emission contract: empty list ⇒
         # no block, regardless of flag state. This guards against
         # accidentally emitting empty <PATH_CONTRACTS></PATH_CONTRACTS>
@@ -329,6 +311,5 @@ class TestNoDirectAttributeReads:
         assert offenders == [], (
             "Direct `.path_contract_enabled` attribute reads found outside "
             "features.py. All call sites must route through "
-            "features.is_enabled('path_contract', ctx):\n  "
-            + "\n  ".join(offenders)
+            "features.is_enabled('path_contract', ctx):\n  " + "\n  ".join(offenders)
         )

--- a/tests/unit/test_path_contract_flag_wiring.py
+++ b/tests/unit/test_path_contract_flag_wiring.py
@@ -26,9 +26,13 @@ validate ``settings`` type).
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
 
 from debate_hall_mcp import features
 from debate_hall_mcp.config import (
@@ -157,6 +161,34 @@ class TestIsEnabledReadsRealTierSettingsField:
 # ---------------------------------------------------------------------------
 
 
+class TestTierSettingsStrictBoolRejectsMalformedInputs:
+    """``TierSettings.path_contract_enabled`` is declared ``StrictBool``.
+
+    Per PROD::I2 (UNIVERSAL_OCTAVE_BINDING — "semantic validity precedes
+    processing; junk in = rejection out"), Pydantic MUST refuse non-bool
+    inputs at construction time instead of silently coercing ``"true"``,
+    ``1``, etc. to ``True``. This is the primary CE finding from PR #222
+    review: without ``StrictBool``, the wrapper's hardening branch never
+    sees malformed values because Pydantic has already coerced them.
+
+    These tests exercise real ``TierSettings(...)`` construction; no
+    ``object.__setattr__`` bypass.
+    """
+
+    @pytest.mark.parametrize("bad_value", ["true", "True", "yes", "1", 1, 0, [], {}])
+    def test_construction_with_non_bool_raises_validation_error(self, bad_value: object) -> None:
+        with pytest.raises(ValidationError):
+            TierSettings(path_contract_enabled=bad_value)  # type: ignore[arg-type]
+
+    def test_construction_with_real_true_succeeds(self) -> None:
+        settings = TierSettings(path_contract_enabled=True)
+        assert settings.path_contract_enabled is True
+
+    def test_construction_with_real_false_succeeds(self) -> None:
+        settings = TierSettings(path_contract_enabled=False)
+        assert settings.path_contract_enabled is False
+
+
 class TestIsEnabledHardening:
     """``features.is_enabled`` validates ``context`` shape strictly.
 
@@ -165,48 +197,83 @@ class TestIsEnabledHardening:
     Per PROD::I5 (SOVEREIGN_SAFETY_OVERRIDE): the off-mode default is the
     kill-switch, so any ambiguity resolves to False — not to a stack
     trace deep inside a downstream call site.
+    Per PROD::I4 (VERIFIABLE_EVENT_LEDGER): each fail-safe-off MUST emit
+    a warning log naming the reason, so operators can diagnose why the
+    feature is silently disabled.
     """
 
-    def test_settings_is_none_returns_false(self) -> None:
+    def test_settings_is_none_returns_false_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         # A bogus context where ``tier_config.settings`` is None must
-        # fail-safe-off, not raise AttributeError downstream.
+        # fail-safe-off, not raise AttributeError downstream, and must
+        # log a warning naming the rejection reason (PROD::I4).
         class _FakeTier:
             settings = None
 
         ctx: features.FeatureContext = {"tier_config": _FakeTier()}  # type: ignore[typeddict-item]
-        assert features.is_enabled("path_contract", ctx) is False
+        with caplog.at_level(logging.WARNING, logger="debate_hall_mcp.features"):
+            assert features.is_enabled("path_contract", ctx) is False
+        assert any(
+            "path_contract" in record.message and "settings" in record.message.lower()
+            for record in caplog.records
+        ), f"Expected warning log naming flag + settings reason, got: {caplog.records}"
 
-    def test_settings_is_dict_returns_false(self) -> None:
-        # A dict masquerading as TierSettings must be rejected — Pydantic
-        # normally enforces this at TierConfig construction, but the
-        # wrapper is the chokepoint and must not assume the caller
-        # constructed the context via Pydantic.
+    def test_settings_wrong_pydantic_model_returns_false_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # CE finding #2: a different Pydantic model with a same-named
+        # field must NOT be accepted. ``isinstance(settings, BaseModel)``
+        # is too permissive; the wrapper must narrow to TierSettings.
+
+        class _OtherModel(BaseModel):
+            path_contract_enabled: bool = True
+
+        class _FakeTier:
+            settings = _OtherModel()
+
+        ctx: features.FeatureContext = {"tier_config": _FakeTier()}  # type: ignore[typeddict-item]
+        with caplog.at_level(logging.WARNING, logger="debate_hall_mcp.features"):
+            assert features.is_enabled("path_contract", ctx) is False
+        assert any(
+            "TierSettings" in record.message or "type" in record.message.lower()
+            for record in caplog.records
+        ), f"Expected warning log naming the wrong-type reason, got: {caplog.records}"
+
+    def test_settings_is_dict_returns_false_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A dict masquerading as TierSettings must be rejected.
         class _FakeTier:
             settings = {"path_contract_enabled": True}
 
         ctx: features.FeatureContext = {"tier_config": _FakeTier()}  # type: ignore[typeddict-item]
-        assert features.is_enabled("path_contract", ctx) is False
+        with caplog.at_level(logging.WARNING, logger="debate_hall_mcp.features"):
+            assert features.is_enabled("path_contract", ctx) is False
+        assert caplog.records, "Expected at least one warning log on fail-safe-off"
 
-    def test_flag_value_non_bool_returns_false(self) -> None:
-        # A truthy non-bool value (e.g. the string "true" from a
-        # mis-typed YAML file that bypassed Pydantic) must NOT be
-        # truthy-coerced. Strict bool-only.
+    def test_defense_in_depth_non_bool_flag_value_returns_false_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Defense in depth: even if a caller bypasses Pydantic via
+        # ``object.__setattr__`` (e.g. malicious runtime mutation, test
+        # double, future refactor that allows extra fields), the wrapper
+        # must still fail-safe-off on a non-bool flag value AND emit a
+        # warning. With StrictBool now blocking construction-time
+        # coercion, this branch is unreachable by normal callers — but
+        # the safety net stays as belt-and-braces.
         settings = TierSettings()
-        # Inject a non-bool to simulate a malformed runtime mutation.
+        # Bypass Pydantic to simulate an attacker / faulty mutator.
         object.__setattr__(settings, "path_contract_enabled", "true")
         role = RoleConfig(provider="cli", cli="claude")
         tier_config = TierConfig(wind=role, wall=role, door=role, settings=settings)
         ctx: features.FeatureContext = {"tier_config": tier_config}
-        assert features.is_enabled("path_contract", ctx) is False
-
-    def test_flag_value_integer_one_returns_false(self) -> None:
-        # ``1`` is truthy in Python but is NOT bool — must be rejected.
-        settings = TierSettings()
-        object.__setattr__(settings, "path_contract_enabled", 1)
-        role = RoleConfig(provider="cli", cli="claude")
-        tier_config = TierConfig(wind=role, wall=role, door=role, settings=settings)
-        ctx: features.FeatureContext = {"tier_config": tier_config}
-        assert features.is_enabled("path_contract", ctx) is False
+        with caplog.at_level(logging.WARNING, logger="debate_hall_mcp.features"):
+            assert features.is_enabled("path_contract", ctx) is False
+        assert any(
+            "path_contract" in record.message and "bool" in record.message.lower()
+            for record in caplog.records
+        ), f"Expected warning log naming the non-bool flag-value reason, got: {caplog.records}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_path_contract_flag_wiring.py
+++ b/tests/unit/test_path_contract_flag_wiring.py
@@ -30,11 +30,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from debate_hall_mcp import features
 from debate_hall_mcp.config import (
-    FallbackConfig,
     RoleConfig,
     TierConfig,
     TierSettings,
@@ -45,7 +42,6 @@ from debate_hall_mcp.path_contract import (
     PathContract,
     new_path_contract,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tiers.yaml.example
+++ b/tiers.yaml.example
@@ -62,6 +62,11 @@ standard:
     max_refinement_loops: 3
     provider_timeout: 300
     show_token_counts: true  # Show token counts per turn in VTP transcript (default: true, opt-out with false)
+    # RFC-0001 path_contract Wind learning loop (§6 step 4, §11.2 row 6).
+    # Default: false. The A/B treatment build sets this to true; the control
+    # build keeps it false. Production code MUST NOT read this directly —
+    # access via debate_hall_mcp.features.is_enabled("path_contract", ctx).
+    # path_contract_enabled: false
     fallback:
       enabled: true
       provider: openrouter


### PR DESCRIPTION
## Summary

Routes the RFC-0001 `path_contract` Wind learning loop through a single feature-flag chokepoint (`features.is_enabled()` from #220). This is the first PR that gates **real path_contract behaviour** through the ADR-0003 wrapper.

- Adds `path_contract_enabled: bool = False` to `TierSettings` as the **single source of truth** (RFC §6 step 4, §11.2 row 6).
- Hardens `features.is_enabled` per the **CE carry-forward from #220 review**: `None` / non-Pydantic / non-bool settings all fail-safe-off (no truthy coercion).
- Wires `DebateOrchestrator._format_debate_state` through the wrapper so the **#202 off-mode byte-identity** acceptance criterion holds: flag OFF ⇒ no `<PATH_CONTRACTS>` block, no `SYNTHESIS_STATUS::` line — even if `path_contracts` is non-empty.
- Documents the flag in `tiers.yaml.example` with an inline pointer to `features.is_enabled()`.

## RFC compliance

- **§3.1** (amended — `Invariant = str`): unchanged; this PR does not touch the schema.
- **§6 step 4**: feature flag wiring through the wrapper from #205/#220.
- **§8 decision 5 / §11.2 row 6**: rollout sequence step 1 ("Flag-off in main"); A/B harness (#203) flips ON in treatment only.
- **§3.3 Finding A supersedes §8.1 closed-enum HardInvariant** — acknowledged; this PR binds to the amended RFC, not the issue-body sketch.

## CE hardening (carry-forward from #220 review)

Inside `features.is_enabled`:

1. `context["tier_config"].settings is None` ⇒ return `False` (fail-safe-off, not `AttributeError` downstream).
2. `settings` not a Pydantic `BaseModel` instance ⇒ return `False` (rejects dicts, plain objects, mocks).
3. Flag value not `isinstance(value, bool)` ⇒ return `False` (strict identity; `1`, `"true"`, `[1]` all reject).

Each case has a dedicated unit test in `tests/unit/test_path_contract_flag_wiring.py::TestIsEnabledHardening`.

Without this hardening, a malformed `settings` object would silently flip the feature state — exactly the hole flagged in #220 review.

## Single source of truth (structural lock)

`TestNoDirectAttributeReads` greps `src/` and fails if any file other than `features.py` reads `.path_contract_enabled` directly. Every future call site is now structurally required to route through `features.is_enabled("path_contract", ctx)`.

## Out-of-scope call sites (justified inline in the commit message)

- `state.py` typed-append API (#219): no production caller exists yet; gating would require threading `TierConfig` into the shared-nothing state model (PROD::I1 violation). Off-mode byte-identity holds vacuously.
- `path_contract_validator.py`: not invoked from production code; write-boundary integration lands in a later PR.
- `tools/get.py`: keeps `path_contracts` key always (per #197/#199 always-emit-empty contract). Empty list ⇒ no block at orchestrator.
- `prompts/__init__.py`: explicitly out-of-scope (#198's surface).

## TDD trail

Two commits, as required:

- `test(rfc-0001): add RED tests for path_contract_enabled flag wiring (#201)` — 8 of 15 tests RED on main (AttributeError, non-bool coercion, unconditional emission); the other 7 lock in invariants that already hold pre-#201.
- `feat(rfc-0001): wire path_contract_enabled through features.is_enabled() (#201)` — GREEN: all 15 pass; 1579 total tests pass.

## Test plan

- [x] `uv run pytest` — 1579 passed
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check .` — clean
- [x] `grep -r '\.path_contract_enabled' src/` returns zero hits outside `features.py` (asserted by `TestNoDirectAttributeReads`)
- [x] Off-mode byte-identity: with flag OFF, envelope is identical for empty-list and non-empty-list `path_contracts` (asserted by `test_flag_off_byte_identical_to_empty_list_envelope`)
- [x] Hardening: `None` / dict / `"true"` / `1` settings all return `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the RFC‑0001 `path_contract` loop behind a single feature flag via `features.is_enabled()`, defaulting to off. The orchestrator only emits `<PATH_CONTRACTS>` and `SYNTHESIS_STATUS::` when the flag is on, keeping off‑mode output byte‑identical for #201/#202.

- **New Features**
  - Added `TierSettings.path_contract_enabled: StrictBool = False` as the single source of truth; access only via `features.is_enabled('path_contract', ctx)`. A test enforces no direct reads.
  - Hardened `features.is_enabled()` and audit logs:
    - `settings is None` or not a `TierSettings` ⇒ `False` with a warning.
    - Non‑bool flag value ⇒ `False` with a warning.
    - Warnings now log type names only (no raw caller values) to prevent data leakage.
  - Updated `DebateOrchestrator._format_debate_state` to gate `<PATH_CONTRACTS>`/`SYNTHESIS_STATUS::`; with the flag off, output is byte‑identical even if `path_contracts` is non‑empty.
  - Documented the flag in `tiers.yaml.example` with a pointer to `features.is_enabled()`.

- **Refactors**
  - Applied Black formatting to touched files; no logic changes.

<sup>Written for commit 59d7245bca45b38d66685046e3e1d5e14432f890. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/222?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

