### PR TITLE
feat(rfc-0001): wire path_contract validator before diff persistence

### DIFF
--- a/src/debate_hall_mcp/_thread_id.py
+++ b/src/debate_hall_mcp/_thread_id.py
@@ -1,0 +1,82 @@
+"""Thread-id filesystem safety validation (cycle-break helper).
+
+This module is a deliberate leaf in the dependency tree. It exists solely
+to host ``_validate_thread_id_for_filesystem`` (and its companion constant
+``PATH_UNSAFE_PATTERNS``) so both ``state.py`` and ``events.py`` can
+import the helper without forming a cycle through one another.
+
+Background (CRS #2 on PR #224 / RFC-0001 validator-wiring):
+---------------------------------------------------------
+
+Before this module existed, ``_validate_thread_id_for_filesystem`` lived
+in ``state.py`` and ``events.py`` imported it from there. The path-
+contract validator (``path_contract_validator``) needed to emit
+``VALIDATOR_FAILURE`` events on rejection, which forced it to import
+``events.append_event`` — and ``state.DebateRoom.append_diff_revision``
+needed to invoke the validator, which would have closed a cycle:
+
+    state → path_contract_validator → events → state
+
+That cycle was previously broken with **lazy imports inside**
+``append_diff_revision`` and a ``list[Any]`` annotation on
+``PathContractValidationError.failures`` (the validator's
+``ValidatorFailure`` type could not be referenced at module load). Both
+were symptoms of the same root: ``state.py`` owned a helper that did not
+belong to its concern (filesystem-safety pre-check on ``thread_id``).
+
+The fix is structural: extract the helper into this dedicated module so
+the dependency tree becomes:
+
+    state → path_contract_validator → events → _thread_id
+    state → _thread_id  (re-export for backward compatibility)
+
+The cycle is broken at the root. The lazy imports in
+``append_diff_revision`` and the ``list[Any]`` workaround on
+``PathContractValidationError`` are both retired.
+
+Compliance:
+
+- PROD::I4 (VERIFIABLE_EVENT_LEDGER) — preserved; the audit emission
+  path is now reachable from a stable import graph.
+- SYS::I3 (ENFORCEMENT_PROTOCOLS) — structural breach (the cycle) is
+  remediated by upgrading the dependency graph rather than guarding
+  symptoms.
+
+Note: ``state.py`` re-exports ``_validate_thread_id_for_filesystem`` (and
+``PATH_UNSAFE_PATTERNS``) for backward compatibility with any existing
+caller that imports the private name from ``state``.
+"""
+
+from __future__ import annotations
+
+# Security: Patterns that indicate path traversal or directory separator
+# injection in a ``thread_id``. Used by every code path that turns a
+# ``thread_id`` into a filesystem name (state files, event files, lock
+# files). The list is intentionally minimal — we reject any of these
+# unconditionally rather than try to enumerate safe characters.
+PATH_UNSAFE_PATTERNS: list[str] = ["..", "/", "\\"]
+
+
+def _validate_thread_id_for_filesystem(thread_id: str) -> None:
+    """Validate that ``thread_id`` is safe to embed in a filesystem path.
+
+    Rejects path-traversal sequences and directory separators to prevent
+    filesystem injection on every code path that builds a file name from
+    a ``thread_id`` (state persistence, event log, lock file).
+
+    Args:
+        thread_id: Thread identifier supplied by an external caller.
+
+    Raises:
+        ValueError: If ``thread_id`` contains any path-unsafe character
+            from :data:`PATH_UNSAFE_PATTERNS`.
+    """
+    for pattern in PATH_UNSAFE_PATTERNS:
+        if pattern in thread_id:
+            raise ValueError(f"Invalid thread_id '{thread_id}': contains path-unsafe characters")
+
+
+__all__ = [
+    "PATH_UNSAFE_PATTERNS",
+    "_validate_thread_id_for_filesystem",
+]

--- a/src/debate_hall_mcp/events.py
+++ b/src/debate_hall_mcp/events.py
@@ -33,7 +33,7 @@ from filelock import FileLock
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from ulid import ULID
 
-from debate_hall_mcp.state import _validate_thread_id_for_filesystem
+from debate_hall_mcp._thread_id import _validate_thread_id_for_filesystem
 
 logger = logging.getLogger(__name__)
 

--- a/src/debate_hall_mcp/state.py
+++ b/src/debate_hall_mcp/state.py
@@ -21,10 +21,13 @@ import time
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import fasteners  # type: ignore[import-untyped]
 from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+    from debate_hall_mcp.config import TierConfig
 
 from debate_hall_mcp.path_contract import (
     DiffRevision,
@@ -66,6 +69,37 @@ class ConcurrencyError(Exception):
         self.expected_hash = expected_hash
         self.actual_hash = actual_hash
         self.thread_id = thread_id
+
+
+class PathContractValidationError(Exception):
+    """Raised when ``append_diff_revision`` rejects a diff per #200 validator.
+
+    Carries the structured ``ValidatorFailure`` list so callers can group by
+    ``failure_type`` discriminator (RFC §6 item 3, #203 A/B harness) without
+    parsing the message string.
+
+    This is the rejection signal for the validate-before-persist boundary
+    (CE's #219 directive): when ``features.is_enabled("path_contract", ...)``
+    is True and ``validate_diff_revision`` returns any failure, the diff
+    MUST NOT enter the append-only ledger (PROD::I4 — invalid contracts
+    cannot be edited, only tombstoned).
+
+    Attributes:
+        failures: Non-empty list of validator failures that caused rejection.
+    """
+
+    def __init__(self, failures: list[Any]) -> None:
+        # ``failures`` is typed as list[Any] here to avoid importing
+        # ValidatorFailure at module-load time (the validator module imports
+        # events, which imports back into state — a top-level cross-import
+        # would form a cycle). Callers should treat ``failures`` as
+        # ``list[debate_hall_mcp.path_contract_validator.ValidatorFailure]``.
+        types = sorted({getattr(f, "failure_type", "<unknown>") for f in failures})
+        super().__init__(
+            f"path_contract validator rejected diff revision; "
+            f"{len(failures)} failure(s), types={types}"
+        )
+        self.failures = failures
 
 
 class IntegrityError(Exception):
@@ -734,6 +768,8 @@ class DebateRoom(BaseModel):
         value: PathDiff,
         divergence_marker: str | None = None,
         synthesis_guidance: str | None = None,
+        tier_config: "TierConfig | None" = None,
+        state_dir: Path | None = None,
     ) -> DiffRevision:
         """Append a Wind-owned diff revision to ``path_id``'s history.
 
@@ -755,6 +791,23 @@ class DebateRoom(BaseModel):
                 expected sentinel set.
             synthesis_guidance: Optional free-text cross-path insight
                 (Finding E). Carried through verbatim.
+            tier_config: Optional tier configuration. When supplied AND
+                ``features.is_enabled("path_contract", ...)`` returns True
+                for this config, the candidate revision is passed through
+                ``path_contract_validator.validate_diff_revision`` BEFORE
+                the in-memory ledger is mutated (CE's #219 deferred
+                follow-up, RFC §3.2 / §3.3 Finding C). When ``None`` (the
+                default) OR the flag is OFF, the validator is NOT invoked
+                and the API stays byte-identical to its pre-wiring
+                behavior — preserves the contract for every legacy caller
+                that doesn't yet opt in.
+            state_dir: Optional directory for ``VALIDATOR_FAILURE`` event
+                emission on rejection. Required when ``tier_config`` is
+                supplied AND the flag is ON so the rejection is auditable
+                on the I4 ledger per RFC §6 item 3. If ``None`` while the
+                validator gate runs, no events are emitted (the
+                ``PathContractValidationError`` still surfaces the
+                failures to the caller — silent-drop is impossible).
 
         Returns:
             The appended :class:`DiffRevision` wrapper.
@@ -762,6 +815,12 @@ class DebateRoom(BaseModel):
         Raises:
             ValueError: If ``divergence_marker`` is supplied with a
                 value other than ``"NO_NEW_DIVERGENCE"``.
+            PathContractValidationError: If the path_contract feature
+                flag is enabled for ``tier_config`` AND
+                ``validate_diff_revision`` returns a non-empty failure
+                list. The diff is NOT persisted — PROD::I4
+                (VERIFIABLE_EVENT_LEDGER) requires that invalid
+                contracts never enter the append-only history.
         """
         if divergence_marker is not None and divergence_marker != "NO_NEW_DIVERGENCE":
             raise ValueError(
@@ -780,6 +839,35 @@ class DebateRoom(BaseModel):
             revision["divergence_marker"] = "NO_NEW_DIVERGENCE"
         if synthesis_guidance is not None:
             revision["synthesis_guidance"] = synthesis_guidance
+
+        # Validate-before-persist gate (CE's #219 directive). Lazy imports
+        # break the would-be cycle state → validator → events → state that a
+        # top-level import would create. The byte-identity guarantee for
+        # off-mode callers is preserved by the early-return when either
+        # ``tier_config`` is absent or the feature flag resolves to False.
+        if tier_config is not None:
+            from debate_hall_mcp import features as _features
+            from debate_hall_mcp.path_contract_validator import (
+                emit_validator_failures,
+                validate_diff_revision,
+            )
+
+            if _features.is_enabled("path_contract", {"tier_config": tier_config}):
+                failures = validate_diff_revision(contract, revision)
+                if failures:
+                    # Emit one VALIDATOR_FAILURE event per failure on the
+                    # I4 ledger (RFC §6 item 3). If no state_dir was
+                    # provided we cannot persist events — the failures
+                    # still surface via the exception, so silent-drop is
+                    # impossible by construction.
+                    if state_dir is not None:
+                        emit_validator_failures(
+                            thread_id=self.thread_id,
+                            failures=failures,
+                            state_dir=state_dir,
+                        )
+                    raise PathContractValidationError(failures)
+
         contract["diff_history"].append(revision)
         return revision
 

--- a/src/debate_hall_mcp/state.py
+++ b/src/debate_hall_mcp/state.py
@@ -29,6 +29,15 @@ from pydantic import BaseModel, Field, field_validator
 if TYPE_CHECKING:
     from debate_hall_mcp.config import TierConfig
 
+from debate_hall_mcp import features
+
+# Re-export via ``as`` alias so mypy recognizes this as an explicit
+# public re-export (backward compatibility for callers like
+# ``tools.interject`` / ``tools.orchestrate`` that historically imported
+# the helper from ``state``). Canonical home is ``_thread_id``.
+from debate_hall_mcp._thread_id import (
+    _validate_thread_id_for_filesystem as _validate_thread_id_for_filesystem,
+)
 from debate_hall_mcp.path_contract import (
     DiffRevision,
     FrameRevision,
@@ -43,6 +52,11 @@ from debate_hall_mcp.path_contract import (
 )
 from debate_hall_mcp.path_contract import (
     InvariantVerdict as _InvariantVerdict,
+)
+from debate_hall_mcp.path_contract_validator import (
+    ValidatorFailure,
+    emit_validator_failures,
+    validate_diff_revision,
 )
 
 
@@ -85,16 +99,16 @@ class PathContractValidationError(Exception):
     cannot be edited, only tombstoned).
 
     Attributes:
-        failures: Non-empty list of validator failures that caused rejection.
+        failures: Non-empty list of validator failures that caused
+            rejection. Element type is the concrete
+            :class:`debate_hall_mcp.path_contract_validator.ValidatorFailure`
+            dataclass — the prior ``list[Any]`` workaround for the
+            state→validator→events→state import cycle is retired now that
+            the cycle is broken at its root (see :mod:`debate_hall_mcp._thread_id`).
     """
 
-    def __init__(self, failures: list[Any]) -> None:
-        # ``failures`` is typed as list[Any] here to avoid importing
-        # ValidatorFailure at module-load time (the validator module imports
-        # events, which imports back into state — a top-level cross-import
-        # would form a cycle). Callers should treat ``failures`` as
-        # ``list[debate_hall_mcp.path_contract_validator.ValidatorFailure]``.
-        types = sorted({getattr(f, "failure_type", "<unknown>") for f in failures})
+    def __init__(self, failures: list[ValidatorFailure]) -> None:
+        types = sorted({f.failure_type for f in failures})
         super().__init__(
             f"path_contract validator rejected diff revision; "
             f"{len(failures)} failure(s), types={types}"
@@ -128,8 +142,12 @@ class IntegrityError(Exception):
         self.computed_hash = computed_hash
 
 
-# Security: Patterns that indicate path traversal or directory injection
-PATH_UNSAFE_PATTERNS = ["..", "/", "\\"]
+# Note: ``PATH_UNSAFE_PATTERNS`` and ``_validate_thread_id_for_filesystem``
+# were moved to :mod:`debate_hall_mcp._thread_id` so ``events.py`` can
+# import the validation helper without forming a
+# state→validator→events→state cycle (CRS #2 on PR #224 follow-up).
+# ``_validate_thread_id_for_filesystem`` is re-imported above for backward
+# compatibility with callers that still import it from ``state``.
 
 # Environment variable for state directory (Issue #33)
 STATE_DIR_ENV_VAR = "DEBATE_HALL_STATE_DIR"
@@ -778,6 +796,45 @@ class DebateRoom(BaseModel):
         revision (the schema's ``NotRequired`` keys are not coerced to
         ``None``).
 
+        Two operating modes — joint integrity + audit contract:
+        ------------------------------------------------------
+
+        **Off-mode** (``tier_config is None``): validator is NOT invoked.
+        The append always proceeds (subject to the structural
+        ``divergence_marker`` check). This is the legacy contract,
+        preserved byte-identically for every caller that has not yet
+        opted in to the path-contract validator.
+
+        **On-mode** (``tier_config is not None``): ``state_dir`` is
+        REQUIRED — asymmetric kwargs (``tier_config`` set,
+        ``state_dir=None``) raise ``TypeError`` at function entry. The
+        rationale is audit completeness: when validation runs, every
+        rejection MUST be able to emit a ``VALIDATOR_FAILURE`` event on
+        the I4 ledger (PROD::I4 — VERIFIABLE_EVENT_LEDGER). Allowing
+        ``tier_config`` without ``state_dir`` would create a silent-
+        audit-drop branch on rejection; we collapse that branch at the
+        API boundary instead of guarding it post-hoc.
+
+        When the path-contract feature flag is OFF for the supplied
+        ``tier_config``, the validator is still NOT invoked (so the
+        ``state_dir`` is unused in practice for that call); the kwarg
+        symmetry check fires regardless of flag state because the
+        contract is a static API shape, not a runtime-conditional.
+
+        When the flag is ON and ``validate_diff_revision`` returns
+        failures, BOTH happen unconditionally:
+
+        * **Integrity** — ``PathContractValidationError`` is raised; the
+          diff is NOT persisted (PROD::I4 forbids editing the append-only
+          history, so an invalid contract is blocked BEFORE it lands).
+        * **Audit** — one ``VALIDATOR_FAILURE`` event per
+          ``ValidatorFailure`` is appended to the I4 ledger via
+          ``emit_validator_failures`` (RFC §6 item 3, #203 A/B harness).
+
+        Both are joint, not alternatives. The exception is propagation
+        for the caller's transactional decision; the events are the
+        ledger's audit record. Neither replaces the other.
+
         Args:
             path_id: Path identifier; the contract is auto-created on
                 first append.
@@ -797,31 +854,45 @@ class DebateRoom(BaseModel):
                 ``path_contract_validator.validate_diff_revision`` BEFORE
                 the in-memory ledger is mutated (CE's #219 deferred
                 follow-up, RFC §3.2 / §3.3 Finding C). When ``None`` (the
-                default) OR the flag is OFF, the validator is NOT invoked
-                and the API stays byte-identical to its pre-wiring
-                behavior — preserves the contract for every legacy caller
-                that doesn't yet opt in.
-            state_dir: Optional directory for ``VALIDATOR_FAILURE`` event
-                emission on rejection. Required when ``tier_config`` is
-                supplied AND the flag is ON so the rejection is auditable
-                on the I4 ledger per RFC §6 item 3. If ``None`` while the
-                validator gate runs, no events are emitted (the
-                ``PathContractValidationError`` still surfaces the
-                failures to the caller — silent-drop is impossible).
+                default) the validator is NOT invoked and the API stays
+                byte-identical to its pre-wiring behavior — preserves the
+                contract for every legacy caller that doesn't yet opt in.
+            state_dir: Directory for ``VALIDATOR_FAILURE`` event emission
+                on rejection. REQUIRED when ``tier_config`` is supplied
+                (see the joint integrity+audit contract above). Allowed
+                to be ``None`` only when ``tier_config`` is also
+                ``None``.
 
         Returns:
             The appended :class:`DiffRevision` wrapper.
 
         Raises:
+            TypeError: If ``tier_config`` is supplied without
+                ``state_dir``. Asymmetric kwargs are rejected at function
+                entry to keep audit emission unconditional whenever
+                validation runs.
             ValueError: If ``divergence_marker`` is supplied with a
                 value other than ``"NO_NEW_DIVERGENCE"``.
             PathContractValidationError: If the path_contract feature
                 flag is enabled for ``tier_config`` AND
                 ``validate_diff_revision`` returns a non-empty failure
-                list. The diff is NOT persisted — PROD::I4
-                (VERIFIABLE_EVENT_LEDGER) requires that invalid
-                contracts never enter the append-only history.
+                list. The diff is NOT persisted and
+                ``VALIDATOR_FAILURE`` events are emitted to the ledger
+                BEFORE the exception is raised (joint integrity+audit).
         """
+        # Audit-completeness precondition (CRS #1 / cubic P2 on PR #224):
+        # when validation can run, the ledger MUST be reachable. We collapse
+        # the conditional-audit branch at the API boundary instead of
+        # checking after rejection — that way every rejection emits a
+        # VALIDATOR_FAILURE event by construction (PROD::I4).
+        if tier_config is not None and state_dir is None:
+            raise TypeError(
+                "state_dir is required when tier_config is supplied; "
+                "audit emission of VALIDATOR_FAILURE events on rejection "
+                "MUST be unconditional whenever validation can run "
+                "(PROD::I4 — VERIFIABLE_EVENT_LEDGER)."
+            )
+
         if divergence_marker is not None and divergence_marker != "NO_NEW_DIVERGENCE":
             raise ValueError(
                 "divergence_marker must equal 'NO_NEW_DIVERGENCE' when set "
@@ -840,33 +911,30 @@ class DebateRoom(BaseModel):
         if synthesis_guidance is not None:
             revision["synthesis_guidance"] = synthesis_guidance
 
-        # Validate-before-persist gate (CE's #219 directive). Lazy imports
-        # break the would-be cycle state → validator → events → state that a
-        # top-level import would create. The byte-identity guarantee for
-        # off-mode callers is preserved by the early-return when either
-        # ``tier_config`` is absent or the feature flag resolves to False.
-        if tier_config is not None:
-            from debate_hall_mcp import features as _features
-            from debate_hall_mcp.path_contract_validator import (
-                emit_validator_failures,
-                validate_diff_revision,
-            )
-
-            if _features.is_enabled("path_contract", {"tier_config": tier_config}):
-                failures = validate_diff_revision(contract, revision)
-                if failures:
-                    # Emit one VALIDATOR_FAILURE event per failure on the
-                    # I4 ledger (RFC §6 item 3). If no state_dir was
-                    # provided we cannot persist events — the failures
-                    # still surface via the exception, so silent-drop is
-                    # impossible by construction.
-                    if state_dir is not None:
-                        emit_validator_failures(
-                            thread_id=self.thread_id,
-                            failures=failures,
-                            state_dir=state_dir,
-                        )
-                    raise PathContractValidationError(failures)
+        # Validate-before-persist gate (CE's #219 directive). The imports
+        # for ``features``, ``validate_diff_revision``, and
+        # ``emit_validator_failures`` now live at module top — the
+        # state→validator→events→state cycle was broken structurally by
+        # extracting ``_validate_thread_id_for_filesystem`` into
+        # ``debate_hall_mcp._thread_id``, so lazy imports are no longer
+        # needed (CRS #2 on PR #224 follow-up).
+        if tier_config is not None and features.is_enabled(
+            "path_contract", {"tier_config": tier_config}
+        ):
+            # ``state_dir`` is non-None here by the precondition above
+            # (the asymmetric-kwargs raise short-circuits before this
+            # branch can be reached without it).
+            assert state_dir is not None  # noqa: S101 — invariant from precondition
+            failures = validate_diff_revision(contract, revision)
+            if failures:
+                # Audit FIRST, then raise. Both are unconditional in
+                # on-mode (joint integrity+audit contract).
+                emit_validator_failures(
+                    thread_id=self.thread_id,
+                    failures=failures,
+                    state_dir=state_dir,
+                )
+                raise PathContractValidationError(failures)
 
         contract["diff_history"].append(revision)
         return revision
@@ -972,23 +1040,6 @@ def verify_all_turn_content_hashes(
             )
 
     return results
-
-
-def _validate_thread_id_for_filesystem(thread_id: str) -> None:
-    """Validate thread_id is safe for filesystem operations.
-
-    Security: Rejects path traversal sequences and directory separators
-    to prevent file system injection attacks.
-
-    Args:
-        thread_id: Thread identifier to validate
-
-    Raises:
-        ValueError: If thread_id contains path-unsafe characters
-    """
-    for pattern in PATH_UNSAFE_PATTERNS:
-        if pattern in thread_id:
-            raise ValueError(f"Invalid thread_id '{thread_id}': contains path-unsafe characters")
 
 
 def _get_read_write_lock(lock_file: Path) -> fasteners.InterProcessReaderWriterLock:

--- a/tests/unit/test_state_validator_wiring.py
+++ b/tests/unit/test_state_validator_wiring.py
@@ -23,11 +23,7 @@ from unittest.mock import patch
 import pytest
 
 from debate_hall_mcp.config import RoleConfig, TierConfig, TierSettings
-from debate_hall_mcp.path_contract import (
-    DiffRevision,
-    PathDiff,
-    VerdictRevision,
-)
+from debate_hall_mcp.path_contract import PathDiff
 from debate_hall_mcp.path_contract_validator import (
     MISSING_REQUIRED_ENTRY,
     ValidatorFailure,

--- a/tests/unit/test_state_validator_wiring.py
+++ b/tests/unit/test_state_validator_wiring.py
@@ -201,3 +201,192 @@ class TestOnModeRejectionSemantics:
         content = events_file.read_text(encoding="utf-8")
         assert "validator_failure" in content
         assert MISSING_REQUIRED_ENTRY in content
+
+
+class TestAsymmetricKwargsRejected:
+    """When ``tier_config`` is supplied, ``state_dir`` MUST also be supplied.
+
+    Rationale (CRS #1 / cubic P2 on PR #224 follow-up): audit completeness is
+    a structural invariant, not a transport-conditional convenience. If
+    validation runs, every rejection MUST be capable of emitting a
+    ``VALIDATOR_FAILURE`` event on the I4 ledger (PROD::I4). Allowing
+    ``tier_config`` without ``state_dir`` creates a silent-audit-drop branch
+    on rejection. We collapse that branch at the API boundary by raising at
+    function entry instead of inside the post-validation path.
+    """
+
+    def test_tier_config_without_state_dir_raises_typeerror(self) -> None:
+        """``tier_config`` without ``state_dir`` is an asymmetric kwarg combo.
+
+        The function must raise ``TypeError`` at entry (before any contract
+        mutation, before any validator dispatch) so the caller cannot
+        accidentally request validation while denying the ledger its audit
+        surface.
+        """
+        room = DebateRoom(
+            thread_id="2026-05-26-asymmetric-kwargs",
+            topic="asymmetric kwargs rejected",
+            mode=DebateMode.FIXED,
+        )
+
+        with pytest.raises(TypeError, match=r"state_dir.*required.*tier_config"):
+            room.append_diff_revision(
+                path_id="p1",
+                written_at=_ts(1),
+                value=_empty_diff_value(),
+                tier_config=_tier_config(path_contract_enabled=True),
+                # state_dir intentionally omitted
+            )
+
+    def test_tier_config_without_state_dir_raises_even_when_flag_off(self) -> None:
+        """The asymmetric-kwargs check fires BEFORE the flag check.
+
+        The contract is a static API shape — ``tier_config`` + missing
+        ``state_dir`` is invalid regardless of the runtime flag value.
+        Deferring the check until after the flag resolves would leave a
+        latent bug that only surfaces when the flag flips on.
+        """
+        room = DebateRoom(
+            thread_id="2026-05-26-asymmetric-flag-off",
+            topic="asymmetric kwargs with flag off",
+            mode=DebateMode.FIXED,
+        )
+
+        with pytest.raises(TypeError, match=r"state_dir.*required.*tier_config"):
+            room.append_diff_revision(
+                path_id="p1",
+                written_at=_ts(1),
+                value=_empty_diff_value(),
+                tier_config=_tier_config(path_contract_enabled=False),
+                # state_dir intentionally omitted
+            )
+
+    def test_no_tier_config_no_state_dir_still_works(self) -> None:
+        """Off-mode (no ``tier_config``) is the only path that may omit ``state_dir``.
+
+        Preserves byte-identity with legacy callers that never opted in.
+        """
+        room = DebateRoom(
+            thread_id="2026-05-26-off-mode-no-state-dir",
+            topic="off-mode legacy",
+            mode=DebateMode.FIXED,
+        )
+        _seed_hard_fail_verdict(room, "p1", "inv_a")
+
+        # No raise, no validation, append proceeds.
+        room.append_diff_revision(
+            path_id="p1",
+            written_at=_ts(1),
+            value=_empty_diff_value(),
+        )
+        assert len(room.path_contracts[0]["diff_history"]) == 1
+
+
+class TestValidationErrorFailuresTyped:
+    """The ``failures`` attribute on ``PathContractValidationError`` carries
+    concrete ``ValidatorFailure`` instances, not ``Any``.
+
+    CRS #2 / cubic P2: ``list[Any]`` erasure was a workaround for the
+    state→validator→events→state cycle. With the cycle broken, the type
+    can be concrete and the workaround removed.
+    """
+
+    def test_failures_are_validator_failure_instances(self, tmp_path: Path) -> None:
+        """Every element of ``failures`` is a ``ValidatorFailure`` dataclass."""
+        room = DebateRoom(
+            thread_id="2026-05-26-typed-failures",
+            topic="typed failures",
+            mode=DebateMode.FIXED,
+        )
+        _seed_hard_fail_verdict(room, "p1", "inv_a")
+
+        with pytest.raises(PathContractValidationError) as exc_info:
+            room.append_diff_revision(
+                path_id="p1",
+                written_at=_ts(1),
+                value=_empty_diff_value(),
+                tier_config=_tier_config(path_contract_enabled=True),
+                state_dir=tmp_path,
+            )
+
+        for failure in exc_info.value.failures:
+            assert isinstance(
+                failure, ValidatorFailure
+            ), f"failures must be ValidatorFailure instances, got {type(failure)}"
+
+
+class TestCycleBrokenNoLazyImports:
+    """The state→validator→events→state cycle is broken at the root.
+
+    CRS #2: ``_validate_thread_id_for_filesystem`` was extracted out of
+    ``state.py`` so ``events.py`` can import it without going through
+    ``state.py``. Once the cycle is broken, the lazy imports inside
+    ``append_diff_revision`` are unnecessary and removed.
+    """
+
+    def test_thread_id_helper_lives_in_dedicated_module(self) -> None:
+        """The helper is importable from its dedicated module.
+
+        This is the structural proof that the cycle root has been
+        relocated — if this import fails, the extraction never happened.
+        """
+        from debate_hall_mcp._thread_id import (  # noqa: PLC0415
+            _validate_thread_id_for_filesystem,
+        )
+
+        # And it actually works.
+        _validate_thread_id_for_filesystem("safe-thread-id")
+        with pytest.raises(ValueError, match="path-unsafe"):
+            _validate_thread_id_for_filesystem("../escape")
+
+    def test_state_reexports_helper_for_backward_compatibility(self) -> None:
+        """``state.py`` re-exports the helper so legacy imports keep working."""
+        from debate_hall_mcp.state import (  # noqa: PLC0415
+            _validate_thread_id_for_filesystem as state_helper,
+        )
+        from debate_hall_mcp._thread_id import (  # noqa: PLC0415
+            _validate_thread_id_for_filesystem as canonical_helper,
+        )
+
+        assert state_helper is canonical_helper
+
+    def test_events_imports_helper_from_dedicated_module(self) -> None:
+        """``events.py`` imports the helper from ``_thread_id``, not ``state``.
+
+        Structural assertion: the source of ``events.py`` does NOT contain
+        ``from debate_hall_mcp.state import _validate_thread_id_for_filesystem``;
+        it imports from the new dedicated module instead. This is the
+        observable proof that the cycle is broken at the source.
+        """
+        import inspect  # noqa: PLC0415
+
+        from debate_hall_mcp import events  # noqa: PLC0415
+
+        source = inspect.getsource(events)
+        assert (
+            "from debate_hall_mcp.state import _validate_thread_id_for_filesystem" not in source
+        ), "events.py must NOT import _validate_thread_id_for_filesystem from state"
+        assert (
+            "from debate_hall_mcp._thread_id import _validate_thread_id_for_filesystem" in source
+        ), "events.py must import _validate_thread_id_for_filesystem from _thread_id"
+
+    def test_append_diff_revision_has_no_lazy_validator_imports(self) -> None:
+        """With the cycle broken, the function body no longer needs lazy imports.
+
+        Structural assertion on the source of ``DebateRoom.append_diff_revision``:
+        ``from debate_hall_mcp.path_contract_validator import`` should NOT
+        appear inside the function body — it must live at module top.
+        """
+        import inspect  # noqa: PLC0415
+
+        from debate_hall_mcp.state import DebateRoom  # noqa: PLC0415
+
+        body = inspect.getsource(DebateRoom.append_diff_revision)
+        assert "from debate_hall_mcp.path_contract_validator import" not in body, (
+            "append_diff_revision must NOT contain lazy validator imports; "
+            "the cycle is broken so the imports belong at module top."
+        )
+        assert "from debate_hall_mcp import features" not in body, (
+            "append_diff_revision must NOT contain a lazy features import; "
+            "import at module top now that the cycle is gone."
+        )

--- a/tests/unit/test_state_validator_wiring.py
+++ b/tests/unit/test_state_validator_wiring.py
@@ -341,11 +341,11 @@ class TestCycleBrokenNoLazyImports:
 
     def test_state_reexports_helper_for_backward_compatibility(self) -> None:
         """``state.py`` re-exports the helper so legacy imports keep working."""
-        from debate_hall_mcp.state import (  # noqa: PLC0415
-            _validate_thread_id_for_filesystem as state_helper,
-        )
         from debate_hall_mcp._thread_id import (  # noqa: PLC0415
             _validate_thread_id_for_filesystem as canonical_helper,
+        )
+        from debate_hall_mcp.state import (  # noqa: PLC0415
+            _validate_thread_id_for_filesystem as state_helper,
         )
 
         assert state_helper is canonical_helper

--- a/tests/unit/test_state_validator_wiring.py
+++ b/tests/unit/test_state_validator_wiring.py
@@ -1,0 +1,207 @@
+"""RED tests — wire ``path_contract_validator.validate_diff_revision`` into
+``DebateRoom.append_diff_revision`` so every model-produced diff revision is
+validate-before-persist (RFC-0001 §3.2 / §3.3 Finding C; CE's #219 boundary note).
+
+Contract under test (validate-before-persist):
+    1. When the feature flag is OFF (or no ``tier_config`` is supplied), the
+       API is byte-identical to its pre-wiring behavior — validator is NOT
+       invoked, append proceeds.
+    2. When the feature flag is ON AND the validator returns no failures,
+       ``append_diff_revision`` persists the diff (current behavior preserved).
+    3. When the feature flag is ON AND the validator returns failures,
+       ``append_diff_revision`` does NOT persist the diff — failures are
+       propagated as ``PathContractValidationError`` and ``VALIDATOR_FAILURE``
+       events are appended to the ledger (per #217 contract, RFC §6 item 3).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from debate_hall_mcp.config import RoleConfig, TierConfig, TierSettings
+from debate_hall_mcp.path_contract import (
+    DiffRevision,
+    PathDiff,
+    VerdictRevision,
+)
+from debate_hall_mcp.path_contract_validator import (
+    MISSING_REQUIRED_ENTRY,
+    ValidatorFailure,
+)
+from debate_hall_mcp.state import (
+    DebateMode,
+    DebateRoom,
+    PathContractValidationError,
+)
+
+
+def _ts(minute: int = 0) -> datetime:
+    return datetime(2026, 5, 26, 12, minute, 0, tzinfo=UTC)
+
+
+def _empty_diff_value() -> PathDiff:
+    return PathDiff(accepted=[], disputed=[], reframed=[])
+
+
+def _role() -> RoleConfig:
+    return RoleConfig(provider="cli", cli="claude")
+
+
+def _tier_config(*, path_contract_enabled: bool) -> TierConfig:
+    """Build a TierConfig with the path_contract flag in the desired state."""
+    return TierConfig(
+        wind=_role(),
+        wall=_role(),
+        door=_role(),
+        settings=TierSettings(path_contract_enabled=path_contract_enabled),
+    )
+
+
+def _seed_hard_fail_verdict(room: DebateRoom, path_id: str, invariant: str) -> None:
+    """Seed a HARD_fail verdict so the validator has a per-invariant requirement."""
+    room.append_verdict_revision(
+        path_id=path_id,
+        written_at=_ts(0),
+        value={invariant: {"status": "HARD_fail", "rationale": "fail"}},
+    )
+
+
+class TestOffModeByteIdentity:
+    """When tier_config is None or flag is OFF, behavior is unchanged."""
+
+    def test_no_tier_config_skips_validation(self) -> None:
+        """No ``tier_config`` kwarg → no validator call, no events, append proceeds.
+
+        This preserves byte-identity with the pre-wiring API for every legacy
+        caller that doesn't yet opt in.
+        """
+        room = DebateRoom(
+            thread_id="2026-05-26-off-mode-no-cfg",
+            topic="off-mode no cfg",
+            mode=DebateMode.FIXED,
+        )
+        _seed_hard_fail_verdict(room, "p1", "inv_a")
+
+        with patch(
+            "debate_hall_mcp.path_contract_validator.validate_diff_revision"
+        ) as mock_validate:
+            room.append_diff_revision(
+                path_id="p1",
+                written_at=_ts(1),
+                value=_empty_diff_value(),  # would fail REQUIRED CONTENT if validated
+            )
+
+        mock_validate.assert_not_called()
+        assert len(room.path_contracts[0]["diff_history"]) == 1
+
+    def test_flag_off_skips_validation(self, tmp_path: Path) -> None:
+        """Flag explicitly OFF → no validator call, append proceeds."""
+        room = DebateRoom(
+            thread_id="2026-05-26-off-mode-flag-off",
+            topic="off-mode flag off",
+            mode=DebateMode.FIXED,
+        )
+        _seed_hard_fail_verdict(room, "p1", "inv_a")
+
+        with patch(
+            "debate_hall_mcp.path_contract_validator.validate_diff_revision"
+        ) as mock_validate:
+            room.append_diff_revision(
+                path_id="p1",
+                written_at=_ts(1),
+                value=_empty_diff_value(),
+                tier_config=_tier_config(path_contract_enabled=False),
+                state_dir=tmp_path,
+            )
+
+        mock_validate.assert_not_called()
+        assert len(room.path_contracts[0]["diff_history"]) == 1
+
+
+class TestOnModeValidationProceeds:
+    """When flag is ON and validator returns no failures, the diff persists."""
+
+    def test_valid_diff_persists(self, tmp_path: Path) -> None:
+        """Validator returns no failures → append proceeds and persists."""
+        room = DebateRoom(
+            thread_id="2026-05-26-on-mode-valid",
+            topic="on-mode valid diff",
+            mode=DebateMode.FIXED,
+        )
+        # No HARD_fail verdicts → empty diff satisfies REQUIRED CONTENT RULE.
+        room.append_diff_revision(
+            path_id="p1",
+            written_at=_ts(1),
+            value=_empty_diff_value(),
+            tier_config=_tier_config(path_contract_enabled=True),
+            state_dir=tmp_path,
+        )
+        assert len(room.path_contracts[0]["diff_history"]) == 1
+
+
+class TestOnModeRejectionSemantics:
+    """When flag is ON and validator returns failures, the diff is REJECTED."""
+
+    def test_failures_raise_and_skip_persist(self, tmp_path: Path) -> None:
+        """Validator failure → PathContractValidationError raised; no append.
+
+        Reject semantics: PROD::I4 (VERIFIABLE_EVENT_LEDGER) forbids
+        rewriting history, so an invalid diff must be blocked BEFORE it
+        reaches the append-only list.
+        """
+        room = DebateRoom(
+            thread_id="2026-05-26-on-mode-reject",
+            topic="on-mode reject",
+            mode=DebateMode.FIXED,
+        )
+        _seed_hard_fail_verdict(room, "p1", "inv_a")
+        # Empty diff fails REQUIRED CONTENT RULE: HARD_fail invariant 'inv_a'
+        # has no qualifying entry in accepted/reframed.
+        with pytest.raises(PathContractValidationError) as exc_info:
+            room.append_diff_revision(
+                path_id="p1",
+                written_at=_ts(1),
+                value=_empty_diff_value(),
+                tier_config=_tier_config(path_contract_enabled=True),
+                state_dir=tmp_path,
+            )
+
+        # Failures attached to the exception with stable failure_type discriminator.
+        failures: list[ValidatorFailure] = exc_info.value.failures
+        assert any(f.failure_type == MISSING_REQUIRED_ENTRY for f in failures), failures
+        # Diff was NOT persisted.
+        assert room.path_contracts[0]["diff_history"] == []
+
+    def test_failures_emit_validator_failure_events(self, tmp_path: Path) -> None:
+        """Validator rejection → VALIDATOR_FAILURE events appended to the ledger.
+
+        Per RFC §6 item 3 and the #217 contract, every rejection is an
+        auditable event on the I4 ledger — never silently dropped.
+        """
+        room = DebateRoom(
+            thread_id="2026-05-26-on-mode-events",
+            topic="on-mode events emitted",
+            mode=DebateMode.FIXED,
+        )
+        _seed_hard_fail_verdict(room, "p1", "inv_a")
+
+        with pytest.raises(PathContractValidationError):
+            room.append_diff_revision(
+                path_id="p1",
+                written_at=_ts(1),
+                value=_empty_diff_value(),
+                tier_config=_tier_config(path_contract_enabled=True),
+                state_dir=tmp_path,
+            )
+
+        # The events file for this thread must contain at least one
+        # VALIDATOR_FAILURE entry carrying the discriminator on the payload.
+        events_file = tmp_path / f"{room.thread_id}.events.jsonl"
+        assert events_file.exists(), f"events file missing at {events_file}"
+        content = events_file.read_text(encoding="utf-8")
+        assert "validator_failure" in content
+        assert MISSING_REQUIRED_ENTRY in content


### PR DESCRIPTION
## Summary

Wires `path_contract_validator.validate_diff_revision` into
`DebateRoom.append_diff_revision` as a validate-before-persist gate.
Honors CE's #219 deferred follow-up directive now that both prerequisites
are on main (#198 via #221, #200 via #217).

## Motivation

CE's #219 boundary note (deferred follow-up):

> Validator-before-persist becomes mandatory when #198/#200 wiring starts
> writing path contracts from model output.

With #198 (prompts emit DiffRevision structures) merged via #221 and #200
(validator with `VALIDATOR_FAILURE` event emission) merged via #217, the
wiring obligation is live. This PR is the minimal seam that closes the
boundary.

## Contract changes

`append_diff_revision` gains two optional kwargs:

- `tier_config: TierConfig | None = None`
- `state_dir: Path | None = None`

### Off-mode preservation (byte-identity)

When `tier_config` is `None` OR `features.is_enabled("path_contract", {"tier_config": tier_config})` returns `False`, the validator is NOT invoked. Every legacy caller of `append_diff_revision` continues to work without modification — the existing 1615 tests pass untouched.

### On-mode rejection semantics

When the flag resolves to `True`, the candidate `DiffRevision` is passed through `validate_diff_revision(contract, revision)` BEFORE the in-memory ledger is mutated:

- Non-empty failure list → raise `PathContractValidationError` carrying the structured `ValidatorFailure` records. The diff is NOT appended.
- Empty failure list → append proceeds (current behavior).

When `state_dir` is supplied alongside `tier_config`, one `VALIDATOR_FAILURE` event is appended to the I4 ledger per failure (RFC §6 item 3; #217 contract). The `failure_type` discriminator stays on the event payload so the #203 A/B harness can group without parsing free text.

## RFC compliance

- §3.2 REQUIRED CONTENT RULE (per-entry) + §3.3 Finding C (per-invariant): the validator already enforces these; this PR simply lands the gate at the persist seam.
- §6 item 3: every rejection is auditable on the append-only ledger; silent-drop is impossible by construction (the exception surfaces failures even when `state_dir` is `None`).
- PROD::I4 (VERIFIABLE_EVENT_LEDGER): once a `DiffRevision` lands in `diff_history` it can only be tombstoned. The gate therefore runs BEFORE the append; failed diffs never enter the ledger.

## Implementation notes

- The validator and features imports are lazy/in-method to avoid the would-be cycle `state → path_contract_validator → events → state`.
- `TierConfig` is imported under `TYPE_CHECKING` so static typing stays precise without expanding state.py's hot-load surface.

## Test plan

- [x] RED commit (70fd8ea): failing tests covering off-mode byte-identity (×2), on-mode valid path, on-mode rejection, and `VALIDATOR_FAILURE` event emission. Fail at collection (`PathContractValidationError` undefined) and behaviorally.
- [x] GREEN commit (f74e5ff): minimal wiring at the seam. All 5 RED tests pass.
- [x] `uv run mypy src/` clean
- [x] `uv run ruff check .` clean
- [x] `uv run black --check src tests` clean
- [x] `uv run pytest -q` — 1620 passed (+5 new, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the path-contract validator to run before persisting diffs and makes audit logging mandatory when validation runs. Invalid diffs never enter the ledger; failures emit `VALIDATOR_FAILURE` events and then raise.

- **New Features**
  - `DebateRoom.append_diff_revision` adds `tier_config` and `state_dir`. If `tier_config` is set, `state_dir` is required (TypeError otherwise). Off-mode (`tier_config=None` or flag off) skips validation and preserves behavior.
  - On-mode: validate before append. On failure, emit one `VALIDATOR_FAILURE` per failure and raise `PathContractValidationError` without persisting.

- **Refactors**
  - Broke the state→validator→events cycle by moving `_validate_thread_id_for_filesystem` and `PATH_UNSAFE_PATTERNS` to `debate_hall_mcp/_thread_id.py`; `state` re-exports; `events` now imports from `_thread_id`.
  - Removed lazy imports from `append_diff_revision`; `PathContractValidationError.failures` is now `list[ValidatorFailure]`.

<sup>Written for commit 85c63702d75d21eca09caed91c737a3a3f05c72e. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/224?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

