### PR TITLE
Add Debate Hall MCP server configuration and Claude Code integration

### DIFF
--- a/.claude/commands/debate.md
+++ b/.claude/commands/debate.md
@@ -1,0 +1,17 @@
+---
+description: Run a full Wind/Wall/Door multi-model debate on a topic
+argument-hint: <the question or topic to debate>
+---
+
+Use the `run_debate` MCP tool to run a complete automated Wind/Wall/Door debate
+on the topic below, then present the result to me:
+
+1. Lead with the **synthesis** (the Door's final resolution) in plain language.
+2. Then give a short bullet summary of the strongest **Wind** ideas and the
+   key **Wall** objections that shaped it.
+
+Topic: $ARGUMENTS
+
+Call `run_debate` with `tier="standard"` by default. Use `tier="fast"` only if
+I said I want something quick or cheap. Do not use `init_debate`, `add_turn`,
+`resolve_question`, or any other debate tool — `run_debate` only.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Claude Code local settings (user-specific, not committed)
 /.claude/settings.json
 /.claude/settings.local.json
-/.claude/commands/
+# User-specific commands stay local, except the shipped /debate command
+/.claude/commands/*
+!/.claude/commands/debate.md
 
 # NOTE: .claude/rules/ IS committed (team conventions per Boris's best practices)
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "command": "debate-hall-mcp",
       "env": {
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
-        "DEBATE_HALL_TIERS_FILE": "${DEBATE_HALL_TIERS_FILE:-config/debate-tiers.yaml}",
+        "DEBATE_HALL_TIERS_FILE": "config/debate-tiers.yaml",
         "GITHUB_TOOLS_ENABLED": "false"
       }
     }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "debate-hall": {
+      "command": "debate-hall-mcp",
+      "env": {
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+        "DEBATE_HALL_TIERS_FILE": "${DEBATE_HALL_TIERS_FILE:-config/debate-tiers.yaml}",
+        "GITHUB_TOOLS_ENABLED": "false"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Working in this repo with Claude Code
+
+This repository is the **Debate Hall** MCP server: it can run an automated
+multi-model "Wind / Wall / Door" debate to think through a problem from three
+angles and hand back a synthesised answer.
+
+## Tool routing — read this first
+
+When the user asks to **debate, brainstorm, weigh options, compare approaches,
+pressure-test an idea, or find the best/"genius" solution to something**, use
+the **`run_debate`** MCP tool. That is the front door.
+
+- Default to `tier="standard"` (three different frontier models debating).
+- Use `tier="fast"` only if the user asks for something quick, cheap, or
+  low-stakes.
+- Pass the user's question as `topic`. Let everything else default — do not set
+  `mode="raci"`, `compression_tier`, `primer_tier`, or `raci_config` unless the
+  user explicitly asks for that kind of control.
+- After it returns, present the **synthesis** (the Door's resolution) clearly,
+  then briefly summarise the strongest Wind ideas and Wall objections that
+  shaped it.
+
+**Do not** reach for the lower-level or alternative tools —
+`init_debate` / `add_turn` / `get_debate` / `close_debate`,
+`pick_next_speaker`, `resolve_question`, `extract_decision_record`,
+`search_decisions`, or the advisory/committee tools — unless the user
+*explicitly* asks for manual turn-by-turn control, a verified decision record,
+or one of those specific workflows. For everyday "let's think this through"
+requests, `run_debate` is always the right call.
+
+There is also a `/debate <your question>` slash command that does exactly this.
+
+## Setup (one time)
+
+`.mcp.json` and `config/debate-tiers.yaml` are already committed, so the only
+thing needed is an API key. From the repo root:
+
+```bash
+pip install -e .                      # or: pip install debate-hall-mcp
+export OPENROUTER_API_KEY=sk-or-...   # get one at https://openrouter.ai
+```
+
+Then run `claude` **from the repo root** so the server picks up the bundled
+tier config, and ask it to run a debate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,9 @@ export OPENROUTER_API_KEY=sk-or-...   # get one at https://openrouter.ai
 
 Then run `claude` **from the repo root** so the server picks up the bundled
 tier config, and ask it to run a debate.
+
+> **Important**: `DEBATE_HALL_TIERS_FILE` in `.mcp.json` is a relative path
+> (`config/debate-tiers.yaml`). The MCP server resolves it against its working
+> directory, which is wherever you launched `claude`. If you launch from a
+> subdirectory, the config will not be found and `run_debate` will fail with a
+> `TierConfigNotFoundError`. Always launch `claude` from the repo root.

--- a/config/debate-tiers.yaml
+++ b/config/debate-tiers.yaml
@@ -19,7 +19,7 @@
 standard:
   wind:                                   # explores / generates options
     provider: openrouter
-    model: anthropic/claude-opus-4.7
+    model: anthropic/claude-opus-4.8
     role: ideator
   wall:                                   # challenges / pressure-tests
     provider: openrouter

--- a/config/debate-tiers.yaml
+++ b/config/debate-tiers.yaml
@@ -1,0 +1,71 @@
+# Debate Hall — ready-to-use tier configuration
+#
+# This file ships with the repo so `run_debate` works straight after cloning.
+# `.mcp.json` points DEBATE_HALL_TIERS_FILE at this file, so you do NOT need to
+# create your own tiers.yaml. The only thing you must provide is an API key:
+#
+#     export OPENROUTER_API_KEY=sk-or-...        # get one at https://openrouter.ai
+#
+# Then just ask Claude Code:  "run a debate on <your question>"  (or use /debate)
+#
+# Models below are OpenRouter slugs. If a run errors with "model not found",
+# open https://openrouter.ai/models and swap in the current Opus / Gemini / GPT
+# slug — nothing else needs to change.
+
+# -----------------------------------------------------------------------------
+# standard — three DIFFERENT frontier models genuinely debating each other.
+# This is the default and what you want for "find me the genius solution".
+# -----------------------------------------------------------------------------
+standard:
+  wind:                                   # explores / generates options
+    provider: openrouter
+    model: anthropic/claude-opus-4.7
+    role: ideator
+  wall:                                   # challenges / pressure-tests
+    provider: openrouter
+    model: google/gemini-3.1-pro-preview
+    role: validator
+  door:                                   # synthesises the third-way answer
+    provider: openrouter
+    model: openai/gpt-5.5
+    role: synthesizer
+  settings:
+    consensus_required: true
+    max_turns: 12
+    max_refinement_loops: 3
+    provider_timeout: 300
+    show_token_counts: true
+    fallback:
+      enabled: true
+      provider: openrouter
+      model: anthropic/claude-sonnet-4.6
+      timeout: 60
+
+# -----------------------------------------------------------------------------
+# fast — cheaper / quicker. Good for low-stakes or "just give me a quick take".
+# Ask for it explicitly: "run a FAST debate on ..." (or /debate handles it).
+# -----------------------------------------------------------------------------
+fast:
+  wind:
+    provider: openrouter
+    model: anthropic/claude-haiku-4.5
+    role: wind-agent
+    timeout: 60
+  wall:
+    provider: openrouter
+    model: openai/gpt-5.4-mini
+    role: wall-agent
+    timeout: 60
+  door:
+    provider: openrouter
+    model: google/gemini-3-flash-preview
+    role: door-agent
+    timeout: 60
+  settings:
+    consensus_required: false
+    max_turns: 6
+    max_refinement_loops: 1
+    provider_timeout: 60
+    show_token_counts: true
+    fallback:
+      enabled: false

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -671,3 +671,43 @@ class TestTierConfigLoader:
         # Should use project-local (max_turns=999), not home (max_turns=1)
         assert config.settings.max_turns == 999
         assert config.wind.model == "project-model"
+
+
+class TestShippedTierConfig:
+    """Smoke tests for config/debate-tiers.yaml committed to the repo."""
+
+    def test_shipped_config_loads_standard_and_fast(self) -> None:
+        """config/debate-tiers.yaml must parse without error and contain both tiers."""
+        from debate_hall_mcp.config import _load_tiers_from_yaml
+
+        repo_root = Path(__file__).parent.parent.parent
+        config_file = repo_root / "config" / "debate-tiers.yaml"
+        assert config_file.exists(), f"Shipped tier config not found: {config_file}"
+
+        tiers = _load_tiers_from_yaml(config_file)
+        assert "standard" in tiers, "Shipped config missing 'standard' tier"
+        assert "fast" in tiers, "Shipped config missing 'fast' tier"
+
+    def test_shipped_config_standard_tier_valid(self) -> None:
+        """standard tier in shipped config has required wind/wall/door roles."""
+        from debate_hall_mcp.config import _load_tiers_from_yaml
+
+        repo_root = Path(__file__).parent.parent.parent
+        tiers = _load_tiers_from_yaml(repo_root / "config" / "debate-tiers.yaml")
+
+        standard = tiers["standard"]
+        assert standard.wind.provider == "openrouter"
+        assert standard.wall.provider == "openrouter"
+        assert standard.door.provider == "openrouter"
+
+    def test_shipped_config_fast_tier_valid(self) -> None:
+        """fast tier in shipped config has required wind/wall/door roles."""
+        from debate_hall_mcp.config import _load_tiers_from_yaml
+
+        repo_root = Path(__file__).parent.parent.parent
+        tiers = _load_tiers_from_yaml(repo_root / "config" / "debate-tiers.yaml")
+
+        fast = tiers["fast"]
+        assert fast.wind.provider == "openrouter"
+        assert fast.wall.provider == "openrouter"
+        assert fast.door.provider == "openrouter"

--- a/tiers.yaml.example
+++ b/tiers.yaml.example
@@ -46,7 +46,7 @@
 standard:
   wind:
     provider: openrouter
-    model: anthropic/claude-opus-4.7
+    model: anthropic/claude-opus-4.8
     role: ideator
   wall:
     provider: openrouter


### PR DESCRIPTION
## Summary
This PR adds production-ready configuration and documentation for running the Debate Hall MCP server with Claude Code, enabling users to run automated multi-model debates immediately after cloning the repository.

## Key Changes

- **Added `config/debate-tiers.yaml`**: Ready-to-use tier configuration with two debate profiles:
  - `standard`: Three different frontier models (Claude Opus, Gemini Pro, GPT-5.5) for genuine multi-perspective debate
  - `fast`: Cheaper/quicker variants (Haiku, GPT Mini, Gemini Flash) for low-stakes scenarios
  - Includes fallback configuration and sensible defaults for consensus, turn limits, and timeouts

- **Added `.mcp.json`**: MCP server configuration that:
  - Points to the bundled `config/debate-tiers.yaml` by default
  - Accepts `OPENROUTER_API_KEY` environment variable
  - Disables GitHub tools for this use case

- **Added `CLAUDE.md`**: Developer guide documenting:
  - When to use `run_debate` vs. lower-level debate tools
  - Default tier selection and parameter guidance
  - One-time setup instructions (API key only)

- **Added `.claude/commands/debate.md`**: Slash command (`/debate`) that wraps `run_debate` with sensible defaults and presentation formatting

- **Updated `.gitignore`**: Allow the shipped `/debate` command to be committed while keeping user-specific commands local

- **Updated `tiers.yaml.example`**: Bumped Claude Opus model version from 4.7 to 4.8 for consistency

## Notable Details

- Users only need to provide an `OPENROUTER_API_KEY` to get started—no manual tier configuration required
- The bundled config ships with the repo so the MCP server works immediately after cloning
- Model slugs are documented as OpenRouter references with guidance on updating them if needed
- The `/debate` command provides a user-friendly entry point that handles presentation of results (synthesis first, then Wind/Wall summary)

https://claude.ai/code/session_01GbF9ukqxt8TUbuPwSieaoq

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clone-and-go `debate-hall` MCP setup for Claude Code, bundling tier configs and a `/debate` command so you can run multi-model debates right after cloning. Uses a literal tiers path and disables GitHub tools for a zero-config start.

- New Features
  - Bundled `config/debate-tiers.yaml` with two profiles: `standard` (Opus, Gemini Pro, GPT‑5.5) and `fast` (Haiku, GPT Mini, Gemini Flash), with sensible defaults and fallback.
  - Added `.mcp.json` registering the `debate-hall` server; passes `OPENROUTER_API_KEY`, points to the bundled tiers via a literal path, and disables GitHub tools.
  - Added `CLAUDE.md` to route debate/brainstorm requests to `run_debate` (default `tier="standard"`, use `tier="fast"` if asked).
  - Added `.claude/commands/debate.md` to wrap `run_debate` and present results (synthesis first, then Wind/Wall summary).
  - Added CI smoke tests to ensure `config/debate-tiers.yaml` loads and both `standard` and `fast` tiers are valid.
  - Updated `.gitignore` to ship `/debate` while keeping other user commands local.
  - Updated `tiers.yaml.example` to `anthropic/claude-opus-4.8`.

- Migration
  - Set `OPENROUTER_API_KEY` and run `claude` from the repo root so `config/debate-tiers.yaml` resolves; no other setup needed.

<sup>Written for commit b0ccbc95f60da81c532fba21aee0c03d947ff9c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

