### PR TITLE
chore: upgrade octave-mcp dependency to v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Changed
+- Upgraded octave-mcp dependency from v1.9.2 to v1.13.0
 - Increased `MAX_TOPIC_LENGTH` from 1000 to 5000 characters for `run_debate` topics
 - Extracted topic validation into shared `topic_validation.py` module (DRY)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "fasteners>=0.19",  # Read/write file locking for concurrency (Issue #106)
     "httpx>=0.27.0",  # GitHub API client (Issue #15)
     "python-dotenv>=1.0.0",  # Load .env files for configuration
-    "octave-mcp>=1.9.2",  # v1.9.2: latest version with improvements
+    "octave-mcp>=1.13.0",  # v1.13.0: latest version
     "python-ulid>=3.0.0",  # ULID for event ordering (ADR-0002)
     "PyYAML>=6.0",  # Tier configuration loading (ADR-0002)
 ]

--- a/tests/unit/utils/test_primers.py
+++ b/tests/unit/utils/test_primers.py
@@ -14,7 +14,7 @@ class TestLoadPrimer:
 
         assert "===OCTAVE_LITERACY_PRIMER===" in primer
         assert "===END===" in primer
-        # Should be relatively compact (~1000-1100 chars typical with octave-mcp >=1.9.2)
+        # Should be relatively compact (~1000-1100 chars typical with octave-mcp >=1.13.0)
         assert len(primer) < 1500
 
     def test_load_mastery_primer(self):
@@ -138,7 +138,7 @@ class TestPrimerContent:
 
         primer = get_literacy_primer()
 
-        # Should be under 1500 chars (~1000-1100 chars typical with octave-mcp >=1.9.2)
+        # Should be under 1500 chars (~1000-1100 chars typical with octave-mcp >=1.13.0)
         # Threshold gives breathing room for future primer growth without being meaningless.
         assert len(primer) < 1500
         # Rough estimate: 4 chars per token; threshold remains compact enough for


### PR DESCRIPTION
## Summary
- Updated octave-mcp from v1.9.2 to v1.13.0 to leverage latest features and improvements
- Ensured all documentation and test fixtures reflect the new dependency version
- Maintained compatibility across the codebase with the upgraded package

## Changes
- **Dependencies**: Updated `pyproject.toml` to specify octave-mcp v1.13.0
- **Documentation**: Added entry to `CHANGELOG.md` documenting the dependency upgrade
- **Tests**: Updated primer test fixtures in `tests/unit/utils/test_primers.py` to align with v1.13.0 behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `octave-mcp` to v1.13.0 and updated `pyproject.toml`, `CHANGELOG.md`, and primer test comments to reflect typical primer size at this version. Synced with latest `main`; no functional changes beyond the dependency bump.

<sup>Written for commit 796035610aafac6676f840d4232b02822a4fd208. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/226?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

