### PR TITLE
feat: increase MAX_TOPIC_LENGTH from 5000 to 12000 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Changed
-- Increased `MAX_TOPIC_LENGTH` from 1000 to 5000 characters for `run_debate` topics
+- Increased `MAX_TOPIC_LENGTH` from 1000 to 12000 characters for `run_debate` and `init_debate` topics (raised in two steps: 1000→5000, then 5000→12000) to support richer pasted problem statements; prefer `context_files` for large supporting material since topic content is replayed per panelist per turn
 - Extracted topic validation into shared `topic_validation.py` module (DRY)
 
 ### Added
-- Topic length validation for `init_debate` (previously unbounded — topics >5000 chars are now rejected)
+- Topic length validation for `init_debate` (previously unbounded — topics >12000 chars are now rejected)
 
 ## [0.5.0] - 2026-02-10
 

--- a/src/debate_hall_mcp/tools/orchestrate.py
+++ b/src/debate_hall_mcp/tools/orchestrate.py
@@ -288,7 +288,7 @@ async def run_debate(
     7. Returns the result
 
     Args:
-        topic: The debate topic to explore (1-5000 chars, non-empty)
+        topic: The debate topic to explore (1-12000 chars, non-empty)
         tier: Tier configuration name (default: "standard")
         thread_id: Optional thread ID (auto-generated if not provided)
         state_dir: Directory for state files (defaults to ./debates)

--- a/src/debate_hall_mcp/tools/topic_validation.py
+++ b/src/debate_hall_mcp/tools/topic_validation.py
@@ -7,7 +7,7 @@ Extracted to avoid circular imports between init.py and orchestrate.py.
 """
 
 # M4: Maximum topic length (reasonable limit for debate topics)
-MAX_TOPIC_LENGTH = 5000
+MAX_TOPIC_LENGTH = 12000
 
 
 def validate_topic(topic: str) -> None:

--- a/src/debate_hall_mcp/tools/topic_validation.py
+++ b/src/debate_hall_mcp/tools/topic_validation.py
@@ -6,7 +6,8 @@ tool boundaries (M4: CE Review mitigation).
 Extracted to avoid circular imports between init.py and orchestrate.py.
 """
 
-# M4: Maximum topic length (reasonable limit for debate topics)
+# M4: Maximum topic length (character count, not tokens — topic is replayed per
+# panelist per turn, so token-cost trade-off is documented in CHANGELOG.md).
 MAX_TOPIC_LENGTH = 12000
 
 

--- a/tests/unit/tools/test_init.py
+++ b/tests/unit/tools/test_init.py
@@ -199,8 +199,8 @@ class TestInitDebateTopicValidation:
             )
 
     def test_raises_error_for_topic_exceeding_max_length(self, tmp_path: Path) -> None:
-        """debate_init should raise ValueError for topic exceeding 5000 chars."""
-        long_topic = "x" * 5001
+        """debate_init should raise ValueError for topic exceeding 12000 chars."""
+        long_topic = "x" * 12001
         with pytest.raises(ValueError, match="Topic exceeds maximum length"):
             debate_init(
                 thread_id="2025-01-01-long-topic",
@@ -209,11 +209,11 @@ class TestInitDebateTopicValidation:
             )
 
     def test_accepts_topic_at_max_length(self, tmp_path: Path) -> None:
-        """debate_init should accept a topic exactly at 5000 chars."""
-        topic_5000_chars = "x" * 5000
+        """debate_init should accept a topic exactly at 12000 chars."""
+        topic_max_chars = "x" * 12000
         result = debate_init(
             thread_id="2025-01-01-max-topic",
-            topic=topic_5000_chars,
+            topic=topic_max_chars,
             state_dir=tmp_path,
         )
         assert result["thread_id"] == "2025-01-01-max-topic"

--- a/tests/unit/tools/test_orchestrate.py
+++ b/tests/unit/tools/test_orchestrate.py
@@ -295,8 +295,8 @@ class TestM4InputValidation:
 
     @pytest.mark.anyio
     async def test_raises_error_for_topic_exceeding_max_length(self) -> None:
-        """run_debate should raise ValueError for topic exceeding 5000 chars."""
-        long_topic = "x" * 5001
+        """run_debate should raise ValueError for topic exceeding 12000 chars."""
+        long_topic = "x" * 12001
         with pytest.raises(ValueError, match="Topic exceeds maximum length"):
             await run_debate(topic=long_topic)
 
@@ -304,8 +304,8 @@ class TestM4InputValidation:
     async def test_accepts_topic_at_max_length(
         self, temp_state_dir: Path, mock_tier_config: TierConfig, mock_debate_result: DebateResult
     ) -> None:
-        """run_debate should accept a topic exactly at 5000 chars."""
-        topic_5000_chars = "x" * 5000
+        """run_debate should accept a topic exactly at 12000 chars."""
+        topic_max_chars = "x" * 12000
         with (
             patch("debate_hall_mcp.tools.orchestrate.load_tier_config") as mock_load_config,
             patch("debate_hall_mcp.tools.orchestrate.get_state_dir") as mock_get_state_dir,
@@ -320,7 +320,7 @@ class TestM4InputValidation:
             mock_orchestrator.run = AsyncMock(return_value=mock_debate_result)
             mock_orchestrator_class.return_value = mock_orchestrator
 
-            result = await run_debate(topic=topic_5000_chars)
+            result = await run_debate(topic=topic_max_chars)
 
         # Should succeed without error
         assert result["thread_id"] is not None

--- a/tests/unit/tools/test_topic_validation.py
+++ b/tests/unit/tools/test_topic_validation.py
@@ -12,9 +12,9 @@ from debate_hall_mcp.tools.topic_validation import MAX_TOPIC_LENGTH, validate_to
 class TestValidateTopic:
     """Tests for validate_topic function."""
 
-    def test_max_topic_length_is_5000(self) -> None:
-        """MAX_TOPIC_LENGTH should be 5000."""
-        assert MAX_TOPIC_LENGTH == 5000
+    def test_max_topic_length_is_12000(self) -> None:
+        """MAX_TOPIC_LENGTH should be 12000."""
+        assert MAX_TOPIC_LENGTH == 12000
 
     def test_raises_error_for_empty_topic(self) -> None:
         """validate_topic should raise ValueError for empty string."""
@@ -27,16 +27,16 @@ class TestValidateTopic:
             validate_topic("   ")
 
     def test_raises_error_for_topic_exceeding_max_length(self) -> None:
-        """validate_topic should raise ValueError for topic exceeding 5000 chars."""
-        long_topic = "x" * 5001
+        """validate_topic should raise ValueError for topic exceeding 12000 chars."""
+        long_topic = "x" * 12001
         with pytest.raises(ValueError, match="Topic exceeds maximum length"):
             validate_topic(long_topic)
 
     def test_accepts_topic_at_max_length(self) -> None:
-        """validate_topic should accept a topic exactly at 5000 chars."""
-        topic_5000 = "x" * 5000
+        """validate_topic should accept a topic exactly at 12000 chars."""
+        topic_max = "x" * 12000
         # Should not raise
-        validate_topic(topic_5000)
+        validate_topic(topic_max)
 
     def test_accepts_valid_topic(self) -> None:
         """validate_topic should accept a normal-length topic."""


### PR DESCRIPTION
## Summary
- Increased the maximum topic length limit in `debate_hall_mcp` from 5000 to 12000 characters to support longer debate prompts
- Updated validation logic and test expectations across orchestration and topic validation modules
- Enables more detailed and nuanced debate scenarios without hitting character constraints

## Changes
- **Core limit update**: Modified `MAX_TOPIC_LENGTH` constant in `topic_validation.py` and `orchestrate.py`
- **Test updates**: Adjusted test fixtures and assertions in `test_topic_validation.py`, `test_orchestrate.py`, and `test_init.py` to reflect the new 12000 character threshold
- **Documentation**: Updated `CHANGELOG.md` to document this feature enhancement

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the maximum debate topic length from 5000 to 12000 characters in `debate_hall_mcp` for `run_debate` and `init_debate`. Updated validation, tests, and docs (clarifies the limit is character-based, not tokens); longer prompts are supported, but prefer `context_files` for large supporting material.

<sup>Written for commit 5d893ff886380c627f3482188e4b0aace0add063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/225?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

