### PR TITLE
feat(setup): optionally store OpenRouter key in clone .env (chmod 600)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@
 # ALL GitHub operations — issue management, project board updates, PR operations,
 # cross-repo coordination, and debate sync. It is NOT debate-hall-specific.
 
+# OpenRouter API Key (required for run_debate / multi-model debates)
+# Get one at https://openrouter.ai. The server loads this from .env automatically
+# (by absolute path to this clone), so run_debate works from any directory.
+# Keep .env at chmod 600. setup-mcp.sh can store this for you (opt-in).
+# OPENROUTER_API_KEY=sk-or-...
+
 # GitHub Token (ecosystem-wide)
 # Used by: gh CLI, debate-hall sync tools, project board operations, cross-repo coordination
 # GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,7 @@ remaining commands from inside it:
 git clone https://github.com/elevanaltd/debate-hall-mcp.git
 cd debate-hall-mcp
 pip install -e .                      # editable install from this clone
-export OPENROUTER_API_KEY=sk-or-...   # get one at https://openrouter.ai
-./setup-mcp.sh --claude-code          # run once
+./setup-mcp.sh --claude-code          # run once (offers to store your API key)
 ```
 
 `setup-mcp.sh` registers the server in your user-global Claude Code config
@@ -55,7 +54,12 @@ tiers (e.g. `premium` / `ultra`).
 `server.py`, so if you move or delete the directory, re-run
 `./setup-mcp.sh --claude-code` from the new location.
 
+**OpenRouter API key.** The server reads `OPENROUTER_API_KEY` from this clone's
+`.env`, which it loads automatically by absolute path — so the key works from
+any launch directory. This is the recommended persistent method:
+`./setup-mcp.sh --claude-code` offers to store it for you (opt-in, written
+`chmod 600`), or `cp .env.example .env` and edit. The `.env` is gitignored;
+keep it `chmod 600`. Alternatively, `export OPENROUTER_API_KEY=sk-or-...` in the
+shell you launch `claude` from for an ephemeral, per-shell key.
+
 After this, just `cd` into any repo, run `claude`, and ask it to run a debate.
-The MCP server inherits `OPENROUTER_API_KEY` from the shell you launch `claude`
-in — `setup-mcp.sh` never writes the key anywhere, so make sure it is exported
-in that environment.

--- a/setup-mcp.sh
+++ b/setup-mcp.sh
@@ -628,12 +628,14 @@ provision_api_key() {
     fi
 
     # Create with 0600 BEFORE writing the secret, then append (never truncate).
-    if touch "$env_file" && chmod 600 "$env_file"; then
-        printf 'OPENROUTER_API_KEY=%s\n' "$key" >> "$env_file"
-        chmod 600 "$env_file"
+    # The append is part of the guarded condition so a write failure routes to
+    # the warning branch instead of aborting the script under set -euo pipefail.
+    if touch "$env_file" && chmod 600 "$env_file" \
+       && printf 'OPENROUTER_API_KEY=%s\n' "$key" >> "$env_file"; then
+        chmod 600 "$env_file" || true
         print_success "Stored OpenRouter key in $env_file (permissions 0600)"
     else
-        print_warning "Could not prepare $env_file — key not stored."
+        print_warning "Could not write to $env_file — key not stored."
         print_api_key_reminder
     fi
     return 0

--- a/setup-mcp.sh
+++ b/setup-mcp.sh
@@ -570,13 +570,73 @@ install_global_tiers_config() {
     return 0
 }
 
-# Remind the user that the OpenRouter API key must live in the launching shell's
-# environment (the MCP server inherits it). We never write the key anywhere.
+# Remind the user how to provide the OpenRouter API key when we do not store it.
+# The server loads it either from the shell environment or from the clone's .env
+# (loaded automatically by absolute path), so either of these works.
 print_api_key_reminder() {
     echo ""
-    print_info "Reminder: export your OpenRouter API key in the shell where you launch Claude Code:"
-    echo "    export OPENROUTER_API_KEY=sk-or-...   # get one at https://openrouter.ai"
-    print_info "The MCP server inherits it from the environment; it is never written to disk by this script."
+    print_info "Provide your OpenRouter API key one of these ways (get one at https://openrouter.ai):"
+    echo "    export OPENROUTER_API_KEY=sk-or-...        # per-shell, ephemeral"
+    echo "    echo 'OPENROUTER_API_KEY=sk-or-...' >> $(get_script_dir)/.env   # persistent (chmod 600)"
+    print_info "The server loads .env from this clone automatically, so the key works from any directory."
+}
+
+# Opt-in: store the OpenRouter API key in the clone's .env so the server picks it
+# up automatically (by absolute path) from any launch directory. Non-destructive,
+# validated, written chmod 600, and never prompts on a non-TTY (CI/automation).
+# Always returns 0 — this is convenience and must never abort the setup chain.
+provision_api_key() {
+    local env_file
+    env_file="$(get_script_dir)/.env"
+
+    # Non-interactive (no TTY): never prompt — would hang automation/CI.
+    if [[ ! -t 0 ]]; then
+        print_api_key_reminder
+        return 0
+    fi
+
+    # Already configured (env var or already in .env): keep, do not clobber.
+    if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+        print_info "OPENROUTER_API_KEY is already set in your environment — leaving it as is."
+        return 0
+    fi
+    if [[ -f "$env_file" ]] && grep -q "^OPENROUTER_API_KEY=" "$env_file" 2>/dev/null; then
+        print_info "OPENROUTER_API_KEY is already present in $env_file — keeping it."
+        return 0
+    fi
+
+    # Opt-in prompt, default SKIP.
+    local ans=""
+    read -r -p "Store your OpenRouter API key in $env_file now? [y/N] " ans || ans=""
+    if [[ ! "$ans" =~ ^[Yy]$ ]]; then
+        print_api_key_reminder
+        return 0
+    fi
+
+    # Read the secret silently; never echo it.
+    local key=""
+    read -r -s -p "Paste OpenRouter API key (sk-or-...): " key || key=""
+    echo ""
+    # Trim leading/trailing whitespace.
+    key="${key#"${key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+
+    if [[ ! "$key" =~ ^sk-or- ]]; then
+        print_warning "That doesn't look like an sk-or-... key — not stored."
+        print_api_key_reminder
+        return 0
+    fi
+
+    # Create with 0600 BEFORE writing the secret, then append (never truncate).
+    if touch "$env_file" && chmod 600 "$env_file"; then
+        printf 'OPENROUTER_API_KEY=%s\n' "$key" >> "$env_file"
+        chmod 600 "$env_file"
+        print_success "Stored OpenRouter key in $env_file (permissions 0600)"
+    else
+        print_warning "Could not prepare $env_file — key not stored."
+        print_api_key_reminder
+    fi
+    return 0
 }
 
 # ----------------------------------------------------------------------------
@@ -701,7 +761,7 @@ interactive_setup() {
             ;;
         2)
             if ensure_venv_exists && configure_claude_code && install_global_tiers_config; then
-                print_api_key_reminder
+                provision_api_key
             else
                 print_error "Claude Code setup did not complete - nothing was configured"
             fi
@@ -720,7 +780,7 @@ interactive_setup() {
             configure_gemini || true
             install_global_tiers_config
             print_info "Setup finished (review any warnings above for clients that were skipped)"
-            print_api_key_reminder
+            provision_api_key
             ;;
         6)
             ensure_venv_exists && show_config
@@ -754,7 +814,7 @@ main() {
             ;;
         --claude-code)
             if ensure_venv_exists && configure_claude_code && install_global_tiers_config; then
-                print_api_key_reminder
+                provision_api_key
             else
                 exit 1
             fi
@@ -773,7 +833,7 @@ main() {
             configure_gemini || true
             install_global_tiers_config
             print_info "Setup finished (review any warnings above for clients that were skipped)"
-            print_api_key_reminder
+            provision_api_key
             ;;
         --show-config)
             ensure_venv_exists && show_config


### PR DESCRIPTION
## Summary

Follow-up to #230. Adds **opt-in** persistence of the OpenRouter API key, deliberately revising #230's "setup never writes the key" stance now that the real loading mechanism is understood.

## Why

The server loads `OPENROUTER_API_KEY` from the **clone's own `.env` by absolute path** — `src/debate_hall_mcp/utils/env.py` auto-runs `load_env()` on import, loading `_REPO_ROOT/.env` (== `$(get_script_dir)/.env` for the editable-from-clone install), independent of cwd. That `.env` is gitignored. So writing the key there is the already-supported, cwd-independent persistence path — no Python change needed.

## Changes

- **`setup-mcp.sh`** — new `provision_api_key()`:
  - Non-TTY guard (`[[ ! -t 0 ]]`) → reminder only, no prompt (CI-safe, never hangs).
  - Already-set (env var **or** `^OPENROUTER_API_KEY=` in `.env`) → keep, no clobber.
  - Opt-in prompt, default **N**; secret read with `read -r -s` (never echoed); validated `^sk-or-`; invalid → warn, not stored.
  - Writes via `touch` + `chmod 600` **before** the secret lands, then appends (`>>`, never truncates), re-asserts `chmod 600`. Success message omits the key.
  - Always `return 0` (opt-in convenience must not abort the gated setup chain); genuine write failure degrades to a warning.
  - Wired into all four Claude Code setup paths, replacing the unconditional reminder. `print_api_key_reminder` retained (shown on skip/non-TTY) and now documents both `export` and `.env`.
- **`CLAUDE.md`** — recommends the clone `.env` as the persistent method (loaded automatically, works from any directory); `export` is the ephemeral alternative; notes opt-in store and `chmod 600`.
- **`.env.example`** — documents `OPENROUTER_API_KEY=sk-or-...`.

## Verification

- `bash -n setup-mcp.sh` clean; `pytest tests/unit/test_config.py` → 35 passed.
- PTY-driven tests pass for: fresh store (file `600`, one key line, **secret not in program output**), already-present (keeps old, no dup), invalid (not stored), non-TTY (reminder, no hang), env-set (no file).
- No real `.env` tracked (gitignored).

Reviewed at identical content on #230 by CE + CRS (APPROVED) before that PR merged without this commit; re-review on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in flow in `setup-mcp.sh` to store `OPENROUTER_API_KEY` in this clone’s `.env` (chmod 600) so the server loads it automatically from any directory. Hardens the write path so failures warn without aborting setup.

- **New Features**
  - Adds `provision_api_key()` to persist `OPENROUTER_API_KEY` in the clone `.env` with 0600; validates `sk-or-`; avoids clobbering; skips on non‑TTY; always returns 0.
  - Replaces the reminder at `--claude-code`, `--all`, and interactive options 2 and 5; reminder now shows both `export` and `.env` options.
  - Docs: `CLAUDE.md` recommends `.env` persistence and notes permissions; `.env.example` includes `OPENROUTER_API_KEY=sk-or-...`.

- **Bug Fixes**
  - Under `set -euo pipefail`, guards the `.env` append by folding `printf >>` into the `if ... &&` chain and making the re-assert `chmod` non-fatal, so a write failure warns and setup continues.

<sup>Written for commit 1b4912baea0601823c62a9890b58e2d039afadb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/debate-hall-mcp/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

